### PR TITLE
Add optimistic iOS session input

### DIFF
--- a/docs/specs/ios-optimistic-session-input.md
+++ b/docs/specs/ios-optimistic-session-input.md
@@ -1,0 +1,130 @@
+# iOS Optimistic Session Input
+
+Status: Proposed
+Last updated: 2026-05-07
+
+## Goal
+
+Make iOS session control feel immediate and trustworthy when sending input to a
+managed session.
+
+The user action target is:
+
+- tap send -> composer clears in the same interaction
+- message appears locally as pending immediately
+- network dispatch and workspace refresh reconcile in the background
+- failures preserve or restore the user's text with an explicit retry path
+
+This is part of the managed-local live-control launch loop. The mobile app must
+not feel slower than a terminal just because the backend is verifying transport
+acceptance or refreshing the full workspace.
+
+## Problem
+
+Today the iOS composer clears only after `SessionViewModel.send(...)` returns.
+That method waits for `POST /api/sessions/{id}/input` and then performs a full
+workspace refresh. `refreshWorkspace(...)` also awaits render telemetry. This
+couples visible input state to network, provider dispatch, JSON decoding, and a
+telemetry beacon.
+
+Observed failure mode:
+
+1. User taps send.
+2. Text remains in the composer, making the tap look ignored.
+3. The transcript may later show "thinking" from realtime refresh.
+4. The original text can still remain in the composer, so the UI contradicts
+   itself.
+
+## Non-Goals
+
+- Do not change backend queue or dispatch semantics.
+- Do not make iOS silently remap explicit `steer` failures into queued input.
+- Do not add a second transcript source of truth. Optimistic rows are local
+  UI state and must disappear once the real transcript catches up.
+- Do not add broad polling. Queue polling can be added only while visible
+  pending/queued input exists.
+
+## Client State Model
+
+The composer owns transient draft text. The view model owns submitted input
+state.
+
+Each submitted input has:
+
+- local id
+- text
+- intent: `auto | queue | steer`
+- phase: `submitting | sent | queued | failed`
+- optional server `input_id`
+- optional `last_error`
+
+State transitions:
+
+```text
+draft text
+  -> submitting       tap send, clear composer immediately
+  -> sent             POST returns outcome=sent
+  -> queued           POST returns outcome=queued
+  -> failed           POST fails, or structured steer turn_ended is rejected
+  -> reconciled       transcript/workspace contains the durable user event
+```
+
+`failed` preserves the text in an explicit retry surface. It must not silently
+repopulate the composer unless the user taps an edit/retry action.
+
+## Send Path
+
+Tap handling should be synchronous from the user's perspective:
+
+1. Trim and capture the current composer text.
+2. Clear the composer and resign focus immediately.
+3. Insert a local pending input row.
+4. Start the async `POST /input` task.
+5. Apply the server outcome to local pending/queued/failed state.
+6. Refresh the workspace in the background.
+
+The send button can show an in-flight indicator, but the text field must not be
+the in-flight indicator. Once the user taps send, the draft is no longer draft
+state.
+
+## Refresh And Telemetry Rules
+
+- `POST /input` response handling must not await a full workspace refresh before
+  returning control to the view.
+- Workspace refresh should reconcile transcript state after the POST response or
+  from SSE/polling.
+- Render beacons are fire-and-forget. Telemetry must not block user-visible
+  state, transcript refresh completion, or composer clearing.
+- Existing backend `managed_turn_dispatch_seconds` and `dispatch_ms` remain the
+  server-side send-accept truth. Client work should add or enable separate
+  action timing later:
+  - tap -> local clear
+  - tap -> POST response
+  - POST response -> transcript event rendered
+
+## Queue And Failure Display
+
+iOS already decodes `SessionInputResponse.queued`. For this phase:
+
+- show queued/delivering count immediately from POST response
+- show recent failed count immediately from POST response
+- preserve the existing explicit `Queue instead` flow for `steer` +
+  `turn_ended`
+- do not hide failed queued rows behind a generic send error
+
+Full web parity for queue chip list, cancel, and `/inputs` polling is a follow-up
+unless the implementation stays small.
+
+## Acceptance
+
+- Tapping send clears the composer immediately, before `POST /input` completes.
+- A local pending/sent/queued status appears without waiting for workspace
+  refresh.
+- If `POST /input` succeeds, the composer stays cleared.
+- If `POST /input` fails, the submitted text remains available in a failed
+  retry/edit surface.
+- If workspace refresh fails after a successful POST, the submitted state still
+  shows success/queued and the transcript is not blanked.
+- Render telemetry cannot delay `refreshWorkspace(...)` completion.
+- Unit tests cover immediate optimistic state, delayed refresh, failed POST, and
+  nonblocking render beacon behavior.

--- a/docs/specs/ios-optimistic-session-input.md
+++ b/docs/specs/ios-optimistic-session-input.md
@@ -52,9 +52,10 @@ state.
 Each submitted input has:
 
 - local id
+- client request id
 - text
 - intent: `auto | queue | steer`
-- phase: `submitting | sent | queued | failed`
+- phase: `submitting | sent | queued | failed | needs_user_decision`
 - optional server `input_id`
 - optional `last_error`
 
@@ -65,12 +66,42 @@ draft text
   -> submitting       tap send, clear composer immediately
   -> sent             POST returns outcome=sent
   -> queued           POST returns outcome=queued
-  -> failed           POST fails, or structured steer turn_ended is rejected
-  -> reconciled       transcript/workspace contains the durable user event
+  -> needs_user_decision
+                      explicit steer races terminal; user may queue instead
+  -> failed           POST fails or submit timeout expires
+  -> removed          transcript/workspace contains the durable user event
 ```
 
+`removed` is not a visible phase. It means the optimistic row was reconciled and
+removed from the pending collection.
+
 `failed` preserves the text in an explicit retry surface. It must not silently
-repopulate the composer unless the user taps an edit/retry action.
+repopulate the composer unless the user taps an edit/retry action. If the user
+has typed a new draft before the failure arrives, the failed text stays in the
+retry surface and never overwrites the active composer.
+
+`needs_user_decision` is not delivery failure. It is the existing `steer` +
+`turn_ended` contract where the user explicitly chooses whether to queue the
+text for the next turn.
+
+## Idempotency And Reconciliation
+
+The client must mint a stable client request id per submitted input. Retries of
+that submitted input reuse the same id. The backend should treat that id as an
+idempotency key for the target session and author, using the existing durable
+input/turn record where possible instead of creating a duplicate send.
+
+Optimistic rows reconcile in this order:
+
+1. Prefer a durable transcript user event that carries the same client request
+   id or server input id.
+2. Until transcript events carry that id end-to-end, fall back to a bounded
+   match on author, exact text, and a short timestamp window after submit.
+3. If no match appears before the reconciliation deadline, keep the row visible
+   as `sent` or `queued` rather than duplicating it in the transcript.
+
+The implementation must not render both an optimistic row and a matching durable
+transcript row indefinitely.
 
 ## Send Path
 
@@ -86,6 +117,10 @@ Tap handling should be synchronous from the user's perspective:
 The send button can show an in-flight indicator, but the text field must not be
 the in-flight indicator. Once the user taps send, the draft is no longer draft
 state.
+
+`submitting` has a bounded timeout. If the app backgrounds, loses network, or
+the request hangs past that timeout, the row becomes `failed` with retry/edit
+available on resume. This phase does not introduce offline local queueing.
 
 ## Refresh And Telemetry Rules
 
@@ -111,6 +146,7 @@ iOS already decodes `SessionInputResponse.queued`. For this phase:
 - preserve the existing explicit `Queue instead` flow for `steer` +
   `turn_ended`
 - do not hide failed queued rows behind a generic send error
+- never overwrite a newer active draft with failed submitted text
 
 Full web parity for queue chip list, cancel, and `/inputs` polling is a follow-up
 unless the implementation stays small.
@@ -121,10 +157,17 @@ unless the implementation stays small.
 - A local pending/sent/queued status appears without waiting for workspace
   refresh.
 - If `POST /input` succeeds, the composer stays cleared.
-- If `POST /input` fails, the submitted text remains available in a failed
-  retry/edit surface.
+- If `POST /input` fails or times out, the submitted text remains available in a
+  failed retry/edit surface and does not overwrite newer draft text.
 - If workspace refresh fails after a successful POST, the submitted state still
   shows success/queued and the transcript is not blanked.
 - Render telemetry cannot delay `refreshWorkspace(...)` completion.
+- Explicit `steer` + `turn_ended` shows the existing `Queue instead` decision
+  surface, not a generic failure.
+- Retrying a submitted input uses the same client request id, so a lost response
+  cannot double-send if the backend already accepted the original request.
+- Reconciliation removes a matching optimistic row when the durable transcript
+  event appears, or leaves a single optimistic row visible if the transcript has
+  not caught up.
 - Unit tests cover immediate optimistic state, delayed refresh, failed POST, and
   nonblocking render beacon behavior.

--- a/ios/Sources/LonghouseApp/SessionView.swift
+++ b/ios/Sources/LonghouseApp/SessionView.swift
@@ -354,6 +354,7 @@ struct SessionView: View {
     }
 
     private func send(intent: String? = nil) async {
+        guard !viewModel.isSending else { return }
         let trimmed = composerText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         let resolvedIntent = intent ?? primaryIntent
@@ -1381,8 +1382,9 @@ final class SessionViewModel: ObservableObject {
             guard input.phase == .sent || input.phase == .queued || input.phase == .submitting else { return false }
             return events.contains { event in
                 guard event.role == "user", event.contentText == input.text else { return false }
-                guard let eventDate = LonghouseDateParser.parse(event.timestamp) else { return true }
+                guard let eventDate = LonghouseDateParser.parse(event.timestamp) else { return false }
                 return eventDate >= input.createdAt.addingTimeInterval(-5)
+                    && eventDate <= input.createdAt.addingTimeInterval(120)
             }
         }
     }

--- a/ios/Sources/LonghouseApp/SessionView.swift
+++ b/ios/Sources/LonghouseApp/SessionView.swift
@@ -147,6 +147,14 @@ struct SessionView: View {
                                     )
                                     .id(item.id)
                                 }
+                                ForEach(viewModel.submittedInputs) { input in
+                                    SubmittedInputBubble(input: input) {
+                                        composerText = input.text
+                                        composerFocused = true
+                                        viewModel.dismissSubmittedInput(input.id)
+                                    }
+                                    .id(input.id)
+                                }
                             }
                         }
                         .padding(.horizontal)
@@ -260,7 +268,7 @@ struct SessionView: View {
                     .textFieldStyle(.roundedBorder)
                     .lineLimit(1...6)
                     .focused($composerFocused)
-                    .disabled(viewModel.isSending || viewModel.isDrafting)
+                    .disabled(viewModel.isDrafting)
 
                 // Send button: always a circle arrow icon; long-press reveals steer/queue split
                 Button {
@@ -349,6 +357,8 @@ struct SessionView: View {
         let trimmed = composerText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         let resolvedIntent = intent ?? primaryIntent
+        composerText = ""
+        composerFocused = false
         let sent = await viewModel.send(
             text: trimmed,
             sessionId: sessionId,
@@ -356,8 +366,6 @@ struct SessionView: View {
             intent: resolvedIntent,
         )
         if sent {
-            composerText = ""
-            composerFocused = false
             let token = viewModel.sendCounter
             Task { [weak viewModel] in
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
@@ -583,6 +591,89 @@ private struct UserBubble: View {
                 }
             }
         }
+    }
+}
+
+enum SubmittedInputPhase: String, Sendable {
+    case submitting
+    case sent
+    case queued
+    case failed
+    case needsUserDecision
+}
+
+struct SubmittedInput: Identifiable, Sendable {
+    let id: String
+    let clientRequestId: String
+    let text: String
+    let intent: String
+    var phase: SubmittedInputPhase
+    var serverInputId: Int?
+    var lastError: String?
+    let createdAt: Date
+}
+
+private struct SubmittedInputBubble: View {
+    let input: SubmittedInput
+    let onEdit: () -> Void
+
+    private var statusText: String {
+        switch input.phase {
+        case .submitting:
+            return "Sending..."
+        case .sent:
+            return "Sent"
+        case .queued:
+            return "Queued"
+        case .failed:
+            return input.lastError ?? "Could not send"
+        case .needsUserDecision:
+            return "Needs choice"
+        }
+    }
+
+    private var statusColor: Color {
+        switch input.phase {
+        case .failed, .needsUserDecision:
+            return .orange
+        case .queued:
+            return .secondary
+        case .submitting, .sent:
+            return .secondary
+        }
+    }
+
+    var body: some View {
+        HStack {
+            Spacer(minLength: 40)
+            VStack(alignment: .trailing, spacing: 6) {
+                Text(input.text)
+                    .font(.callout)
+                    .textSelection(.enabled)
+                    .padding(10)
+                    .background(Color.blue.opacity(0.10), in: RoundedRectangle(cornerRadius: 12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.blue.opacity(0.20), lineWidth: 1)
+                    )
+                    .frame(alignment: .trailing)
+                HStack(spacing: 8) {
+                    if input.phase == .submitting {
+                        ProgressView().controlSize(.mini)
+                    }
+                    Text(statusText)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(statusColor)
+                    if input.phase == .failed {
+                        Button("Edit") { onEdit() }
+                            .font(.caption2.weight(.semibold))
+                            .buttonStyle(.plain)
+                            .foregroundStyle(.blue)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("session-chat-submitted-input")
     }
 }
 
@@ -993,6 +1084,7 @@ final class SessionViewModel: ObservableObject {
     @Published var lastSendOutcome: SessionInputOutcome?
     @Published var queuedInputCount: Int = 0
     @Published var failedInputCount: Int = 0
+    @Published var submittedInputs: [SubmittedInput] = []
     /// Text preserved from a steer attempt that the server rejected with
     /// error_code: "turn_ended". The UI offers an explicit "Queue instead"
     /// action; we do not silently convert the intent for the user.
@@ -1032,6 +1124,7 @@ final class SessionViewModel: ObservableObject {
             isInitialLoading = true
             detail = nil
             items = []
+            submittedInputs = []
             errorMessage = nil
             expandedIds.removeAll()
         }
@@ -1080,26 +1173,72 @@ final class SessionViewModel: ObservableObject {
     }
 
     func send(text: String, sessionId: String, appState: AppState, intent: String = "auto") async -> Bool {
-        guard let api = apiFactory(appState.serverURL) else { return false }
+        let clientRequestId = "ios-\(UUID().uuidString)"
+        let localInput = SubmittedInput(
+            id: clientRequestId,
+            clientRequestId: clientRequestId,
+            text: text,
+            intent: intent,
+            phase: .submitting,
+            serverInputId: nil,
+            lastError: nil,
+            createdAt: Date()
+        )
+        submittedInputs.append(localInput)
+        guard let api = apiFactory(appState.serverURL) else {
+            updateSubmittedInput(
+                clientRequestId,
+                phase: .failed,
+                serverInputId: nil,
+                lastError: "Invalid server URL"
+            )
+            return false
+        }
         isSending = true
         draftErrorMessage = nil
         defer { isSending = false }
         do {
-            let response = try await api.sendInput(id: sessionId, text: text, intent: intent)
+            let response = try await api.sendInput(
+                id: sessionId,
+                text: text,
+                intent: intent,
+                clientRequestId: clientRequestId
+            )
             sendCounter &+= 1
             lastSendOutcome = response.outcome
             queuedInputCount = response.pendingInputCount
             failedInputCount = response.visibleFailedInputCount
             turnEndedDraft = nil
-            try? await refreshWorkspace(api: api, sessionId: sessionId, allowFailure: true)
+            updateSubmittedInput(
+                clientRequestId,
+                phase: response.outcome == .sent ? .sent : .queued,
+                serverInputId: response.inputId,
+                lastError: nil
+            )
+            Task { [weak self] in
+                guard let self else { return }
+                try? await self.refreshWorkspace(api: api, sessionId: sessionId, allowFailure: true)
+            }
             return true
         } catch let LonghouseAPIError.structured(_, code, message) where intent == "steer" && code == "turn_ended" {
             // Preserve the original text; the UI offers an explicit
             // "Queue instead" action. Intent is never silently mapped.
+            updateSubmittedInput(
+                clientRequestId,
+                phase: .needsUserDecision,
+                serverInputId: nil,
+                lastError: message.isEmpty ? "Active turn ended before your update arrived." : message
+            )
             turnEndedDraft = text
             errorMessage = message.isEmpty ? "Active turn ended before your update arrived." : message
             return false
         } catch {
+            updateSubmittedInput(
+                clientRequestId,
+                phase: .failed,
+                serverInputId: nil,
+                lastError: error.localizedDescription
+            )
             errorMessage = "Send failed: \(error.localizedDescription)"
             return false
         }
@@ -1111,6 +1250,10 @@ final class SessionViewModel: ObservableObject {
         guard let text = turnEndedDraft else { return false }
         turnEndedDraft = nil
         return await send(text: text, sessionId: sessionId, appState: appState, intent: "queue")
+    }
+
+    func dismissSubmittedInput(_ id: String) {
+        submittedInputs.removeAll { $0.id == id }
     }
 
     func draftReply(sessionId: String, appState: AppState) async -> String? {
@@ -1210,9 +1353,37 @@ final class SessionViewModel: ObservableObject {
             self.detail = workspace.session
             let events = workspace.events
             self.items = TimelineBuilder.build(events: events)
-            await reportRenderBeacon(api: api, sessionId: sessionId, events: events)
+            reconcileSubmittedInputs(with: events)
+            Task { [weak self] in
+                guard let self else { return }
+                await self.reportRenderBeacon(api: api, sessionId: sessionId, events: events)
+            }
         } catch {
             if !allowFailure { throw error }
+        }
+    }
+
+    private func updateSubmittedInput(
+        _ id: String,
+        phase: SubmittedInputPhase,
+        serverInputId: Int?,
+        lastError: String?
+    ) {
+        guard let index = submittedInputs.firstIndex(where: { $0.id == id }) else { return }
+        submittedInputs[index].phase = phase
+        submittedInputs[index].serverInputId = serverInputId
+        submittedInputs[index].lastError = lastError
+    }
+
+    private func reconcileSubmittedInputs(with events: [SessionEvent]) {
+        guard !submittedInputs.isEmpty else { return }
+        submittedInputs.removeAll { input in
+            guard input.phase == .sent || input.phase == .queued || input.phase == .submitting else { return false }
+            return events.contains { event in
+                guard event.role == "user", event.contentText == input.text else { return false }
+                guard let eventDate = LonghouseDateParser.parse(event.timestamp) else { return true }
+                return eventDate >= input.createdAt.addingTimeInterval(-5)
+            }
         }
     }
 

--- a/ios/Sources/Shared/LonghouseAPI.swift
+++ b/ios/Sources/Shared/LonghouseAPI.swift
@@ -42,7 +42,7 @@ actor RenderBeaconReporter {
 
 protocol SessionWorkspaceClient: Sendable {
     func sessionWorkspace(id: String, limit: Int, branchMode: String) async throws -> SessionWorkspaceResponse
-    func sendInput(id: String, text: String, intent: String) async throws -> SessionInputResponse
+    func sendInput(id: String, text: String, intent: String, clientRequestId: String?) async throws -> SessionInputResponse
     func draftReply(id: String, maxChars: Int) async throws -> DraftReplyResponse
     func setSessionLoopMode(id: String, loopMode: SessionLoopMode) async throws -> LoopModeResponse
     func postRenderBeacon(_ payload: RenderBeaconReporter.Payload) async
@@ -147,12 +147,21 @@ struct LonghouseAPI: Sendable {
     /// UI's capability check and dispatch. That surfaces as
     /// `LonghouseAPIError.structured(...)` so the caller can offer a
     /// "Queue instead" action instead of silently converting the intent.
-    func sendInput(id: String, text: String, intent: String = "auto") async throws -> SessionInputResponse {
+    func sendInput(
+        id: String,
+        text: String,
+        intent: String = "auto",
+        clientRequestId: String? = nil
+    ) async throws -> SessionInputResponse {
         var request = URLRequest(url: baseURL.appendingPathComponent("/api/sessions/\(id)/input"))
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
-        request.httpBody = try JSONSerialization.data(withJSONObject: ["text": text, "intent": intent])
+        var body: [String: Any] = ["text": text, "intent": intent]
+        if let clientRequestId, !clientRequestId.isEmpty {
+            body["client_request_id"] = clientRequestId
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let (data, httpResponse) = try await data(for: request)
         guard (200..<300).contains(httpResponse.statusCode) else {

--- a/ios/Tests/LonghouseIOSTests/SessionViewModelTests.swift
+++ b/ios/Tests/LonghouseIOSTests/SessionViewModelTests.swift
@@ -26,7 +26,7 @@ struct SessionViewModelTests {
     }
 
     @Test
-    func sendRefreshesFromWorkspaceEndpoint() async throws {
+    func sendReturnsBeforeWorkspaceRefreshCompletes() async throws {
         let before = try makeWorkspace(eventId: 10, content: "Before send")
         let after = try makeWorkspace(eventId: 11, content: "After send")
         let api = FakeSessionWorkspaceClient(workspaces: [before, after])
@@ -35,12 +35,14 @@ struct SessionViewModelTests {
         let model = SessionViewModel(apiFactory: { _ in api }, enableRealtime: false)
 
         await model.start(sessionId: "session-1", appState: appState)
+        await api.failFutureWorkspaceLoads()
         let sent = await model.send(text: "continue", sessionId: "session-1", appState: appState)
 
         #expect(sent)
         #expect(model.lastSendOutcome == .sent)
-        #expect(model.items.map(\.id) == ["user:11"])
-        #expect(await api.workspaceRequestCount() == 2)
+        #expect(model.items.map(\.id) == ["user:10"])
+        #expect(model.submittedInputs.count == 1)
+        #expect(model.submittedInputs.first?.phase == .sent)
         #expect(await api.sendRequests() == ["continue:auto"])
     }
 
@@ -59,7 +61,61 @@ struct SessionViewModelTests {
         #expect(sent)
         #expect(model.errorMessage == nil)
         #expect(model.items.map(\.id) == ["user:10"])
-        #expect(await api.workspaceRequestCount() == 2)
+        #expect(await api.workspaceRequestCount() >= 1)
+    }
+
+    @Test
+    func sendFailureKeepsSubmittedTextOutOfComposerState() async throws {
+        let before = try makeWorkspace(eventId: 10, content: "Before send")
+        let api = FakeSessionWorkspaceClient(workspaces: [before])
+        await api.failFutureSends(URLError(.notConnectedToInternet))
+        let appState = AppState()
+        appState.serverURL = "https://example.longhouse.ai"
+        let model = SessionViewModel(apiFactory: { _ in api }, enableRealtime: false)
+
+        await model.start(sessionId: "session-1", appState: appState)
+        let sent = await model.send(text: "do not lose this", sessionId: "session-1", appState: appState)
+
+        #expect(!sent)
+        #expect(model.submittedInputs.count == 1)
+        #expect(model.submittedInputs.first?.text == "do not lose this")
+        #expect(model.submittedInputs.first?.phase == .failed)
+        #expect(model.errorMessage?.contains("Send failed") == true)
+    }
+
+    @Test
+    func queuedSendUpdatesSubmittedStateWithoutTranscriptRefresh() async throws {
+        let before = try makeWorkspace(eventId: 10, content: "Before send")
+        let api = FakeSessionWorkspaceClient(
+            workspaces: [before],
+            sendResponse: SessionInputResponse(
+                outcome: .queued,
+                inputId: 7,
+                intent: "queue",
+                queued: [
+                    QueuedInputSummary(
+                        id: 7,
+                        text: "next",
+                        intent: "queue",
+                        status: "queued",
+                        lastError: nil,
+                        createdAt: "2026-05-02T20:00:00Z"
+                    )
+                ]
+            )
+        )
+        let appState = AppState()
+        appState.serverURL = "https://example.longhouse.ai"
+        let model = SessionViewModel(apiFactory: { _ in api }, enableRealtime: false)
+
+        await model.start(sessionId: "session-1", appState: appState)
+        let sent = await model.send(text: "next", sessionId: "session-1", appState: appState, intent: "queue")
+
+        #expect(sent)
+        #expect(model.lastSendOutcome == .queued)
+        #expect(model.queuedInputCount == 1)
+        #expect(model.submittedInputs.first?.phase == .queued)
+        #expect(model.submittedInputs.first?.serverInputId == 7)
     }
 
     private func makeWorkspace(eventId: Int, content: String) throws -> SessionWorkspaceResponse {
@@ -116,12 +172,18 @@ struct SessionViewModelTests {
 
 private actor FakeSessionWorkspaceClient: SessionWorkspaceClient {
     private var workspaces: [SessionWorkspaceResponse]
+    private let sendResponse: SessionInputResponse
     private var shouldFailWorkspaceLoads = false
+    private var sendError: Error?
     private var workspaceRequests: [(id: String, limit: Int, branchMode: String)] = []
     private var sentInputs: [String] = []
 
-    init(workspaces: [SessionWorkspaceResponse]) {
+    init(
+        workspaces: [SessionWorkspaceResponse],
+        sendResponse: SessionInputResponse = SessionInputResponse(outcome: .sent, inputId: 1, intent: "auto", queued: [])
+    ) {
         self.workspaces = workspaces
+        self.sendResponse = sendResponse
     }
 
     func sessionWorkspace(id: String, limit: Int, branchMode: String) async throws -> SessionWorkspaceResponse {
@@ -135,9 +197,12 @@ private actor FakeSessionWorkspaceClient: SessionWorkspaceClient {
         return workspaces[0]
     }
 
-    func sendInput(id: String, text: String, intent: String) async throws -> SessionInputResponse {
+    func sendInput(id: String, text: String, intent: String, clientRequestId: String?) async throws -> SessionInputResponse {
         sentInputs.append("\(text):\(intent)")
-        return SessionInputResponse(outcome: .sent, inputId: 1, intent: intent, queued: [])
+        if let sendError {
+            throw sendError
+        }
+        return sendResponse
     }
 
     func draftReply(id: String, maxChars: Int) async throws -> DraftReplyResponse {
@@ -152,6 +217,10 @@ private actor FakeSessionWorkspaceClient: SessionWorkspaceClient {
 
     func failFutureWorkspaceLoads() {
         shouldFailWorkspaceLoads = true
+    }
+
+    func failFutureSends(_ error: Error) {
+        sendError = error
     }
 
     func workspaceRequestCount() -> Int {

--- a/server/tests_lite/test_session_inputs_api.py
+++ b/server/tests_lite/test_session_inputs_api.py
@@ -295,6 +295,81 @@ def test_client_request_id_dedupes_queued_input(monkeypatch, tmp_path):
         api_app_ref.dependency_overrides = {}
 
 
+def test_client_request_id_unique_constraint_blocks_duplicate_rows(tmp_path):
+    from sqlalchemy.exc import IntegrityError
+
+    from zerg.services.session_inputs import create_session_input
+
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_live_session(session_local)
+
+    with session_local() as db:
+        create_session_input(
+            db,
+            session_id=session_id,
+            text="once",
+            owner_id=user_id,
+            intent="queue",
+            status=INPUT_STATUS_QUEUED,
+            request_id="ios-unique-1",
+        )
+        try:
+            create_session_input(
+                db,
+                session_id=session_id,
+                text="twice",
+                owner_id=user_id,
+                intent="queue",
+                status=INPUT_STATUS_QUEUED,
+                request_id="ios-unique-1",
+            )
+        except IntegrityError:
+            db.rollback()
+        else:
+            raise AssertionError("duplicate client request id inserted")
+
+        rows = db.query(SessionInput).filter(SessionInput.session_id == session_id).all()
+        assert len(rows) == 1
+        assert rows[0].body == "once"
+
+
+def test_client_request_id_failed_retry_does_not_report_queued(monkeypatch, tmp_path):
+    from zerg.services.session_inputs import create_session_input
+
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_live_session(session_local)
+    _stub_dispatch(monkeypatch)
+
+    with session_local() as db:
+        row = create_session_input(
+            db,
+            session_id=session_id,
+            text="failed once",
+            owner_id=user_id,
+            intent="auto",
+            status=INPUT_STATUS_FAILED,
+            request_id="ios-failed-1",
+        )
+        row.last_error = "provider disconnected"
+        db.commit()
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    try:
+        retry = client.post(
+            f"/api/sessions/{session_id}/input",
+            json={"text": "failed once", "intent": "auto", "client_request_id": "ios-failed-1"},
+        )
+        assert retry.status_code == 409, retry.text
+        body = retry.json()["detail"]
+        assert body["error_code"] == "input_failed"
+        assert "provider disconnected" in body["message"]
+    finally:
+        api_app_ref.dependency_overrides = {}
+
+
 def test_intent_auto_locked_returns_queued(monkeypatch, tmp_path):
     session_local = _make_db(tmp_path)
     session_id, user_id = _seed_live_session(session_local)

--- a/server/tests_lite/test_session_inputs_api.py
+++ b/server/tests_lite/test_session_inputs_api.py
@@ -10,7 +10,6 @@ from uuid import uuid4
 
 from cryptography.fernet import Fernet
 from fastapi.testclient import TestClient
-import pytest
 
 os.environ.setdefault("DATABASE_URL", "sqlite://")
 os.environ.setdefault("TESTING", "1")
@@ -21,11 +20,11 @@ from zerg.database import initialize_database
 from zerg.database import make_engine
 from zerg.database import make_sessionmaker
 from zerg.dependencies.browser_route_auth import get_current_browser_route_user
+from zerg.models.agents import AgentSession
 from zerg.models.agents import SessionInput
 from zerg.models.enums import UserRole
 from zerg.models.models import Runner
 from zerg.models.user import User
-from zerg.routers import session_chat
 from zerg.services.agents_store import AgentsStore
 from zerg.services.agents_store import EventIngest
 from zerg.services.agents_store import SessionIngest
@@ -73,7 +72,12 @@ def _seed_live_runtime_state(db, session, *, phase: str = "idle") -> None:
     key = runtime_key_for_session(str(session.provider or "claude"), str(session.id))
     state = db.query(SessionRuntimeState).filter(SessionRuntimeState.runtime_key == key).first()
     if state is None:
-        state = SessionRuntimeState(runtime_key=key, session_id=session.id, provider=str(session.provider or "claude"), device_id=session.device_id)
+        state = SessionRuntimeState(
+            runtime_key=key,
+            session_id=session.id,
+            provider=str(session.provider or "claude"),
+            device_id=session.device_id,
+        )
         db.add(state)
     state.phase = phase
     state.phase_source = "semantic"
@@ -205,6 +209,35 @@ def test_intent_auto_not_locked_returns_sent(monkeypatch, tmp_path):
         api_app_ref.dependency_overrides = {}
 
 
+def test_client_request_id_dedupes_delivered_auto(monkeypatch, tmp_path):
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_live_session(session_local)
+    calls = _stub_dispatch(monkeypatch)
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    try:
+        payload = {"text": "hello once", "intent": "auto", "client_request_id": "ios-request-1"}
+        first = client.post(f"/api/sessions/{session_id}/input", json=payload)
+        second = client.post(f"/api/sessions/{session_id}/input", json=payload)
+
+        assert first.status_code == 200, first.text
+        assert second.status_code == 200, second.text
+        assert first.json()["input_id"] == second.json()["input_id"]
+        assert second.json()["outcome"] == "sent"
+        assert len(calls) == 1
+        with session_local() as db:
+            rows = db.query(SessionInput).filter(SessionInput.session_id == session_id).all()
+            assert len(rows) == 1
+            assert rows[0].request_id == "ios-request-1"
+            assert rows[0].status == INPUT_STATUS_DELIVERED
+    finally:
+        asyncio.run(session_lock_manager.release(str(session_id)))
+        api_app_ref.dependency_overrides = {}
+
+
 def test_intent_queue_always_persists_queued(monkeypatch, tmp_path):
     session_local = _make_db(tmp_path)
     session_id, user_id = _seed_live_session(session_local)
@@ -231,6 +264,33 @@ def test_intent_queue_always_persists_queued(monkeypatch, tmp_path):
             row = db.query(SessionInput).filter(SessionInput.session_id == session_id).one()
             assert row.status == INPUT_STATUS_QUEUED
             assert row.intent == "queue"
+    finally:
+        api_app_ref.dependency_overrides = {}
+
+
+def test_client_request_id_dedupes_queued_input(monkeypatch, tmp_path):
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_live_session(session_local)
+    _stub_dispatch(monkeypatch)
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    try:
+        payload = {"text": "queued once", "intent": "queue", "client_request_id": "ios-queued-1"}
+        first = client.post(f"/api/sessions/{session_id}/input", json=payload)
+        second = client.post(f"/api/sessions/{session_id}/input", json=payload)
+
+        assert first.status_code == 200, first.text
+        assert second.status_code == 200, second.text
+        assert first.json()["input_id"] == second.json()["input_id"]
+        assert second.json()["outcome"] == "queued"
+        with session_local() as db:
+            rows = db.query(SessionInput).filter(SessionInput.session_id == session_id).all()
+            assert len(rows) == 1
+            assert rows[0].request_id == "ios-queued-1"
+            assert rows[0].status == INPUT_STATUS_QUEUED
     finally:
         api_app_ref.dependency_overrides = {}
 
@@ -314,7 +374,7 @@ def _seed_codex_session(session_local):
     capability gate for steer is satisfied."""
     session_id, user_id = _seed_live_session(session_local)
     with session_local() as db:
-        session = db.query(__import__("zerg.models.agents", fromlist=["AgentSession"]).AgentSession).filter_by(id=session_id).one()
+        session = db.query(AgentSession).filter_by(id=session_id).one()
         session.managed_transport = "codex_app_server"
         db.commit()
         _seed_live_runtime_state(db, session, phase="running")

--- a/server/zerg/database.py
+++ b/server/zerg/database.py
@@ -4,6 +4,8 @@ This module provides database connection and session management for Zerg.
 The codebase is SQLite-only for OSS deployment simplicity.
 """
 
+# ruff: noqa: E501
+
 import logging
 import os
 from contextlib import contextmanager
@@ -840,6 +842,26 @@ def _migrate_agents_columns(engine: Engine) -> None:
                 conn.commit()
     except Exception:
         logger.debug("session_tasks table migration skipped (table may not exist yet)", exc_info=True)
+
+    # session_inputs table migrations
+    try:
+        with engine.connect() as conn:
+            session_inputs_exists = conn.execute(
+                text("SELECT 1 FROM sqlite_master WHERE type='table' AND name='session_inputs'")
+            ).fetchone()
+            if session_inputs_exists:
+                conn.execute(
+                    text(
+                        """
+                        CREATE UNIQUE INDEX IF NOT EXISTS ix_session_inputs_session_owner_request
+                        ON session_inputs(session_id, owner_id, request_id)
+                        WHERE request_id IS NOT NULL
+                        """
+                    )
+                )
+                conn.commit()
+    except Exception:
+        logger.debug("session_inputs table migration skipped", exc_info=True)
 
     # session_messages table migrations
     try:

--- a/server/zerg/database.py
+++ b/server/zerg/database.py
@@ -861,7 +861,7 @@ def _migrate_agents_columns(engine: Engine) -> None:
                 )
                 conn.commit()
     except Exception:
-        logger.debug("session_inputs table migration skipped", exc_info=True)
+        logger.warning("session_inputs idempotency index migration skipped", exc_info=True)
 
     # session_messages table migrations
     try:

--- a/server/zerg/models/agents.py
+++ b/server/zerg/models/agents.py
@@ -676,4 +676,15 @@ class SessionInput(AgentsBase):
     delivered_at = Column(DateTime(timezone=True), nullable=True)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
-    __table_args__ = (Index("ix_session_inputs_session_status_created", "session_id", "status", "created_at"),)
+    __table_args__ = (
+        Index("ix_session_inputs_session_status_created", "session_id", "status", "created_at"),
+        Index(
+            "ix_session_inputs_session_owner_request",
+            "session_id",
+            "owner_id",
+            "request_id",
+            unique=True,
+            postgresql_where=text("request_id IS NOT NULL"),
+            sqlite_where=text("request_id IS NOT NULL"),
+        ),
+    )

--- a/server/zerg/routers/session_chat.py
+++ b/server/zerg/routers/session_chat.py
@@ -26,6 +26,7 @@ from zerg.database import get_db
 from zerg.dependencies.agents_auth import require_single_tenant
 from zerg.dependencies.agents_auth import verify_agents_token
 from zerg.dependencies.browser_route_auth import get_current_browser_route_user
+from zerg.models.agents import SessionInput
 from zerg.models.device_token import DeviceToken
 from zerg.models.user import User
 from zerg.services.managed_local_launcher import ManagedLocalLaunchError
@@ -119,6 +120,12 @@ class SessionInputRequest(BaseModel):
 
     text: str = Field(..., min_length=1, max_length=10000)
     intent: str = Field(INPUT_INTENT_AUTO, description="auto | queue | steer")
+    client_request_id: str | None = Field(
+        None,
+        min_length=1,
+        max_length=64,
+        description="Optional client idempotency key for this submitted input",
+    )
 
 
 class QueuedInputSummary(BaseModel):
@@ -508,6 +515,45 @@ def _queued_summary(row) -> QueuedInputSummary:
     )
 
 
+def _request_id_for_input(body: SessionInputRequest) -> str:
+    client_request_id = (body.client_request_id or "").strip()
+    if client_request_id:
+        return client_request_id
+    return str(uuid.uuid4())[:8]
+
+
+def _existing_input_response(
+    *,
+    source_session,
+    owner_id: int,
+    body: SessionInputRequest,
+    db: Session,
+) -> SessionInputResponse | None:
+    client_request_id = (body.client_request_id or "").strip()
+    if not client_request_id:
+        return None
+    existing = (
+        db.query(SessionInput)
+        .filter(
+            SessionInput.session_id == source_session.id,
+            SessionInput.owner_id == owner_id,
+            SessionInput.request_id == client_request_id,
+        )
+        .order_by(SessionInput.id.asc())
+        .first()
+    )
+    if existing is None:
+        return None
+    recent = list_recent_inputs(db, source_session.id)
+    outcome = "sent" if existing.status == "delivered" else "queued"
+    return SessionInputResponse(
+        outcome=outcome,
+        input_id=int(existing.id),
+        intent=existing.intent,
+        queued=[_queued_summary(r) for r in recent],
+    )
+
+
 async def _dispatch_steer_input(
     *,
     source_session,
@@ -605,7 +651,15 @@ async def _create_session_input_response(
 
     _assert_live_session_send_available(db, source_session, owner_id=owner_id)
 
-    request_id = str(uuid.uuid4())[:8]
+    if existing_response := _existing_input_response(
+        source_session=source_session,
+        owner_id=owner_id,
+        body=body,
+        db=db,
+    ):
+        return existing_response
+
+    request_id = _request_id_for_input(body)
 
     def _cap_check_or_raise() -> None:
         current = count_queued(db, source_session.id)

--- a/server/zerg/routers/session_chat.py
+++ b/server/zerg/routers/session_chat.py
@@ -19,6 +19,7 @@ from fastapi import Response
 from fastapi import status
 from pydantic import BaseModel
 from pydantic import Field
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from zerg.config import get_settings
@@ -49,6 +50,10 @@ from zerg.services.session_current_control import current_session_capabilities
 from zerg.services.session_inputs import INPUT_INTENT_AUTO
 from zerg.services.session_inputs import INPUT_INTENT_QUEUE
 from zerg.services.session_inputs import INPUT_INTENT_STEER
+from zerg.services.session_inputs import INPUT_STATUS_CANCELLED
+from zerg.services.session_inputs import INPUT_STATUS_DELIVERED
+from zerg.services.session_inputs import INPUT_STATUS_DELIVERING
+from zerg.services.session_inputs import INPUT_STATUS_FAILED
 from zerg.services.session_inputs import INPUT_STATUS_QUEUED
 from zerg.services.session_inputs import MAX_QUEUED_PER_SESSION
 from zerg.services.session_inputs import cancel_queued_input
@@ -519,7 +524,51 @@ def _request_id_for_input(body: SessionInputRequest) -> str:
     client_request_id = (body.client_request_id or "").strip()
     if client_request_id:
         return client_request_id
-    return str(uuid.uuid4())[:8]
+    return uuid.uuid4().hex
+
+
+def _conflict_for_existing_input(existing: SessionInput) -> HTTPException:
+    status_value = str(existing.status or "")
+    if status_value == INPUT_STATUS_DELIVERING:
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error_code": "input_in_flight",
+                "message": "This input is already being sent.",
+            },
+        )
+    if status_value == INPUT_STATUS_CANCELLED:
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error_code": "input_cancelled",
+                "message": "This submitted input was already cancelled. Edit and send it again.",
+            },
+        )
+    if status_value == INPUT_STATUS_FAILED:
+        last_error = str(existing.last_error or "").strip()
+        if last_error == "turn_ended":
+            return HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "error_code": "turn_ended",
+                    "message": "The active turn already ended. Queue this as the next message instead?",
+                },
+            )
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error_code": "input_failed",
+                "message": last_error or "This submitted input already failed. Edit and send it again.",
+            },
+        )
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "error_code": "input_conflict",
+            "message": "This submitted input is not retryable. Edit and send it again.",
+        },
+    )
 
 
 def _existing_input_response(
@@ -544,14 +593,48 @@ def _existing_input_response(
     )
     if existing is None:
         return None
+    if existing.status not in (INPUT_STATUS_DELIVERED, INPUT_STATUS_QUEUED):
+        raise _conflict_for_existing_input(existing)
     recent = list_recent_inputs(db, source_session.id)
-    outcome = "sent" if existing.status == "delivered" else "queued"
+    outcome = "sent" if existing.status == INPUT_STATUS_DELIVERED else "queued"
     return SessionInputResponse(
         outcome=outcome,
         input_id=int(existing.id),
         intent=existing.intent,
         queued=[_queued_summary(r) for r in recent],
     )
+
+
+def _create_session_input_or_existing(
+    *,
+    db: Session,
+    source_session,
+    owner_id: int,
+    body: SessionInputRequest,
+    intent: str,
+    status_value: str,
+    request_id: str,
+) -> SessionInput | SessionInputResponse:
+    try:
+        return create_session_input(
+            db,
+            session_id=source_session.id,
+            text=body.text,
+            owner_id=owner_id,
+            intent=intent,
+            status=status_value,
+            request_id=request_id,
+        )
+    except IntegrityError:
+        db.rollback()
+        if existing_response := _existing_input_response(
+            source_session=source_session,
+            owner_id=owner_id,
+            body=body,
+            db=db,
+        ):
+            return existing_response
+        raise
 
 
 async def _dispatch_steer_input(
@@ -583,15 +666,18 @@ async def _dispatch_steer_input(
 
     # Record a delivering row so the steer attempt is audit-visible even on
     # failure (for drain-failure UX parity with intent=auto).
-    row = create_session_input(
-        db,
-        session_id=source_session.id,
-        text=body.text,
+    created = _create_session_input_or_existing(
+        db=db,
+        source_session=source_session,
         owner_id=owner_id,
+        body=body,
         intent=INPUT_INTENT_STEER,
-        status="delivering",
+        status_value=INPUT_STATUS_DELIVERING,
         request_id=request_id,
     )
+    if isinstance(created, SessionInputResponse):
+        return created
+    row = created
 
     result = await steer_text_to_managed_local_session(
         db=db,
@@ -681,15 +767,18 @@ async def _create_session_input_response(
     # Queue intent always persists and returns without attempting dispatch.
     if body.intent == INPUT_INTENT_QUEUE:
         _cap_check_or_raise()
-        row = create_session_input(
-            db,
-            session_id=source_session.id,
-            text=body.text,
+        created = _create_session_input_or_existing(
+            db=db,
+            source_session=source_session,
             owner_id=owner_id,
+            body=body,
             intent=INPUT_INTENT_QUEUE,
-            status=INPUT_STATUS_QUEUED,
+            status_value=INPUT_STATUS_QUEUED,
             request_id=request_id,
         )
+        if isinstance(created, SessionInputResponse):
+            return created
+        row = created
         recent = list_recent_inputs(db, source_session.id)
         return SessionInputResponse(
             outcome="queued",
@@ -707,15 +796,18 @@ async def _create_session_input_response(
     )
     if not lock:
         _cap_check_or_raise()
-        row = create_session_input(
-            db,
-            session_id=source_session.id,
-            text=body.text,
+        created = _create_session_input_or_existing(
+            db=db,
+            source_session=source_session,
             owner_id=owner_id,
+            body=body,
             intent=INPUT_INTENT_AUTO,
-            status=INPUT_STATUS_QUEUED,
+            status_value=INPUT_STATUS_QUEUED,
             request_id=request_id,
         )
+        if isinstance(created, SessionInputResponse):
+            return created
+        row = created
         recent = list_recent_inputs(db, source_session.id)
         return SessionInputResponse(
             outcome="queued",
@@ -725,15 +817,23 @@ async def _create_session_input_response(
         )
 
     # Lock acquired: record a delivering row for audit, then dispatch.
-    row = create_session_input(
-        db,
-        session_id=source_session.id,
-        text=body.text,
-        owner_id=owner_id,
-        intent=INPUT_INTENT_AUTO,
-        status="delivering",
-        request_id=request_id,
-    )
+    try:
+        created = _create_session_input_or_existing(
+            db=db,
+            source_session=source_session,
+            owner_id=owner_id,
+            body=body,
+            intent=INPUT_INTENT_AUTO,
+            status_value=INPUT_STATUS_DELIVERING,
+            request_id=request_id,
+        )
+    except Exception:
+        await session_lock_manager.release(lock_scope_id, request_id)
+        raise
+    if isinstance(created, SessionInputResponse):
+        await session_lock_manager.release(lock_scope_id, request_id)
+        return created
+    row = created
     try:
         dispatch_response = await _build_managed_local_chat_response(
             source_session=source_session,


### PR DESCRIPTION
## Summary
- Add a formal iOS optimistic session input spec
- Clear the iOS composer immediately and render submitted input rows with submitting/sent/queued/failed/needs-choice phases
- Send client request ids from iOS and enforce backend idempotency with a session_inputs unique index
- Keep refresh and render beacon work off the send hot path
- Harden duplicate retry semantics so failed/cancelled/in-flight inputs do not masquerade as queued

## Validation
- `cd server && uv run --extra dev pytest tests_lite/test_session_inputs_api.py -q` -> 19 passed
- iOS Xcode harness `LonghouseIOSTests/SessionViewModelTests` -> 5 passed
- targeted `ruff check` and `git diff --check` passed
- Hatch Opus reviewed the implementation, found blockers, reviewed the hardening follow-up, and reported no blocking issues

## Notes
- Adds a SQLite startup migration for the session input idempotency index; migration failure now logs a warning.
- iOS changes still require an Xcode build/run on device; no TestFlight/App Store distribution path exists yet.
- Remaining non-blocking risk: queued optimistic rows may linger if the durable transcript echo appears more than 120s after submit.