### PR TITLE
Remote session launch

### DIFF
--- a/docs/specs/remote-session-launch.md
+++ b/docs/specs/remote-session-launch.md
@@ -1,0 +1,575 @@
+# Remote Session Launch
+
+Status: Proposed. Phase 0 implementable now. Phase 1+ gated on companion-view stability (see Deferral Gate).
+Owner: machine control + mobile/web launch UX
+Updated: 2026-05-12
+
+## Goal
+
+Let a user start a new managed session on one of their own already-enrolled
+machines from iOS or web, without first opening a terminal on that machine.
+
+Today, managed sessions are created by `longhouse codex` / `longhouse claude`
+running on the target machine itself. That machine POSTs to
+`/api/sessions/managed-local/this-device` with its own device token.
+
+After this spec, a user on iPhone or browser picks a machine, picks a
+workspace (cwd), picks a provider, and says "start it there." The target
+Machine Agent receives a typed `session.launch` command over its existing
+control WebSocket, spawns the provider locally (headless under the engine
+bridge), and reports the pre-allocated session id back.
+
+This is a natural extension of `machine-agent-control-channel.md`: Phase 2
+gave us `session.send_text` / `interrupt` / `steer_text` on known sessions.
+This spec adds `session.launch` — a command that happens to create the
+session rather than act on an existing one.
+
+## Non-Goals
+
+- No session migration between machines. Sessions run where launched.
+- No workspace filesystem sync, rsync, or git auto-commit on launch.
+- No Longhouse-provisioned runtime. Machines are user-owned.
+- No Claude support in v1. Codex only. Claude joins when its control path
+  leaves `legacy_runner` and becomes native.
+- No "queue launch until machine comes online." Machine must be online at
+  request time. Queueing is a jobs product.
+- No generic remote shell. `session.launch` spawns one Longhouse-managed
+  provider session, nothing else.
+- No continuation of a prior session into a fresh launch in v1. Fresh
+  sessions only.
+
+## Deferral Gate (ship Phase 0 only)
+
+Phase 0 (machines endpoint + projection) ships now. It is useful on its
+own for a machines page and derisks the data shape.
+
+Phase 1+ (the `session.launch` command, `launch_state` lifecycle on
+`sessions`, the launch sheet UI) are **deferred until all of**:
+
+- `ios-session-workspace-contract` is fully landed on TestFlight builds
+- observation ledger has been dogfooded for two weeks with no new ingest
+  bugs reported
+- managed Codex send/interrupt/steer on the engine channel (not legacy
+  runner) is the default transport and has been green on the propagation
+  SLA dashboard for two weeks
+
+Why: companion view is the current chapter. Remote launch is the next
+chapter. We spec it now so we are ready; we do not build it until the
+substrate is boring.
+
+Before re-opening Phase 1, revisit this spec's Open Questions and confirm
+none have become decisions.
+
+## Product Shape
+
+### Launch sheet — cold path first
+
+A new user has no sessions. The UX leads with **machines** (what they
+just enrolled) and a **directory picker served by the target Machine
+Agent** (which is authoritative for cwd). Presets are additive.
+
+```
+Start Session
+──────────────
+Machine
+  [cinder]  online     · Codex ✓
+  [homelab] offline              (disabled)
+
+Workspace on cinder
+  /Users/david/git/zerg         · main     (recent)
+  /Users/david/git/me           · master   (recent)
+  Browse this machine…                     (opens picker)
+
+Provider     [Codex]
+
+Initial prompt (optional)  ___________________________
+
+                                                [Start]
+```
+
+- Machine list is first — it is what new users actually have.
+- Workspace is a directory picker backed by the Machine Agent. Recent
+  workspaces for the selected machine surface at the top once history
+  exists, as an affordance — not as the only path.
+- Provider defaults to the only one in v1 (Codex).
+- Initial prompt is optional. If provided, it is sent as a follow-up
+  `session.send_text` once the session is created, not bundled into the
+  launch frame (keeps launch semantics narrow).
+
+### After "Start"
+
+- Success deep-links into session detail, which already renders managed
+  Codex live transcript + steering.
+- Provider process runs headless on the target machine under the
+  engine-owned bridge. Same path a local `longhouse codex` ends up on,
+  minus the terminal attach.
+- A user at a terminal on the target machine can later `longhouse codex
+  --attach <session-id>` if they want to watch it there (pre-existing
+  capability; unchanged).
+
+## First-Principles Invariants
+
+1. **One session, one execution owner.**
+   The target Machine Agent is the execution owner from the moment the
+   launch succeeds. Runtime Host coordinates; it does not execute.
+
+2. **Workspace is user intent; machine is placement. Machine picks first.**
+   New users have no workspace history. Leading with machines matches
+   reality. Recents are an accelerator, not the bootstrap.
+
+3. **No hidden state transfer.**
+   Launch carries only declared parameters: cwd, provider, optional repo
+   context, optional initial prompt. No silent copy of files, secrets, or
+   env from the requester's device.
+
+4. **Online-only placement.**
+   Target machine must have an active control-channel connection at the
+   moment of request. Offline machines fail fast with clear copy.
+
+5. **Pre-allocated session id. No parallel status table.**
+   Runtime Host mints the session UUID, inserts a `sessions` row with
+   `launch_state=launching`, and includes `session_id` in the
+   `session.launch` frame. The control-channel envelope rule — every
+   command carries `session_id` — is preserved. Lifecycle is one column
+   on one table.
+
+6. **Explicit per-provider per-op capability.**
+   Only providers the Machine Agent announces in `supports[]` as
+   `<provider>.launch` are offerable. Codex in v1.
+
+7. **Machine Agent is authoritative for cwd.**
+   Runtime Host does not validate filesystem paths. The Machine Agent
+   validates cwd exists, is a directory, and is allowed by local policy.
+
+8. **cwd allowlist is enforced locally.**
+   `send_text` is bounded by the session's existing cwd. `launch` picks
+   cwd, so it widens the implicit code-running surface. Machine Agent
+   applies a local allowlist (default: directory must be under `$HOME`
+   and contain a `.git`, OR match a cwd used by a prior session on this
+   device). Rejections return `cwd_not_allowed`. Users can relax the
+   policy per-machine via a config file (out of scope for v1 UI).
+
+## Request Flow
+
+```
+iOS / Web (user auth cookie)
+        │
+        ▼
+POST /api/sessions/launch
+  - verify user owns target device_id
+  - verify control channel online for device_id
+  - verify provider ∈ device supports[] as <provider>.launch
+  - mint session UUID
+  - INSERT sessions row: launch_state=launching,
+      owner_id, device_id, cwd, provider, display_name,
+      git_repo, git_branch, project, started_at=now()
+  - send session.launch command frame over control WS
+  - await command_result (short timeout, 20s)
+        │
+        ▼
+Machine Agent (WS)
+  - check cwd exists + allowed by local policy
+  - call cmd_codex_bridge_start(session_id, cwd, …)
+    (engine/src/codex_bridge.rs:484 — existing seam)
+  - wait for bridge status=ready
+  - return command_result { ok=true, provider_session_id, transport }
+        │
+        ▼
+Runtime Host
+  - UPDATE sessions row: launch_state=live, provider_session_id
+  - return { session_id, launch_state } to client
+        │
+        ▼
+Client deep-links to /sessions/{session_id}
+```
+
+### Timeout / mid-flight disconnect
+
+- Runtime Host marks `launch_state=launching_unknown` and returns the
+  session_id with that state to the client.
+- Client polls `GET /api/sessions/{id}` (or subscribes to the existing
+  session stream) for resolution.
+- On Machine Agent reconnect, it sends any buffered late
+  `command_result` frames (same LRU behavior as other control commands).
+- If no result arrives before `launch_lease_until` (e.g. 120s after
+  request), Runtime Host moves the row to `launch_state=launch_orphaned`.
+  No retry. The row becomes a cold record; timeline filters hide
+  `launch_orphaned` from default views but leaves it for debug.
+
+### Failure
+
+- Typed errors from Machine Agent (`cwd_not_found`, `cwd_not_allowed`,
+  `provider_unsupported`, `provider_launch_failed`,
+  `already_running_for_cwd`) propagate to the client and mark the row
+  `launch_state=launch_failed` with `launch_error_code` /
+  `launch_error_message`.
+
+## Data Model
+
+### `sessions` — add three columns
+
+```text
+launch_state          text nullable  -- launching | live | launching_unknown
+                                     -- | launch_failed | launch_orphaned
+                                     -- NULL for sessions created the old way
+launch_error_code     text nullable
+launch_error_message  text nullable
+launch_lease_until    timestamptz nullable
+```
+
+`launch_state=live` is functionally equivalent to "session exists
+normally" — it's the steady state for any remotely-launched session. For
+sessions created by the existing this-device path, the column stays NULL
+and readers treat NULL as `live`.
+
+No new table.
+
+### Workspace presets (derived, not stored)
+
+Presets on the launch sheet are a read-only projection — same as before,
+but explicitly secondary to the machine picker:
+
+```sql
+SELECT cwd, provider,
+       max(git_repo)   AS git_repo,
+       max(git_branch) AS git_branch,   -- NOTE: lossy; see Open Q 4
+       max(project)    AS project,
+       max(created_at) AS last_active_at,
+       count(*)        AS session_count
+FROM sessions
+WHERE owner_id = ? AND device_id = ?
+GROUP BY cwd, provider
+ORDER BY last_active_at DESC
+LIMIT 10;
+```
+
+Presets are scoped per-(owner, device). A session on laptop-A does not
+surface as a preset on laptop-B — that implies filesystem knowledge we
+don't have.
+
+## Endpoints
+
+### Machines (Phase 0 — ships now)
+
+Follow the agents-sessions pattern: one builder, two route wrappers.
+
+- `GET /api/agents/machines` — machine-token auth
+- `GET /api/timeline/machines` — user-cookie auth
+
+Both return:
+
+```json
+[
+  {
+    "device_id": "cinder-abc123",
+    "machine_name": "cinder",
+    "online": true,
+    "supports": ["codex.send", "codex.interrupt", "codex.steer", "codex.launch"],
+    "last_seen_at": "2026-05-12T13:44:22Z",
+    "engine_build": "29db1495"
+  }
+]
+```
+
+The list reads from the control-channel in-memory registry for
+online/supports/last_seen, joined with persisted device metadata for
+machines that are currently offline but have been seen before.
+
+### Launch (Phase 1 — gated)
+
+- `POST /api/sessions/launch`
+  body:
+  ```json
+  {
+    "device_id": "cinder-abc123",
+    "provider": "codex",
+    "cwd": "/Users/david/git/zerg",
+    "git_repo": "zerg",
+    "git_branch": "main",
+    "project": "zerg",
+    "display_name": null,
+    "initial_prompt": null
+  }
+  ```
+  returns:
+  ```json
+  {
+    "session_id": "…",
+    "launch_state": "live",
+    "launch_error_code": null,
+    "launch_error_message": null
+  }
+  ```
+
+Session state transitions post-response are observable via the existing
+`GET /api/sessions/{id}` and session stream. No separate launch-request
+endpoint exists because there is no separate launch-request resource.
+
+### Control channel (Phase 1)
+
+`session.launch` is a new command type on the existing control WebSocket.
+The frame carries `session_id` like every other command:
+
+```json
+{
+  "type": "command",
+  "command_id": "…",
+  "session_id": "pre-allocated-uuid",
+  "command_type": "session.launch",
+  "payload": {
+    "provider": "codex",
+    "cwd": "/Users/david/git/zerg",
+    "git_repo": "zerg",
+    "git_branch": "main",
+    "project": "zerg",
+    "display_name": null,
+    "owner_id": "…"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "type": "command_result",
+  "command_id": "…",
+  "ok": true,
+  "result": {
+    "session_id": "…",
+    "provider_session_id": "…",
+    "transport": "codex_app_server"
+  }
+}
+```
+
+Failure codes (mapped to `launch_error_code`): `cwd_not_found`,
+`cwd_not_allowed`, `provider_unsupported`, `provider_launch_failed`,
+`launch_timeout`, `already_running_for_cwd`.
+
+## Authorization
+
+- `POST /api/sessions/launch` requires a user auth cookie.
+- Runtime Host verifies:
+  - `device_id` belongs to this user (via device registration ownership)
+  - target is the user's — no cross-account launch
+- `initial_prompt`, when provided, is sent as a follow-up
+  `session.send_text`. Launch permission implies send permission; no
+  separate check needed.
+
+**Why no 2FA in v1**: Device enrollment already granted code-running
+trust. The existing `send_text` primitive can already steer an LLM that
+can write and run code. Launch widens the implicit surface by letting the
+caller pick cwd — the `cwd_allowlist` (Invariant 8) bounds that widening.
+If, post-launch, we observe abuse or user demand for stronger guarantees,
+add a machine-local "confirm on device" hook. Not required for v1.
+
+## Engine Reuse
+
+Confirmed reusable without duplication:
+
+- Validate cwd + policy in a new small Rust helper
+  (`engine/src/launch_policy.rs`).
+- Call `cmd_codex_bridge_start` in `engine/src/codex_bridge.rs:484`
+  directly — the existing Rust seam spawns the detached `codex-bridge
+  run` daemon, waits for `ready`, writes state files.
+- Return success with `session_id`, `provider_session_id`, `transport`.
+
+**Explicitly not reused**: `_run_native_codex_tui` and
+`_run_foreground_process_group` in `server/zerg/cli/codex.py`. These
+attach a terminal. Remote launch is headless. The engine handler must
+not attach a TUI.
+
+Device identity: the handler reads `device_id` from the engine's own
+config. Runtime Host does not pass it in the frame. This differs from
+`/managed-local/this-device` which derives it from the caller's token;
+the caller here is user-authed, so the target must be named explicitly
+upstream (in the POST body) and routed by the control-channel
+registry.
+
+## Capability Gating
+
+Launch button enabled iff:
+
+- target `machine.online = true`
+- `<provider>.launch ∈ machine.supports`
+
+Offline / unsupported states reuse the existing control-capability copy
+patterns. No new design language.
+
+## Phased Plan
+
+### Phase 0 — machines endpoints (ships now)
+
+- `GET /api/agents/machines` (machine-token)
+- `GET /api/timeline/machines` (user-cookie)
+- Shared builder joining the in-memory control-channel registry with
+  persisted device metadata.
+- Backend tests: empty list, online/offline mix, supports[] echo, parity
+  between routes, user-scoped filtering.
+
+Acceptance:
+- Both routes return the same body for the same user.
+- Offline-but-seen machines appear with `online=false, supports=[]` (last
+  known supports are not persisted — avoid implying stale truth).
+- Unknown users return `[]` (not 404).
+
+### Phase 1 — `session.launch` + `launch_state` on `sessions` (gated)
+
+- DB migration: add `launch_state`, `launch_error_code`,
+  `launch_error_message`, `launch_lease_until` to `sessions`.
+- `POST /api/sessions/launch` endpoint.
+- Control-channel `session.launch` command dispatch.
+- Engine handler in `control_channel.rs` that validates cwd via
+  `launch_policy`, calls `cmd_codex_bridge_start`, returns the typed
+  result.
+- Engine `supports[]` gains `codex.launch` when the Codex bridge is
+  available.
+- `launch_error_code` + `launch_error_message` surface on
+  `GET /api/sessions/{id}` for clients to render.
+
+Acceptance:
+- Launch happy-path creates a `sessions` row in `launch_state=live`.
+- Bogus cwd returns `cwd_not_found`, row ends in `launch_failed`.
+- cwd outside policy returns `cwd_not_allowed`, row ends in
+  `launch_failed`.
+- Offline device returns 409 `machine_offline` without inserting a row.
+- Rapid double-submit returns one `live` row + one `already_running_for_cwd`
+  via engine LRU.
+- Command-result arriving after Runtime Host timeout moves the row from
+  `launching_unknown` to `live` or `launch_failed` deterministically.
+- No new table created. `launch_state` column is nullable and NULL for
+  all pre-migration rows (= equivalent to `live`).
+
+### Phase 2 — Web launch sheet (gated)
+
+- Launch sheet UI using `/timeline/machines` + directory picker.
+- Machine-first ordering in the UI.
+- Presets surface under the selected machine once history exists.
+- Deep-link on success.
+
+Acceptance:
+- Zero-history user can complete a launch via directory picker.
+- Second-session user sees their recent workspace as a preset under
+  that machine.
+- Offline machine visually disabled with clear copy.
+- E2E test covers happy-path launch from click to transcript render.
+
+### Phase 3 — iOS launch sheet (gated)
+
+- Mirror web UX.
+- Existing user-cookie auth (no machine token).
+- Xcode UI test covers happy-path launch.
+
+### Phase 4 — telemetry (gated)
+
+- Propagation metric: POST-to-first-transcript-byte for remote launches,
+  tracked alongside existing managed-op SLAs.
+- Hidden admin view of sessions filtered by `launch_state !=
+  {live, NULL}` for debugging.
+
+## Directory Picker (Phase 2/3 sub-spec)
+
+The Machine Agent serves directory listings over a new narrow control
+command `machine.list_dir`:
+
+```json
+{
+  "command_type": "machine.list_dir",
+  "payload": { "path": "/Users/david/git" }
+}
+```
+
+Response returns entries that are directories only, with an `is_git`
+boolean and `last_session_at` (if any). Entries outside policy are
+omitted, not merely flagged — the picker cannot surface a path the
+launch would reject.
+
+The picker is scoped: browsing is rooted at `$HOME` by default. A user
+who wants a different root edits machine policy config. Out of scope for
+v1 UI.
+
+## Testing Plan
+
+Backend (Phase 0):
+- machines routes: empty, mixed, parity
+- supports[] reflection
+- offline-but-persisted surfaces with `online=false, supports=[]`
+
+Backend (Phase 1):
+- `POST /api/sessions/launch` happy path
+- pre-allocated UUID persists in row before command is sent
+- timeout path: row moves to `launching_unknown`, then resolves
+- `launch_orphaned` after lease expiry without result
+- offline device → 409, no row
+- authorization: user cannot launch on a device_id they don't own
+
+Engine (Phase 1):
+- `session.launch` handler validates cwd
+- policy rejection returns `cwd_not_allowed`
+- happy path calls `cmd_codex_bridge_start` and returns the typed result
+- duplicate `command_id` dedupe via existing LRU
+- `already_running_for_cwd` when the local bridge registry shows an
+  active bridge for the same `(cwd, provider)`
+- `supports[]` includes `codex.launch` iff bridge seam is available
+
+End-to-end (Phase 2/3):
+- web: pick machine → pick cwd → launch → transcript renders
+- iOS: same, fixture-backed
+- offline machine path: disabled UI; direct POST returns 409
+
+## Open Questions
+
+1. Directory picker scope. v1 defaults to `$HOME`. Do we want a
+   machine-agent-side "favorites" (bookmarks of common roots) from day
+   one, or defer until users ask?
+
+2. `initial_prompt` policy. Current decision: send as follow-up
+   `session.send_text` after `launch` succeeds. That means a launch can
+   succeed and the prompt can fail independently. UX implication: if
+   send fails, the session exists but is empty. Acceptable?
+
+3. Rate limiting. `already_running_for_cwd` is cheap on the engine.
+   Do we need a Runtime Host rate limit, or is engine-side idempotency
+   sufficient for launch?
+
+4. Preset branch aggregation. The projection uses `max(git_branch)` for
+   grouping by `(cwd, provider)`. Same cwd with multiple branches
+   collapses the branch silently. Options: (a) group by
+   `(cwd, provider, git_branch)` and let presets expand; (b) drop branch
+   from preset entirely and let the user confirm branch post-launch;
+   (c) keep current lossy aggregation and ship. Recommendation for v1:
+   (b) — branch is a session concern, not a workspace identity concern.
+
+5. Cross-machine presets. If I always launch in `~/git/zerg` on laptop,
+   should that surface as a hint when I switch to homelab? Out of scope
+   for v1 — implies shared filesystem knowledge. Flag for post-launch.
+
+## Deletion Targets
+
+After Phase 1 ships:
+
+- Nothing is deleted in v1. `/managed-local/this-device` stays as the
+  `longhouse codex` CLI path.
+
+After dogfooding Phase 1-3 for a month, consider:
+
+- Collapsing `/managed-local/this-device` into `/sessions/launch` with
+  machine-token auth, making them one endpoint. Out of scope for this
+  spec.
+
+## Review Provenance
+
+This spec was revised after three independent reviews:
+
+- Repo-aware subagent review — flagged `launch_requests` redundancy,
+  confirmed `cmd_codex_bridge_start` as the clean Rust seam, pointed out
+  the `device_id` plumbing bug in the old draft.
+- Hatch Opus review — pushed for machines-first UX, explicit cwd
+  allowlist, and the Phase 1 deferral gate.
+- Hatch DeepSeek review — confirmed pre-allocated UUID as strictly
+  better, agreed `session.launch` belongs on the control channel if the
+  durable-FSM rule is respected.
+
+All three agreed on: drop the parallel table, lead UX with machines, wire
+`cwd_not_allowed` as a real policy, and ship Phase 0 only.

--- a/docs/specs/remote-session-launch.md
+++ b/docs/specs/remote-session-launch.md
@@ -1,6 +1,6 @@
 # Remote Session Launch
 
-Status: Proposed. Phase 0 implementable now. Phase 1+ gated on companion-view stability (see Deferral Gate).
+Status: Implemented in `remote-session-launch` as a Codex-only v1. Directory picker, presets, Claude launch, and richer SLA telemetry remain deferred.
 Owner: machine control + mobile/web launch UX
 Updated: 2026-05-12
 
@@ -38,35 +38,30 @@ session rather than act on an existing one.
 - No continuation of a prior session into a fresh launch in v1. Fresh
   sessions only.
 
-## Deferral Gate (ship Phase 0 only)
+## Release Scope
 
-Phase 0 (machines endpoint + projection) ships now. It is useful on its
-own for a machines page and derisks the data shape.
+The release scope is the narrow Codex v1:
 
-Phase 1+ (the `session.launch` command, `launch_state` lifecycle on
-`sessions`, the launch sheet UI) are **deferred until all of**:
+- machine directory endpoints for browser and machine clients
+- `POST /api/sessions/launch`
+- `session.launch` over the Machine Agent control WebSocket
+- headless Codex bridge startup with thread creation
+- web and iOS launch sheets
+- launch lifecycle fields on `sessions`
+- launch reaper and admin debug endpoint
 
-- `ios-session-workspace-contract` is fully landed on TestFlight builds
-- observation ledger has been dogfooded for two weeks with no new ingest
-  bugs reported
-- managed Codex send/interrupt/steer on the engine channel (not legacy
-  runner) is the default transport and has been green on the propagation
-  SLA dashboard for two weeks
-
-Why: companion view is the current chapter. Remote launch is the next
-chapter. We spec it now so we are ready; we do not build it until the
-substrate is boring.
-
-Before re-opening Phase 1, revisit this spec's Open Questions and confirm
-none have become decisions.
+Directory picker, workspace presets, Claude launch, queued offline
+launch, and propagation SLA dashboard integration are intentionally
+deferred.
 
 ## Product Shape
 
 ### Launch sheet — cold path first
 
 A new user has no sessions. The UX leads with **machines** (what they
-just enrolled) and a **directory picker served by the target Machine
-Agent** (which is authoritative for cwd). Presets are additive.
+just enrolled) and a typed cwd on the target Machine Agent (which is
+authoritative for cwd validation). A directory picker and presets are
+additive follow-ups.
 
 ```
 Start Session
@@ -76,25 +71,20 @@ Machine
   [homelab] offline              (disabled)
 
 Workspace on cinder
-  /Users/david/git/zerg         · main     (recent)
-  /Users/david/git/me           · master   (recent)
-  Browse this machine…                     (opens picker)
+  /Users/david/git/zerg
 
 Provider     [Codex]
-
-Initial prompt (optional)  ___________________________
 
                                                 [Start]
 ```
 
 - Machine list is first — it is what new users actually have.
-- Workspace is a directory picker backed by the Machine Agent. Recent
-  workspaces for the selected machine surface at the top once history
-  exists, as an affordance — not as the only path.
+- Workspace is a typed absolute cwd in v1. A directory picker backed by
+  the Machine Agent and recent workspaces are deferred accelerators.
 - Provider defaults to the only one in v1 (Codex).
-- Initial prompt is optional. If provided, it is sent as a follow-up
-  `session.send_text` once the session is created, not bundled into the
-  launch frame (keeps launch semantics narrow).
+- Initial prompt is deferred from the Codex v1 release. The v1 launch
+  creates a steerable empty session; the user sends the first prompt from
+  session detail.
 
 ### After "Start"
 
@@ -118,9 +108,9 @@ Initial prompt (optional)  ___________________________
    reality. Recents are an accelerator, not the bootstrap.
 
 3. **No hidden state transfer.**
-   Launch carries only declared parameters: cwd, provider, optional repo
-   context, optional initial prompt. No silent copy of files, secrets, or
-   env from the requester's device.
+   Launch carries only declared parameters: cwd, provider, and optional
+   repo context. No silent copy of files, secrets, or env from the
+   requester's device.
 
 4. **Online-only placement.**
    Target machine must have an active control-channel connection at the
@@ -275,7 +265,7 @@ The list reads from the control-channel in-memory registry for
 online/supports/last_seen, joined with persisted device metadata for
 machines that are currently offline but have been seen before.
 
-### Launch (Phase 1 — gated)
+### Launch (Phase 1)
 
 - `POST /api/sessions/launch`
   body:
@@ -287,8 +277,7 @@ machines that are currently offline but have been seen before.
     "git_repo": "zerg",
     "git_branch": "main",
     "project": "zerg",
-    "display_name": null,
-    "initial_prompt": null
+    "display_name": null
   }
   ```
   returns:
@@ -353,9 +342,9 @@ Failure codes (mapped to `launch_error_code`): `cwd_not_found`,
 - Runtime Host verifies:
   - `device_id` belongs to this user (via device registration ownership)
   - target is the user's — no cross-account launch
-- `initial_prompt`, when provided, is sent as a follow-up
-  `session.send_text`. Launch permission implies send permission; no
-  separate check needed.
+- Initial prompt is deferred from v1. Launch permission creates the
+  managed session; the follow-up send uses the existing live-session
+  permission path.
 
 **Why no 2FA in v1**: Device enrollment already granted code-running
 trust. The existing `send_text` primitive can already steer an LLM that
@@ -414,7 +403,7 @@ Acceptance:
   known supports are not persisted — avoid implying stale truth).
 - Unknown users return `[]` (not 404).
 
-### Phase 1 — `session.launch` + `launch_state` on `sessions` (gated)
+### Phase 1 — `session.launch` + `launch_state` on `sessions`
 
 - DB migration: add `launch_state`, `launch_error_code`,
   `launch_error_message`, `launch_lease_until` to `sessions`.
@@ -441,32 +430,31 @@ Acceptance:
 - No new table created. `launch_state` column is nullable and NULL for
   all pre-migration rows (= equivalent to `live`).
 
-### Phase 2 — Web launch sheet (gated)
+### Phase 2 — Web launch sheet
 
-- Launch sheet UI using `/timeline/machines` + directory picker.
+- Launch sheet UI using `/timeline/machines` + typed cwd.
 - Machine-first ordering in the UI.
 - Presets surface under the selected machine once history exists.
 - Deep-link on success.
 
 Acceptance:
-- Zero-history user can complete a launch via directory picker.
-- Second-session user sees their recent workspace as a preset under
-  that machine.
+- Zero-history user can complete a launch by entering a cwd.
+- Second-session user can reuse a cwd manually.
 - Offline machine visually disabled with clear copy.
 - E2E test covers happy-path launch from click to transcript render.
 
-### Phase 3 — iOS launch sheet (gated)
+### Phase 3 — iOS launch sheet
 
 - Mirror web UX.
 - Existing user-cookie auth (no machine token).
 - Xcode UI test covers happy-path launch.
 
-### Phase 4 — telemetry (gated)
+### Phase 4 — telemetry/admin debug
 
-- Propagation metric: POST-to-first-transcript-byte for remote launches,
-  tracked alongside existing managed-op SLAs.
 - Hidden admin view of sessions filtered by `launch_state !=
   {live, NULL}` for debugging.
+- Propagation metric: POST-to-first-transcript-byte for remote launches,
+  tracked alongside existing managed-op SLAs. Deferred.
 
 ## Directory Picker (Phase 2/3 sub-spec)
 
@@ -524,10 +512,9 @@ End-to-end (Phase 2/3):
    machine-agent-side "favorites" (bookmarks of common roots) from day
    one, or defer until users ask?
 
-2. `initial_prompt` policy. Current decision: send as follow-up
-   `session.send_text` after `launch` succeeds. That means a launch can
-   succeed and the prompt can fail independently. UX implication: if
-   send fails, the session exists but is empty. Acceptable?
+2. Initial prompt. Deferred from Codex v1. When added, prefer sending it
+   as a follow-up `session.send_text` after `launch` succeeds so launch
+   semantics stay narrow.
 
 3. Rate limiting. `already_running_for_cwd` is cheap on the engine.
    Do we need a Runtime Host rate limit, or is engine-side idempotency
@@ -571,5 +558,6 @@ This spec was revised after three independent reviews:
   better, agreed `session.launch` belongs on the control channel if the
   durable-FSM rule is respected.
 
-All three agreed on: drop the parallel table, lead UX with machines, wire
-`cwd_not_allowed` as a real policy, and ship Phase 0 only.
+All three agreed on: drop the parallel table, lead UX with machines, and
+wire `cwd_not_allowed` as a real policy. The original staged plan shipped
+Phase 0 first; the implementation branch now carries the full Codex v1.

--- a/engine/src/codex_bridge.rs
+++ b/engine/src/codex_bridge.rs
@@ -848,6 +848,10 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
     // launches already have a thread id; TUI launches capture it later from
     // thread/started notifications.
     write_state_file(&context.state_file, &context.state)?;
+    if config.start_thread && context.state.thread_id.is_some() {
+        let startup_phase = context.runtime_tracker.current_phase_update();
+        emit_runtime_updates(&config, &mut context, vec![startup_phase]).await;
+    }
 
     // Spawn IPC socket listener so `send` routes through the daemon's persistent connection
     let sock_path = ipc_socket_path(&context.state_file);

--- a/engine/src/codex_bridge.rs
+++ b/engine/src/codex_bridge.rs
@@ -58,6 +58,10 @@ pub struct BridgeStartConfig {
     pub longhouse_home: Option<PathBuf>,
     pub log_file: Option<PathBuf>,
     pub start_timeout_secs: u64,
+    /// When true, the bridge's run loop will invoke `thread/start` itself so
+    /// the managed session is driveable without a TUI attach. Default (false)
+    /// preserves the legacy behavior where a TUI creates the thread.
+    pub start_thread: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +81,9 @@ pub struct BridgeRunConfig {
     pub longhouse_home: Option<PathBuf>,
     pub state_file: PathBuf,
     pub log_file: PathBuf,
+    /// When true, the bridge calls `thread/start` itself instead of waiting
+    /// for a TUI attach. Used by the headless remote-launch path.
+    pub start_thread: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -588,6 +595,9 @@ pub async fn cmd_codex_bridge_start(config: BridgeStartConfig) -> Result<BridgeS
     if config.auto_approve {
         child.arg("--auto-approve");
     }
+    if config.start_thread {
+        child.arg("--start-thread");
+    }
 
     #[cfg(unix)]
     {
@@ -702,11 +712,53 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
     starting_state.app_server_ws_url = client.child_ws_url.clone();
     write_state_file(&config.state_file, &starting_state)?;
 
-    // Initialize the protocol handshake but do NOT call thread/start.
-    // The TUI (codex --enable tui_app_server --remote <ws_url>) will create
-    // the thread; the bridge captures the thread_id via the thread/started
-    // notification and posts idle once it knows which thread to drive.
+    // Initialize the protocol handshake. The normal TUI path creates the
+    // thread later; headless remote launch creates it below.
     initialize_client(&mut client).await?;
+
+    // Headless remote-launch path: create the thread ourselves so the session
+    // is driveable via send/interrupt/steer without a TUI attach. A TUI that
+    // attaches later can still create its own thread; bridge state captures
+    // the most recent thread via thread/started notifications.
+    if config.start_thread {
+        let params = json!({
+            "cwd": config.cwd.to_string_lossy(),
+            "approvalPolicy": config.approval_policy,
+            "sandbox": config.sandbox,
+            "model": config.model,
+        });
+        match send_request(&mut client, "thread/start", params).await {
+            Ok(response) => {
+                let thread_id = response
+                    .get("thread")
+                    .and_then(|thread| thread.get("id"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                let thread_path = response
+                    .get("thread")
+                    .and_then(|thread| thread.get("path"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                starting_state.thread_id = thread_id;
+                starting_state.thread_path = thread_path;
+                write_state_file(&config.state_file, &starting_state)?;
+            }
+            Err(err) => {
+                starting_state.status = "error".to_string();
+                starting_state.last_error = Some(format!("thread/start failed: {err}"));
+                let _ = write_state_file(&config.state_file, &starting_state);
+                bail!("thread/start failed in headless bridge: {err}");
+            }
+        }
+    }
+
+    let initial_thread_id = starting_state.thread_id.clone();
+    let initial_thread_path = starting_state.thread_path.clone();
+    let initial_subscription_status = if initial_thread_id.is_some() {
+        ThreadSubscriptionStatus::WaitingForTurn
+    } else {
+        ThreadSubscriptionStatus::WaitingForThread
+    };
 
     let mut runtime_headers = HeaderMap::new();
     runtime_headers.insert(
@@ -729,7 +781,7 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
         session_id: config.session_id.clone(),
         cwd: config.cwd.display().to_string(),
         machine_name: config.machine_name.clone(),
-        thread_id: None,
+        thread_id: initial_thread_id.clone(),
         local_db_path: None,
         runtime_tx: None,
         live_runtime_tx: None,
@@ -742,7 +794,7 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
         session_id: config.session_id.clone(),
         cwd: config.cwd.display().to_string(),
         machine_name: config.machine_name.clone(),
-        thread_id: None,
+        thread_id: initial_thread_id.clone(),
         local_db_path: None,
         runtime_tx: None,
         live_runtime_tx: None,
@@ -757,8 +809,8 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
             cwd: config.cwd.display().to_string(),
             codex_bin: config.codex_bin.clone(),
             ws_url: Some(ws_url.clone()),
-            thread_id: None,
-            thread_path: None,
+            thread_id: initial_thread_id.clone(),
+            thread_path: initial_thread_path.clone(),
             pid,
             app_server_pid: client.child_pid,
             app_server_pgid: client.child_pgid,
@@ -768,11 +820,7 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
             active_turn_id: None,
             last_turn_status: None,
             last_error: None,
-            thread_subscription_status: Some(
-                ThreadSubscriptionStatus::WaitingForThread
-                    .as_str()
-                    .to_string(),
-            ),
+            thread_subscription_status: Some(initial_subscription_status.as_str().to_string()),
             thread_subscription_attempts: 0,
             thread_subscription_last_error: None,
             updated_at: Utc::now().to_rfc3339(),
@@ -784,7 +832,7 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
             session_id: config.session_id.clone(),
             cwd: config.cwd.display().to_string(),
             machine_name: config.machine_name.clone(),
-            thread_id: None,
+            thread_id: initial_thread_id,
             local_db_path: resolve_bridge_agent_db_path(config.longhouse_home.as_deref()).ok(),
             runtime_tx: Some(runtime_tx),
             live_runtime_tx: Some(live_runtime_tx),
@@ -796,8 +844,9 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
         subscribed_thread_id: None,
         rejected_thread_ids: BTreeSet::new(),
     };
-    // Mark ready so the CLI can read ws_url and launch the TUI.
-    // idle is posted once the TUI creates a thread (thread/started notification).
+    // Mark ready so the CLI can read ws_url and launch the TUI. Headless
+    // launches already have a thread id; TUI launches capture it later from
+    // thread/started notifications.
     write_state_file(&context.state_file, &context.state)?;
 
     // Spawn IPC socket listener so `send` routes through the daemon's persistent connection
@@ -3737,6 +3786,7 @@ mod tests {
             longhouse_home: Some(temp.path().to_path_buf()),
             state_file: temp.path().join("bridge-state.json"),
             log_file: temp.path().join("bridge.log"),
+            start_thread: false,
         }
     }
 

--- a/engine/src/control_channel.rs
+++ b/engine/src/control_channel.rs
@@ -241,6 +241,9 @@ async fn execute_command(
                 longhouse_home: None,
                 log_file: None,
                 start_timeout_secs: LAUNCH_START_TIMEOUT_SECS,
+                // Headless: there is no TUI to create a thread, so we ask the
+                // bridge to call thread/start itself.
+                start_thread: true,
             })
             .await
             .map_err(|err| CommandError {
@@ -401,19 +404,25 @@ impl CompletedCommandCache {
 
 /// Local policy for launch cwds.
 ///
-/// Default allowlist: any directory under $HOME. A machine-local override file
-/// (`~/.longhouse/launch-allowlist`) may list extra prefixes, one per line. If
-/// `$HOME` is unresolvable, reject all launches rather than default-open.
+/// A cwd is allowed when all of:
+///   1. Canonical path lives under `$HOME` (or an explicit prefix listed in
+///      `~/.longhouse/launch-allowlist`, one per line).
+///   2. Canonical path contains a `.git` entry (file or directory) — i.e. it is
+///      the root of a repo, or a subtree inside one. This keeps cwd to places
+///      the user meaningfully uses for code work, instead of letting any path
+///      under `$HOME` be a launch target.
+///
+/// Fail closed when `$HOME` is unresolvable.
 fn cwd_under_allowed_roots(cwd: &std::path::Path) -> bool {
     let canonical = match cwd.canonicalize() {
         Ok(path) => path,
         Err(_) => return false,
     };
     let home = std::env::var("HOME").ok().map(PathBuf::from);
-    let mut allowlist: Vec<PathBuf> = Vec::new();
+    let mut prefixes: Vec<PathBuf> = Vec::new();
     if let Some(home) = home.as_ref() {
         if let Ok(canon_home) = home.canonicalize() {
-            allowlist.push(canon_home);
+            prefixes.push(canon_home);
         }
         let override_file = home.join(".longhouse").join("launch-allowlist");
         if let Ok(contents) = std::fs::read_to_string(&override_file) {
@@ -424,15 +433,31 @@ fn cwd_under_allowed_roots(cwd: &std::path::Path) -> bool {
                 }
                 let expanded = PathBuf::from(trimmed);
                 if let Ok(canon) = expanded.canonicalize() {
-                    allowlist.push(canon);
+                    prefixes.push(canon);
                 }
             }
         }
     }
-    if allowlist.is_empty() {
+    if prefixes.is_empty() {
         return false;
     }
-    allowlist.iter().any(|root| canonical.starts_with(root))
+    let under_prefix = prefixes.iter().any(|root| canonical.starts_with(root));
+    if !under_prefix {
+        return false;
+    }
+    // Walk up the tree looking for a .git marker. Stops at the first allowlist
+    // prefix boundary so we don't leak above the allowed root.
+    let mut cursor: Option<&std::path::Path> = Some(&canonical);
+    while let Some(dir) = cursor {
+        if dir.join(".git").exists() {
+            return true;
+        }
+        if prefixes.iter().any(|root| dir == root.as_path()) {
+            return false;
+        }
+        cursor = dir.parent();
+    }
+    false
 }
 
 fn control_ws_url(api_url: &str) -> Result<String> {
@@ -727,6 +752,33 @@ mod tests {
         let tmp = std::path::Path::new("/tmp");
         if tmp.exists() {
             assert!(!cwd_under_allowed_roots(tmp));
+        }
+    }
+
+    #[test]
+    fn cwd_under_allowed_roots_requires_git_marker() {
+        use std::fs;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Point $HOME at our sandbox so the policy check exercises the marker rule.
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", tmp.path());
+
+        let no_git = tmp.path().join("project-no-git");
+        fs::create_dir_all(&no_git).unwrap();
+        assert!(!cwd_under_allowed_roots(&no_git));
+
+        let git_root = tmp.path().join("project-with-git");
+        fs::create_dir_all(git_root.join(".git")).unwrap();
+        assert!(cwd_under_allowed_roots(&git_root));
+
+        let nested = git_root.join("subdir");
+        fs::create_dir_all(&nested).unwrap();
+        assert!(cwd_under_allowed_roots(&nested));
+
+        if let Some(value) = old_home {
+            std::env::set_var("HOME", value);
+        } else {
+            std::env::remove_var("HOME");
         }
     }
 }

--- a/engine/src/control_channel.rs
+++ b/engine/src/control_channel.rs
@@ -15,15 +15,19 @@ use tokio_tungstenite::tungstenite::Message;
 
 use crate::build_identity;
 use crate::codex_bridge::{
-    cmd_codex_bridge_interrupt, cmd_codex_bridge_send, cmd_codex_bridge_steer,
-    validate_codex_bridge_attached, BridgeInterruptConfig, BridgeSendConfig, BridgeSteerConfig,
-    BridgeSteerError,
+    cmd_codex_bridge_interrupt, cmd_codex_bridge_send, cmd_codex_bridge_start,
+    cmd_codex_bridge_steer, validate_codex_bridge_attached, BridgeInterruptConfig,
+    BridgeSendConfig, BridgeStartConfig, BridgeSteerConfig, BridgeSteerError,
 };
 use crate::config::ShipperConfig;
+use std::path::PathBuf;
 
 const COMMAND_SEND_TEXT: &str = "session.send_text";
 const COMMAND_INTERRUPT: &str = "session.interrupt";
 const COMMAND_STEER_TEXT: &str = "session.steer_text";
+const COMMAND_LAUNCH: &str = "session.launch";
+const DEFAULT_CODEX_BIN: &str = "codex";
+const LAUNCH_START_TIMEOUT_SECS: u64 = 45;
 const COMPLETED_COMMAND_CACHE_CAPACITY: usize = 256;
 const COMPLETED_COMMAND_CACHE_TTL_SECS: u64 = 5 * 60;
 const HEARTBEAT_INTERVAL_SECS: u64 = 25;
@@ -87,7 +91,7 @@ async fn run_once(
         "device_id": config.machine_name,
         "machine_name": config.machine_name,
         "engine_build": build_identity::COMMIT_SHORT,
-        "supports": ["codex.send", "codex.interrupt", "codex.steer"],
+        "supports": ["codex.send", "codex.interrupt", "codex.steer", "codex.launch"],
     });
     write
         .send(Message::Text(hello.to_string()))
@@ -123,7 +127,7 @@ async fn run_once(
                     );
                     continue;
                 }
-                let result = handle_command_frame(frame, completed_commands).await;
+                let result = handle_command_frame(frame, completed_commands, config).await;
                 write
                     .send(Message::Text(result.to_string()))
                     .await
@@ -142,6 +146,7 @@ fn heartbeat_frame() -> Value {
 async fn handle_command_frame(
     frame: Value,
     completed_commands: &mut CompletedCommandCache,
+    config: &ShipperConfig,
 ) -> Value {
     let command_id = frame
         .get("command_id")
@@ -156,7 +161,7 @@ async fn handle_command_frame(
         return result;
     }
 
-    let result = execute_command(&frame).await;
+    let result = execute_command(&frame, config).await;
     let response = match result {
         Ok(result) => json!({
             "type": "command_result",
@@ -170,12 +175,87 @@ async fn handle_command_frame(
     response
 }
 
-async fn execute_command(frame: &Value) -> std::result::Result<Value, CommandError> {
+async fn execute_command(
+    frame: &Value,
+    config: &ShipperConfig,
+) -> std::result::Result<Value, CommandError> {
     let session_id = required_string(frame, "session_id")?;
     let command_type = required_string(frame, "command_type")?;
     let payload = frame.get("payload").cloned().unwrap_or_else(|| json!({}));
 
     match command_type.as_str() {
+        COMMAND_LAUNCH => {
+            let provider = payload_required_string(&payload, "provider")?;
+            if provider != "codex" {
+                return Err(CommandError {
+                    code: "provider_unsupported".to_string(),
+                    message: format!("provider={provider} is not supported by this engine build"),
+                });
+            }
+            let cwd_raw = payload_required_string(&payload, "cwd")?;
+            let cwd = PathBuf::from(&cwd_raw);
+            if !cwd.is_absolute() {
+                return Err(CommandError {
+                    code: "cwd_not_allowed".to_string(),
+                    message: "cwd must be absolute".to_string(),
+                });
+            }
+            if !cwd.is_dir() {
+                return Err(CommandError {
+                    code: "cwd_not_found".to_string(),
+                    message: format!("cwd does not exist: {}", cwd.display()),
+                });
+            }
+            if !cwd_under_allowed_roots(&cwd) {
+                return Err(CommandError {
+                    code: "cwd_not_allowed".to_string(),
+                    message: format!(
+                        "cwd {} is outside the Machine Agent's launch allowlist",
+                        cwd.display()
+                    ),
+                });
+            }
+
+            let api_url = config.api_url.clone();
+            let api_token = config
+                .api_token
+                .clone()
+                .ok_or_else(|| CommandError {
+                    code: "provider_launch_failed".to_string(),
+                    message: "Machine Agent has no device token configured".to_string(),
+                })?;
+
+            let summary = cmd_codex_bridge_start(BridgeStartConfig {
+                session_id: session_id.clone(),
+                cwd,
+                api_url,
+                api_token,
+                codex_bin: DEFAULT_CODEX_BIN.to_string(),
+                approval_policy: None,
+                sandbox: None,
+                model: None,
+                model_reasoning_effort: None,
+                machine_name: Some(config.machine_name.clone()),
+                auto_approve: false,
+                state_root: None,
+                longhouse_home: None,
+                log_file: None,
+                start_timeout_secs: LAUNCH_START_TIMEOUT_SECS,
+            })
+            .await
+            .map_err(|err| CommandError {
+                code: "provider_launch_failed".to_string(),
+                message: err.to_string(),
+            })?;
+
+            Ok(json!({
+                "session_id": summary.session_id,
+                "provider": "codex",
+                "transport": "codex_app_server",
+                "ws_url": summary.ws_url,
+                "thread_id": summary.thread_id,
+            }))
+        }
         COMMAND_SEND_TEXT => {
             let text = payload_required_string(&payload, "text")?;
             validate_codex_bridge_attached(&session_id, None)
@@ -319,6 +399,42 @@ impl CompletedCommandCache {
     }
 }
 
+/// Local policy for launch cwds.
+///
+/// Default allowlist: any directory under $HOME. A machine-local override file
+/// (`~/.longhouse/launch-allowlist`) may list extra prefixes, one per line. If
+/// `$HOME` is unresolvable, reject all launches rather than default-open.
+fn cwd_under_allowed_roots(cwd: &std::path::Path) -> bool {
+    let canonical = match cwd.canonicalize() {
+        Ok(path) => path,
+        Err(_) => return false,
+    };
+    let home = std::env::var("HOME").ok().map(PathBuf::from);
+    let mut allowlist: Vec<PathBuf> = Vec::new();
+    if let Some(home) = home.as_ref() {
+        if let Ok(canon_home) = home.canonicalize() {
+            allowlist.push(canon_home);
+        }
+        let override_file = home.join(".longhouse").join("launch-allowlist");
+        if let Ok(contents) = std::fs::read_to_string(&override_file) {
+            for line in contents.lines() {
+                let trimmed = line.trim();
+                if trimmed.is_empty() || trimmed.starts_with('#') {
+                    continue;
+                }
+                let expanded = PathBuf::from(trimmed);
+                if let Ok(canon) = expanded.canonicalize() {
+                    allowlist.push(canon);
+                }
+            }
+        }
+    }
+    if allowlist.is_empty() {
+        return false;
+    }
+    allowlist.iter().any(|root| canonical.starts_with(root))
+}
+
 fn control_ws_url(api_url: &str) -> Result<String> {
     let base = api_url.trim().trim_end_matches('/');
     if let Some(rest) = base.strip_prefix("http://") {
@@ -407,6 +523,15 @@ mod tests {
         CompletedCommandCache::new(16, Duration::from_secs(60))
     }
 
+    fn test_config() -> ShipperConfig {
+        ShipperConfig {
+            api_url: "http://localhost:8000".to_string(),
+            api_token: Some("test-token".to_string()),
+            machine_name: "test-machine".to_string(),
+            ..ShipperConfig::default()
+        }
+    }
+
     #[test]
     fn control_ws_url_converts_http_and_https() {
         assert_eq!(
@@ -435,6 +560,7 @@ mod tests {
                 "payload": {"text": "continue"},
             }),
             &mut cache,
+            &test_config(),
         )
         .await;
 
@@ -454,6 +580,7 @@ mod tests {
                 "payload": {},
             }),
             &mut cache,
+            &test_config(),
         )
         .await;
 
@@ -474,6 +601,7 @@ mod tests {
                 "payload": {"text": "continue"},
             }),
             &mut cache,
+            &test_config(),
         )
         .await;
 
@@ -494,6 +622,7 @@ mod tests {
                 "payload": {},
             }),
             &mut cache,
+            &test_config(),
         )
         .await;
         let second = handle_command_frame(
@@ -505,6 +634,7 @@ mod tests {
                 "payload": {"text": "continue"},
             }),
             &mut cache,
+            &test_config(),
         )
         .await;
 
@@ -520,5 +650,83 @@ mod tests {
 
         assert_eq!(cache.get("cmd-1"), None);
         assert_eq!(cache.get("cmd-2").unwrap()["command_id"], "cmd-2");
+    }
+
+    #[tokio::test]
+    async fn launch_rejects_nonexistent_cwd() {
+        let mut cache = command_cache();
+        let result = handle_command_frame(
+            json!({
+                "type": "command",
+                "command_id": "cmd-launch-missing-cwd",
+                "session_id": "00000000-0000-0000-0000-000000000001",
+                "command_type": COMMAND_LAUNCH,
+                "payload": {
+                    "provider": "codex",
+                    "cwd": "/does/not/exist/anywhere-pls",
+                },
+            }),
+            &mut cache,
+            &test_config(),
+        )
+        .await;
+
+        assert_eq!(result["ok"], false);
+        assert_eq!(result["error"]["code"], "cwd_not_found");
+    }
+
+    #[tokio::test]
+    async fn launch_rejects_relative_cwd() {
+        let mut cache = command_cache();
+        let result = handle_command_frame(
+            json!({
+                "type": "command",
+                "command_id": "cmd-launch-relative",
+                "session_id": "00000000-0000-0000-0000-000000000002",
+                "command_type": COMMAND_LAUNCH,
+                "payload": {
+                    "provider": "codex",
+                    "cwd": "relative/path",
+                },
+            }),
+            &mut cache,
+            &test_config(),
+        )
+        .await;
+
+        assert_eq!(result["ok"], false);
+        assert_eq!(result["error"]["code"], "cwd_not_allowed");
+    }
+
+    #[tokio::test]
+    async fn launch_rejects_unsupported_provider() {
+        let mut cache = command_cache();
+        let result = handle_command_frame(
+            json!({
+                "type": "command",
+                "command_id": "cmd-launch-provider",
+                "session_id": "00000000-0000-0000-0000-000000000003",
+                "command_type": COMMAND_LAUNCH,
+                "payload": {
+                    "provider": "claude",
+                    "cwd": "/tmp",
+                },
+            }),
+            &mut cache,
+            &test_config(),
+        )
+        .await;
+
+        assert_eq!(result["ok"], false);
+        assert_eq!(result["error"]["code"], "provider_unsupported");
+    }
+
+    #[test]
+    fn cwd_under_allowed_roots_rejects_outside_home() {
+        // /tmp is reliably not under $HOME on macOS/Linux
+        let tmp = std::path::Path::new("/tmp");
+        if tmp.exists() {
+            assert!(!cwd_under_allowed_roots(tmp));
+        }
     }
 }

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -443,6 +443,11 @@ enum CodexBridgeCommands {
         #[arg(long, default_value_t = 25)]
         start_timeout_secs: u64,
 
+        /// Create the codex thread ourselves via thread/start; used by the
+        /// headless remote-launch path where no TUI will attach to create one.
+        #[arg(long)]
+        start_thread: bool,
+
         #[arg(long)]
         json: bool,
     },
@@ -493,6 +498,11 @@ enum CodexBridgeCommands {
 
         #[arg(long)]
         log_file: PathBuf,
+
+        /// When set, the bridge calls thread/start itself during startup so
+        /// remote launches produce a driveable session without a TUI attach.
+        #[arg(long)]
+        start_thread: bool,
     },
 
     /// Attach stock Codex TUI to a running managed bridge
@@ -953,6 +963,7 @@ fn main() -> anyhow::Result<()> {
                     isolation_root,
                     log_file,
                     start_timeout_secs,
+                    start_thread,
                     json,
                 } => {
                     let (state_root, longhouse_home) = resolve_codex_bridge_start_roots(
@@ -976,6 +987,7 @@ fn main() -> anyhow::Result<()> {
                         longhouse_home,
                         log_file,
                         start_timeout_secs,
+                        start_thread,
                     }))?;
                     if json {
                         println!("{}", serde_json::to_string_pretty(&summary)?);
@@ -1009,6 +1021,7 @@ fn main() -> anyhow::Result<()> {
                     longhouse_home,
                     state_file,
                     log_file,
+                    start_thread,
                 } => {
                     rt.block_on(cmd_codex_bridge_run(BridgeRunConfig {
                         session_id,
@@ -1026,6 +1039,7 @@ fn main() -> anyhow::Result<()> {
                         longhouse_home,
                         state_file,
                         log_file,
+                        start_thread,
                     }))?;
                 }
                 CodexBridgeCommands::Attach {

--- a/ios/Sources/LonghouseApp/InboxView.swift
+++ b/ios/Sources/LonghouseApp/InboxView.swift
@@ -7,6 +7,7 @@ struct TimelineView: View {
     @Environment(\.scenePhase) private var scenePhase
     @StateObject private var viewModel = TimelineViewModel()
     @State private var path: [SessionRoute] = []
+    @State private var launchSheetPresented = false
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -24,9 +25,23 @@ struct TimelineView: View {
             .navigationTitle("Timeline")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    if viewModel.isRefreshing && !viewModel.isInitialLoading {
-                        ProgressView().controlSize(.small)
+                    HStack(spacing: 12) {
+                        if viewModel.isRefreshing && !viewModel.isInitialLoading {
+                            ProgressView().controlSize(.small)
+                        }
+                        Button {
+                            launchSheetPresented = true
+                        } label: {
+                            Image(systemName: "plus.circle.fill")
+                                .accessibilityLabel("Start session")
+                        }
                     }
+                }
+            }
+            .sheet(isPresented: $launchSheetPresented) {
+                LaunchSessionSheet { sessionId in
+                    launchSheetPresented = false
+                    path.append(SessionRoute(sessionId: sessionId, fallbackTitle: "New session"))
                 }
             }
             .refreshable { await viewModel.refresh(using: appState, reloadWidget: true) }

--- a/ios/Sources/LonghouseApp/LaunchSessionSheet.swift
+++ b/ios/Sources/LonghouseApp/LaunchSessionSheet.swift
@@ -165,7 +165,7 @@ struct LaunchSessionSheet: View {
         submitting = true
         submitError = nil
         defer { submitting = false }
-        let clientRequestId = "launch-\(selectedDeviceId)-\(Int(Date().timeIntervalSince1970 * 1000))"
+        let clientRequestId = "launch-\(UUID().uuidString)"
         do {
             let response = try await api.launchRemoteSession(
                 deviceId: selectedDeviceId,

--- a/ios/Sources/LonghouseApp/LaunchSessionSheet.swift
+++ b/ios/Sources/LonghouseApp/LaunchSessionSheet.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+/// Phase 3 of the remote-session-launch epic. Mirrors the web launch sheet:
+/// list enrolled machines, require one that advertises codex.launch and is
+/// online, take an absolute cwd, POST /api/sessions/launch, and hand back the
+/// new session id for navigation.
+@MainActor
+struct LaunchSessionSheet: View {
+    @EnvironmentObject private var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    let onLaunched: (String) -> Void
+
+    @State private var machines: [MachineDirectoryEntry] = []
+    @State private var loadError: String?
+    @State private var loading = false
+    @State private var submitting = false
+    @State private var submitError: String?
+
+    @State private var selectedDeviceId: String = ""
+    @State private var cwd: String = ""
+    @State private var displayName: String = ""
+
+    private var launchable: [MachineDirectoryEntry] {
+        machines.filter { $0.isLaunchable }
+    }
+
+    private var canSubmit: Bool {
+        !submitting && !selectedDeviceId.isEmpty && !cwd.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if loading {
+                    ProgressView("Loading machines…")
+                } else if let loadError {
+                    errorView(loadError)
+                } else if launchable.isEmpty {
+                    emptyView
+                } else {
+                    formView
+                }
+            }
+            .navigationTitle("Start session")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .task { await loadMachines() }
+    }
+
+    private var formView: some View {
+        Form {
+            Section("Machine") {
+                Picker("Target", selection: $selectedDeviceId) {
+                    ForEach(launchable, id: \.deviceId) { m in
+                        Text(m.machineName).tag(m.deviceId)
+                    }
+                }
+            }
+            Section("Workspace") {
+                TextField("/Users/you/git/your-repo", text: $cwd)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                Text("Must be absolute and under $HOME on the target machine.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Section("Optional") {
+                TextField("Display name", text: $displayName)
+                    .textInputAutocapitalization(.never)
+            }
+            if let submitError {
+                Section {
+                    Text(submitError)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+            }
+            Section {
+                Button {
+                    Task { await submit() }
+                } label: {
+                    if submitting {
+                        ProgressView().frame(maxWidth: .infinity)
+                    } else {
+                        Text("Start").frame(maxWidth: .infinity)
+                    }
+                }
+                .disabled(!canSubmit)
+            }
+        }
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "desktopcomputer")
+                .font(.system(size: 42))
+                .foregroundStyle(.secondary)
+            if machines.isEmpty {
+                Text("No enrolled machines yet.")
+                    .font(.headline)
+                Text("Install Longhouse on a machine with `longhouse connect` first.")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal)
+            } else {
+                Text("No machines are online with Codex support right now.")
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+                ForEach(machines, id: \.deviceId) { m in
+                    HStack {
+                        Text(m.machineName).font(.footnote)
+                        Spacer()
+                        Text(m.online ? "online" : "offline")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 24)
+                }
+            }
+        }
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 32))
+                .foregroundStyle(.red)
+            Text(message)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            Button("Retry") {
+                Task { await loadMachines() }
+            }
+        }
+    }
+
+    private func loadMachines() async {
+        guard let api = LonghouseAPI(host: appState.serverURL) else {
+            loadError = "Not authenticated."
+            return
+        }
+        loading = true
+        loadError = nil
+        do {
+            let result = try await api.listMachines()
+            machines = result
+            if selectedDeviceId.isEmpty, let first = result.first(where: { $0.isLaunchable }) {
+                selectedDeviceId = first.deviceId
+            }
+        } catch {
+            loadError = (error as? LocalizedError)?.errorDescription ?? "Could not load machines."
+        }
+        loading = false
+    }
+
+    private func submit() async {
+        guard canSubmit, let api = LonghouseAPI(host: appState.serverURL) else { return }
+        submitting = true
+        submitError = nil
+        defer { submitting = false }
+        let clientRequestId = "launch-\(selectedDeviceId)-\(Int(Date().timeIntervalSince1970 * 1000))"
+        do {
+            let response = try await api.launchRemoteSession(
+                deviceId: selectedDeviceId,
+                cwd: cwd.trimmingCharacters(in: .whitespaces),
+                displayName: displayName.trimmingCharacters(in: .whitespaces).isEmpty ? nil : displayName,
+                clientRequestId: clientRequestId
+            )
+            onLaunched(response.sessionId)
+        } catch let LonghouseAPIError.structured(_, _, message) {
+            submitError = message.isEmpty ? "Launch failed." : message
+        } catch {
+            submitError = (error as? LocalizedError)?.errorDescription ?? "Launch failed."
+        }
+    }
+}

--- a/ios/Sources/Shared/LonghouseAPI.swift
+++ b/ios/Sources/Shared/LonghouseAPI.swift
@@ -386,7 +386,7 @@ public struct MachineDirectoryEntry: Decodable, Sendable, Hashable {
     public let machineName: String
     public let online: Bool
     public let supports: [String]
-    public let lastSeenAt: Date?
+    public let lastSeenAt: String?
     public let engineBuild: String?
 
     public var supportsCodexLaunch: Bool { supports.contains("codex.launch") }

--- a/ios/Sources/Shared/LonghouseAPI.swift
+++ b/ios/Sources/Shared/LonghouseAPI.swift
@@ -379,6 +379,93 @@ struct LonghouseAPI: Sendable {
     }
 }
 
+// MARK: - Remote session launch
+
+public struct MachineDirectoryEntry: Decodable, Sendable, Hashable {
+    public let deviceId: String
+    public let machineName: String
+    public let online: Bool
+    public let supports: [String]
+    public let lastSeenAt: Date?
+    public let engineBuild: String?
+
+    public var supportsCodexLaunch: Bool { supports.contains("codex.launch") }
+    public var isLaunchable: Bool { online && supportsCodexLaunch }
+}
+
+public struct MachineDirectoryResponse: Decodable, Sendable {
+    public let machines: [MachineDirectoryEntry]
+}
+
+public enum RemoteLaunchState: String, Decodable, Sendable {
+    case launching
+    case live
+    case launchingUnknown = "launching_unknown"
+    case launchFailed = "launch_failed"
+    case launchOrphaned = "launch_orphaned"
+}
+
+public struct RemoteSessionLaunchResponse: Decodable, Sendable {
+    public let sessionId: String
+    public let launchState: RemoteLaunchState
+    public let launchErrorCode: String?
+    public let launchErrorMessage: String?
+}
+
+extension LonghouseAPI {
+    func listMachines() async throws -> [MachineDirectoryEntry] {
+        var request = URLRequest(url: baseURL.appendingPathComponent("/api/timeline/machines"))
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        let (data, httpResponse) = try await data(for: request)
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw LonghouseAPIError.from(statusCode: httpResponse.statusCode)
+        }
+        return try JSONDecoder.snakeCase.decode(MachineDirectoryResponse.self, from: data).machines
+    }
+
+    func launchRemoteSession(
+        deviceId: String,
+        provider: String = "codex",
+        cwd: String,
+        displayName: String? = nil,
+        clientRequestId: String? = nil
+    ) async throws -> RemoteSessionLaunchResponse {
+        var request = URLRequest(url: baseURL.appendingPathComponent("/api/sessions/launch"))
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        var body: [String: Any] = [
+            "device_id": deviceId,
+            "provider": provider,
+            "cwd": cwd,
+        ]
+        if let displayName, !displayName.isEmpty { body["display_name"] = displayName }
+        if let clientRequestId, !clientRequestId.isEmpty { body["client_request_id"] = clientRequestId }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, httpResponse) = try await data(for: request)
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            if let structured = Self.parseLaunchError(statusCode: httpResponse.statusCode, data: data) {
+                throw structured
+            }
+            throw LonghouseAPIError.from(statusCode: httpResponse.statusCode)
+        }
+        return try JSONDecoder.snakeCase.decode(RemoteSessionLaunchResponse.self, from: data)
+    }
+
+    static func parseLaunchError(statusCode: Int, data: Data) -> LonghouseAPIError? {
+        guard
+            let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+            let detail = obj["detail"] as? [String: Any],
+            let code = detail["code"] as? String
+        else {
+            return nil
+        }
+        let message = (detail["message"] as? String) ?? ""
+        return .structured(status: statusCode, errorCode: code, message: message)
+    }
+}
+
 extension LonghouseAPI: SessionWorkspaceClient {}
 
 enum LonghouseAPIError: Error {

--- a/server/tests_lite/test_machines_directory.py
+++ b/server/tests_lite/test_machines_directory.py
@@ -1,0 +1,258 @@
+"""Tests for the /agents/machines and /timeline/machines directory routes.
+
+Phase 0 of the remote-session-launch epic. See
+``docs/specs/remote-session-launch.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime
+from datetime import timezone
+from types import SimpleNamespace
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("TESTING", "1")
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("FERNET_SECRET", Fernet.generate_key().decode())
+
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from zerg.database import Base  # noqa: E402
+from zerg.database import get_db  # noqa: E402
+from zerg.database import make_engine  # noqa: E402
+from zerg.dependencies.agents_auth import require_single_tenant  # noqa: E402
+from zerg.dependencies.agents_auth import verify_agents_token  # noqa: E402
+from zerg.dependencies.browser_auth import get_current_browser_user  # noqa: E402
+from zerg.models import User  # noqa: E402
+from zerg.models.agents import AgentsBase  # noqa: E402
+from zerg.models.device_token import DeviceToken  # noqa: E402
+from zerg.services.machine_control_channel import MachineControlChannelRegistry  # noqa: E402
+from zerg.services.machines_directory import build_machines_directory  # noqa: E402
+
+
+OWNER_ID = 42
+
+
+def _make_db(tmp_path):
+    db_path = tmp_path / "test_machines_directory.db"
+    engine = make_engine(f"sqlite:///{db_path}")
+    engine = engine.execution_options(schema_translate_map={"agents": None})
+    Base.metadata.create_all(bind=engine)
+    AgentsBase.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine)
+
+
+def _seed_user(SessionLocal, *, user_id: int = OWNER_ID, email: str | None = None):
+    with SessionLocal() as db:
+        db.add(User(id=user_id, email=email or f"user{user_id}@example.com", role="ADMIN"))
+        db.commit()
+
+
+def _seed_device_token(SessionLocal, device_id: str, *, owner_id: int = OWNER_ID, revoked: bool = False):
+    with SessionLocal() as db:
+        token = DeviceToken(
+            owner_id=owner_id,
+            device_id=device_id,
+            token_hash=f"hash-{device_id}-{owner_id}",
+        )
+        if revoked:
+            token.revoked_at = datetime.now(timezone.utc)
+        db.add(token)
+        db.commit()
+
+
+class _FakeWebSocket:
+    async def send_json(self, message):  # pragma: no cover — registration only
+        pass
+
+
+def _register(registry: MachineControlChannelRegistry, *, owner_id: int, device_id: str, supports=("codex.send",)):
+    asyncio.run(
+        registry.register(
+            owner_id=owner_id,
+            device_id=device_id,
+            machine_name=device_id,
+            engine_build="test-build",
+            supports=list(supports),
+            websocket=_FakeWebSocket(),
+        )
+    )
+
+
+def test_directory_returns_online_machine_with_supports(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user(SessionLocal)
+    registry = MachineControlChannelRegistry()
+    _register(registry, owner_id=OWNER_ID, device_id="cinder", supports=("codex.send", "codex.launch"))
+
+    with SessionLocal() as db:
+        entries = build_machines_directory(db, owner_id=OWNER_ID, registry=registry)
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.device_id == "cinder"
+    assert entry.online is True
+    assert entry.supports == ("codex.launch", "codex.send")  # sorted
+    assert entry.engine_build == "test-build"
+
+
+def test_directory_surfaces_offline_enrolled_machine_with_empty_supports(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user(SessionLocal)
+    _seed_device_token(SessionLocal, "homelab")
+    registry = MachineControlChannelRegistry()
+
+    with SessionLocal() as db:
+        entries = build_machines_directory(db, owner_id=OWNER_ID, registry=registry)
+
+    assert [(e.device_id, e.online, e.supports) for e in entries] == [("homelab", False, ())]
+
+
+def test_directory_prefers_online_record_over_persisted_row(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user(SessionLocal)
+    _seed_device_token(SessionLocal, "cinder")
+    registry = MachineControlChannelRegistry()
+    _register(registry, owner_id=OWNER_ID, device_id="cinder", supports=("codex.launch",))
+
+    with SessionLocal() as db:
+        entries = build_machines_directory(db, owner_id=OWNER_ID, registry=registry)
+
+    assert [e.device_id for e in entries] == ["cinder"]
+    assert entries[0].online is True
+    assert entries[0].supports == ("codex.launch",)
+
+
+def test_directory_excludes_other_owners_and_revoked_tokens(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user(SessionLocal)
+    _seed_user(SessionLocal, user_id=OWNER_ID + 1)
+    _seed_device_token(SessionLocal, "someone-else", owner_id=OWNER_ID + 1)
+    _seed_device_token(SessionLocal, "retired", revoked=True)
+    registry = MachineControlChannelRegistry()
+    _register(registry, owner_id=OWNER_ID + 1, device_id="not-mine")
+
+    with SessionLocal() as db:
+        entries = build_machines_directory(db, owner_id=OWNER_ID, registry=registry)
+
+    assert entries == []
+
+
+def test_directory_sort_online_first_then_alpha(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user(SessionLocal)
+    _seed_device_token(SessionLocal, "z-offline")
+    _seed_device_token(SessionLocal, "a-offline")
+    registry = MachineControlChannelRegistry()
+    _register(registry, owner_id=OWNER_ID, device_id="m-online")
+
+    with SessionLocal() as db:
+        entries = build_machines_directory(db, owner_id=OWNER_ID, registry=registry)
+
+    assert [e.device_id for e in entries] == ["m-online", "a-offline", "z-offline"]
+
+
+# ---------- HTTP route parity ----------------------------------------------
+
+
+def _make_agents_client(SessionLocal, *, owner_id: int = OWNER_ID):
+    from zerg.main import api_app
+    from zerg.main import app
+
+    def override_get_db():
+        with SessionLocal() as db:
+            yield db
+
+    def override_verify_agents_token():
+        return SimpleNamespace(device_id="testclient", id="token-1", owner_id=owner_id)
+
+    api_app.dependency_overrides[get_db] = override_get_db
+    api_app.dependency_overrides[verify_agents_token] = override_verify_agents_token
+    api_app.dependency_overrides[require_single_tenant] = lambda: None
+    return TestClient(app, backend="asyncio"), api_app
+
+
+def _make_browser_client(SessionLocal, *, owner_id: int = OWNER_ID):
+    from zerg.main import api_app
+    from zerg.main import app
+
+    def override_get_db():
+        with SessionLocal() as db:
+            yield db
+
+    def override_browser_user():
+        return SimpleNamespace(id=owner_id, email="owner@example.com", role="ADMIN")
+
+    api_app.dependency_overrides[get_db] = override_get_db
+    api_app.dependency_overrides[get_current_browser_user] = override_browser_user
+    api_app.dependency_overrides[require_single_tenant] = lambda: None
+    return TestClient(app, backend="asyncio"), api_app
+
+
+def _swap_registry(registry: MachineControlChannelRegistry):
+    import zerg.services.machines_directory as module
+
+    original = module.get_machine_control_channel_registry
+    module.get_machine_control_channel_registry = lambda: registry
+    return original, module
+
+
+def test_agents_machines_route_matches_timeline_route(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user(SessionLocal)
+    _seed_device_token(SessionLocal, "homelab")
+    registry = MachineControlChannelRegistry()
+    _register(registry, owner_id=OWNER_ID, device_id="cinder", supports=("codex.launch",))
+
+    original, module = _swap_registry(registry)
+    try:
+        agents_client, api_app = _make_agents_client(SessionLocal)
+        try:
+            agents_resp = agents_client.get("/api/agents/machines")
+        finally:
+            api_app.dependency_overrides.clear()
+
+        browser_client, api_app = _make_browser_client(SessionLocal)
+        try:
+            browser_resp = browser_client.get("/api/timeline/machines")
+        finally:
+            api_app.dependency_overrides.clear()
+    finally:
+        module.get_machine_control_channel_registry = original
+
+    assert agents_resp.status_code == 200, agents_resp.text
+    assert browser_resp.status_code == 200, browser_resp.text
+
+    # Normalize last_seen_at since the online entry carries an assigned-at-register
+    # timestamp that is identical across calls because the registry is shared.
+    assert agents_resp.json() == browser_resp.json()
+
+    body = agents_resp.json()
+    assert [m["device_id"] for m in body["machines"]] == ["cinder", "homelab"]
+    assert body["machines"][0]["supports"] == ["codex.launch"]
+    assert body["machines"][1]["online"] is False
+    assert body["machines"][1]["supports"] == []
+
+
+def test_machines_route_returns_empty_for_unknown_user(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user(SessionLocal)
+    registry = MachineControlChannelRegistry()
+
+    original, module = _swap_registry(registry)
+    try:
+        browser_client, api_app = _make_browser_client(SessionLocal, owner_id=9999)
+        try:
+            resp = browser_client.get("/api/timeline/machines")
+        finally:
+            api_app.dependency_overrides.clear()
+    finally:
+        module.get_machine_control_channel_registry = original
+
+    assert resp.status_code == 200
+    assert resp.json() == {"machines": []}

--- a/server/tests_lite/test_remote_session_launch.py
+++ b/server/tests_lite/test_remote_session_launch.py
@@ -517,6 +517,77 @@ def test_reap_orphaned_launches_expires_stale_rows(tmp_path):
         assert row.ended_at is not None
 
 
+def _make_admin_client(SessionLocal, *, owner_id: int = OWNER_ID):
+    from zerg.dependencies.auth import get_current_user
+    from zerg.dependencies.auth import require_admin
+    from zerg.main import api_app
+    from zerg.main import app
+
+    def override_get_db():
+        with SessionLocal() as db:
+            yield db
+
+    def override_user():
+        return SimpleNamespace(id=owner_id, email="admin@example.com", role="ADMIN")
+
+    api_app.dependency_overrides[get_db] = override_get_db
+    api_app.dependency_overrides[get_current_user] = override_user
+    api_app.dependency_overrides[require_admin] = override_user
+    api_app.dependency_overrides[require_single_tenant] = lambda: None
+    return TestClient(app, backend="asyncio"), api_app
+
+
+def test_admin_launch_debug_lists_non_live_rows(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+
+    now = datetime.now(timezone.utc)
+    with SessionLocal() as db:
+        for state in ("launching_unknown", "launch_failed", "launch_orphaned", "live"):
+            sid = uuid4()
+            db.add(
+                AgentSession(
+                    id=sid,
+                    provider="codex",
+                    environment="development",
+                    project="repo",
+                    device_id="cinder",
+                    cwd="/Users/me/repo",
+                    started_at=now,
+                    thread_root_session_id=sid,
+                    continued_from_session_id=None,
+                    continuation_kind="local",
+                    origin_label="cinder",
+                    user_messages=0,
+                    assistant_messages=0,
+                    tool_calls=0,
+                    is_writable_head=1,
+                    is_sidechain=0,
+                    execution_home="managed_local",
+                    launch_state=state,
+                )
+            )
+        db.commit()
+
+    client, api_app = _make_admin_client(SessionLocal)
+    try:
+        resp = client.get("/api/admin/launches/debug")
+    finally:
+        api_app.dependency_overrides.clear()
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    states = sorted(e["launch_state"] for e in body["entries"])
+    assert states == ["launch_failed", "launch_orphaned", "launching_unknown"]
+
+    client, api_app = _make_admin_client(SessionLocal)
+    try:
+        resp_all = client.get("/api/admin/launches/debug?include_live=true")
+    finally:
+        api_app.dependency_overrides.clear()
+    assert resp_all.status_code == 200
+    assert len(resp_all.json()["entries"]) == 4
+
+
 def test_http_endpoint_offline_machine_is_409(tmp_path):
     SessionLocal = _make_db(tmp_path)
     _seed_user_and_device(SessionLocal)

--- a/server/tests_lite/test_remote_session_launch.py
+++ b/server/tests_lite/test_remote_session_launch.py
@@ -30,16 +30,20 @@ from zerg.database import make_engine  # noqa: E402
 from zerg.dependencies.agents_auth import require_single_tenant  # noqa: E402
 from zerg.dependencies.browser_route_auth import get_current_browser_route_user  # noqa: E402
 from zerg.models import User  # noqa: E402
-from zerg.models.agents import AgentSession  # noqa: E402
 from zerg.models.agents import AgentsBase  # noqa: E402
+from zerg.models.agents import AgentSession  # noqa: E402
 from zerg.models.device_token import DeviceToken  # noqa: E402
 from zerg.services.machine_control_channel import MachineControlChannelRegistry  # noqa: E402
 from zerg.services.machine_control_channel import MachineControlCommandResponse  # noqa: E402
+from zerg.services.machine_control_channel import get_machine_control_channel_registry  # noqa: E402
 from zerg.services.remote_session_launch import RemoteLaunchError  # noqa: E402
 from zerg.services.remote_session_launch import RemoteLaunchParams  # noqa: E402
 from zerg.services.remote_session_launch import launch_remote_session  # noqa: E402
 from zerg.services.remote_session_launch import reap_orphaned_launches  # noqa: E402
 from zerg.services.remote_session_launch import reconcile_launch_from_command_result  # noqa: E402
+from zerg.services.session_runtime import RuntimeEventIngest  # noqa: E402
+from zerg.services.session_runtime import ingest_runtime_events  # noqa: E402
+from zerg.services.session_workspace import build_session_workspace  # noqa: E402
 
 OWNER_ID = 77
 
@@ -413,6 +417,64 @@ def test_client_request_id_is_idempotent(tmp_path):
 
     assert first.session_id == second.session_id
     assert len(registry.sent) == 1  # second call short-circuits
+
+
+def test_launched_codex_workspace_exposes_live_engine_control(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    launch_registry = _StubRegistry()
+    _register_online(launch_registry, owner_id=OWNER_ID, device_id="cinder")
+
+    global_registry = get_machine_control_channel_registry()
+    asyncio.run(global_registry.clear_for_tests())
+    _register_online(
+        global_registry,
+        owner_id=OWNER_ID,
+        device_id="cinder",
+        supports=("codex.launch", "codex.send", "codex.interrupt", "codex.steer"),
+    )
+
+    try:
+        with SessionLocal() as db:
+            result = asyncio.run(
+                launch_remote_session(
+                    db,
+                    RemoteLaunchParams(
+                        owner_id=OWNER_ID,
+                        device_id="cinder",
+                        provider="codex",
+                        cwd="/Users/me/repo",
+                    ),
+                    registry=launch_registry,
+                )
+            )
+            ingest_runtime_events(
+                db,
+                [
+                    RuntimeEventIngest(
+                        runtime_key=f"codex:{result.session_id}",
+                        session_id=result.session_id,
+                        provider="codex",
+                        device_id="cinder",
+                        source="codex_bridge",
+                        kind="phase_signal",
+                        phase="idle",
+                        tool_name=None,
+                        occurred_at=datetime.now(timezone.utc),
+                        freshness_ms=60_000,
+                        dedupe_key=f"test-launch-ready:{result.session_id}",
+                        payload={"managed_transport": "codex_app_server", "thread_id": "thread-1"},
+                    )
+                ],
+            )
+            workspace = build_session_workspace(db=db, session_id=result.session_id, owner_id=OWNER_ID)
+    finally:
+        asyncio.run(global_registry.clear_for_tests())
+
+    assert workspace.session.launch_state == "live"
+    assert workspace.session.capabilities.live_control_available is True
+    assert workspace.session.capabilities.can_queue_next_input is True
+    assert workspace.session.capabilities.can_steer_active_turn is False
 
 
 def test_late_result_reconciliation_moves_unknown_to_live(tmp_path):

--- a/server/tests_lite/test_remote_session_launch.py
+++ b/server/tests_lite/test_remote_session_launch.py
@@ -1,0 +1,544 @@
+"""Tests for POST /api/sessions/launch and the launch_remote_session service.
+
+Phase 1 of the remote-session-launch epic. See
+``docs/specs/remote-session-launch.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime
+from datetime import timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("TESTING", "1")
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+os.environ.setdefault("FERNET_SECRET", Fernet.generate_key().decode())
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from zerg.database import Base  # noqa: E402
+from zerg.database import get_db  # noqa: E402
+from zerg.database import make_engine  # noqa: E402
+from zerg.dependencies.agents_auth import require_single_tenant  # noqa: E402
+from zerg.dependencies.browser_route_auth import get_current_browser_route_user  # noqa: E402
+from zerg.models import User  # noqa: E402
+from zerg.models.agents import AgentSession  # noqa: E402
+from zerg.models.agents import AgentsBase  # noqa: E402
+from zerg.models.device_token import DeviceToken  # noqa: E402
+from zerg.services.machine_control_channel import MachineControlChannelRegistry  # noqa: E402
+from zerg.services.machine_control_channel import MachineControlCommandResponse  # noqa: E402
+from zerg.services.remote_session_launch import RemoteLaunchError  # noqa: E402
+from zerg.services.remote_session_launch import RemoteLaunchParams  # noqa: E402
+from zerg.services.remote_session_launch import launch_remote_session  # noqa: E402
+from zerg.services.remote_session_launch import reap_orphaned_launches  # noqa: E402
+from zerg.services.remote_session_launch import reconcile_launch_from_command_result  # noqa: E402
+
+OWNER_ID = 77
+
+
+def _make_db(tmp_path):
+    db_path = tmp_path / "remote_launch.db"
+    engine = make_engine(f"sqlite:///{db_path}")
+    engine = engine.execution_options(schema_translate_map={"agents": None})
+    Base.metadata.create_all(bind=engine)
+    AgentsBase.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine)
+
+
+def _seed_user_and_device(SessionLocal, *, owner_id: int = OWNER_ID, device_id: str = "cinder"):
+    with SessionLocal() as db:
+        existing = db.query(User).filter(User.id == owner_id).first()
+        if existing is None:
+            db.add(User(id=owner_id, email=f"u{owner_id}@ex.com", role="ADMIN"))
+            db.commit()
+    with SessionLocal() as db:
+        db.add(
+            DeviceToken(
+                owner_id=owner_id,
+                device_id=device_id,
+                token_hash=f"hash-{device_id}-{owner_id}",
+            )
+        )
+        db.commit()
+
+
+class _FakeWebSocket:
+    async def send_json(self, message):  # pragma: no cover — tests short-circuit registry
+        pass
+
+
+def _register_online(
+    registry: MachineControlChannelRegistry,
+    *,
+    owner_id: int,
+    device_id: str,
+    supports: tuple[str, ...] = ("codex.launch",),
+):
+    asyncio.run(
+        registry.register(
+            owner_id=owner_id,
+            device_id=device_id,
+            machine_name=device_id,
+            engine_build="test",
+            supports=list(supports),
+            websocket=_FakeWebSocket(),
+        )
+    )
+
+
+class _StubRegistry(MachineControlChannelRegistry):
+    """Registry with scripted ``send_command`` responses per session_id."""
+
+    def __init__(self):
+        super().__init__()
+        self._scripted: dict[str, MachineControlCommandResponse] = {}
+        self.sent: list[dict] = []
+
+    def script(self, session_id: str, response: MachineControlCommandResponse):
+        self._scripted[session_id] = response
+
+    async def send_command(self, **kwargs):  # type: ignore[override]
+        self.sent.append(kwargs)
+        session_id = kwargs.get("session_id", "")
+        if session_id in self._scripted:
+            return self._scripted[session_id]
+        # Default: transport ok, ok=True
+        return MachineControlCommandResponse(
+            transport_ok=True,
+            message={"type": "command_result", "ok": True, "result": {"session_id": session_id}},
+        )
+
+
+def test_happy_path_inserts_live_session(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    registry = _StubRegistry()
+    _register_online(registry, owner_id=OWNER_ID, device_id="cinder")
+
+    with SessionLocal() as db:
+        result = asyncio.run(
+            launch_remote_session(
+                db,
+                RemoteLaunchParams(
+                    owner_id=OWNER_ID,
+                    device_id="cinder",
+                    provider="codex",
+                    cwd="/Users/me/repo",
+                ),
+                registry=registry,
+            )
+        )
+
+    assert result.launch_state == "live"
+    with SessionLocal() as db:
+        row = db.get(AgentSession, result.session_id)
+        assert row is not None
+        assert row.launch_state == "live"
+        assert row.launch_error_code is None
+        assert row.launch_lease_until is None
+        assert row.provider == "codex"
+        assert row.cwd == "/Users/me/repo"
+        assert row.device_id == "cinder"
+        assert row.source_runner_id is None
+
+    # verify we dispatched a session.launch with the pre-allocated id
+    assert len(registry.sent) == 1
+    sent = registry.sent[0]
+    assert sent["command_type"] == "session.launch"
+    assert sent["session_id"] == str(result.session_id)
+    assert sent["payload"]["provider"] == "codex"
+
+
+def test_offline_machine_returns_409_no_row(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    registry = _StubRegistry()
+    # Never register — machine offline
+
+    with SessionLocal() as db:
+        with pytest.raises(RemoteLaunchError) as excinfo:
+            asyncio.run(
+                launch_remote_session(
+                    db,
+                    RemoteLaunchParams(
+                        owner_id=OWNER_ID,
+                        device_id="cinder",
+                        provider="codex",
+                        cwd="/Users/me/repo",
+                    ),
+                    registry=registry,
+                )
+            )
+    assert excinfo.value.code == "machine_offline"
+    assert excinfo.value.status_code == 409
+
+    with SessionLocal() as db:
+        assert db.query(AgentSession).count() == 0
+
+
+def test_unsupported_provider_rejected(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    registry = _StubRegistry()
+    _register_online(registry, owner_id=OWNER_ID, device_id="cinder", supports=("codex.launch",))
+
+    with SessionLocal() as db:
+        with pytest.raises(RemoteLaunchError) as excinfo:
+            asyncio.run(
+                launch_remote_session(
+                    db,
+                    RemoteLaunchParams(
+                        owner_id=OWNER_ID,
+                        device_id="cinder",
+                        provider="claude",
+                        cwd="/Users/me/repo",
+                    ),
+                    registry=registry,
+                )
+            )
+    assert excinfo.value.code == "provider_unsupported"
+
+
+def test_device_ownership_required(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal, owner_id=OWNER_ID)
+    _seed_user_and_device(SessionLocal, owner_id=OWNER_ID + 1, device_id="not-mine")
+    registry = _StubRegistry()
+    # Register the other user's machine — shouldn't be launchable by OWNER_ID
+    _register_online(registry, owner_id=OWNER_ID + 1, device_id="not-mine")
+
+    with SessionLocal() as db:
+        with pytest.raises(RemoteLaunchError) as excinfo:
+            asyncio.run(
+                launch_remote_session(
+                    db,
+                    RemoteLaunchParams(
+                        owner_id=OWNER_ID,
+                        device_id="not-mine",
+                        provider="codex",
+                        cwd="/Users/me/repo",
+                    ),
+                    registry=registry,
+                )
+            )
+    assert excinfo.value.code == "device_not_enrolled"
+    assert excinfo.value.status_code == 404
+
+
+def test_engine_error_maps_to_launch_failed(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    registry = _StubRegistry()
+    _register_online(registry, owner_id=OWNER_ID, device_id="cinder")
+
+    # First call will get a typed cwd_not_found error — use a wildcard match
+    class _EngineErrorRegistry(_StubRegistry):
+        async def send_command(self, **kwargs):
+            self.sent.append(kwargs)
+            return MachineControlCommandResponse(
+                transport_ok=True,
+                message={
+                    "type": "command_result",
+                    "ok": False,
+                    "error": {"code": "cwd_not_found", "message": "nope"},
+                },
+            )
+
+    err_registry = _EngineErrorRegistry()
+    _register_online(err_registry, owner_id=OWNER_ID, device_id="cinder")
+
+    with SessionLocal() as db:
+        result = asyncio.run(
+            launch_remote_session(
+                db,
+                RemoteLaunchParams(
+                    owner_id=OWNER_ID,
+                    device_id="cinder",
+                    provider="codex",
+                    cwd="/Users/me/repo",
+                ),
+                registry=err_registry,
+            )
+        )
+    assert result.launch_state == "launch_failed"
+    assert result.launch_error_code == "cwd_not_found"
+    with SessionLocal() as db:
+        row = db.get(AgentSession, result.session_id)
+        assert row.launch_state == "launch_failed"
+        assert row.launch_error_code == "cwd_not_found"
+        assert row.ended_at is not None
+
+
+def test_transport_timeout_leaves_unknown(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+
+    class _TimeoutRegistry(_StubRegistry):
+        async def send_command(self, **kwargs):
+            self.sent.append(kwargs)
+            return MachineControlCommandResponse(
+                transport_ok=False,
+                error="command timed out after 30 seconds",
+            )
+
+    registry = _TimeoutRegistry()
+    _register_online(registry, owner_id=OWNER_ID, device_id="cinder")
+
+    with SessionLocal() as db:
+        result = asyncio.run(
+            launch_remote_session(
+                db,
+                RemoteLaunchParams(
+                    owner_id=OWNER_ID,
+                    device_id="cinder",
+                    provider="codex",
+                    cwd="/Users/me/repo",
+                ),
+                registry=registry,
+            )
+        )
+    assert result.launch_state == "launching_unknown"
+    with SessionLocal() as db:
+        row = db.get(AgentSession, result.session_id)
+        assert row.launch_state == "launching_unknown"
+        assert row.launch_lease_until is not None
+        assert row.ended_at is None
+
+
+def test_cwd_relative_rejected_server_side(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    registry = _StubRegistry()
+    _register_online(registry, owner_id=OWNER_ID, device_id="cinder")
+
+    with SessionLocal() as db:
+        with pytest.raises(RemoteLaunchError) as excinfo:
+            asyncio.run(
+                launch_remote_session(
+                    db,
+                    RemoteLaunchParams(
+                        owner_id=OWNER_ID,
+                        device_id="cinder",
+                        provider="codex",
+                        cwd="not/absolute",
+                    ),
+                    registry=registry,
+                )
+            )
+    assert excinfo.value.code == "cwd_not_allowed"
+
+
+# -------- HTTP endpoint ---------------------------------------------------
+
+
+def _make_browser_client(SessionLocal, *, owner_id: int = OWNER_ID):
+    from zerg.main import api_app
+    from zerg.main import app
+
+    def override_db():
+        with SessionLocal() as db:
+            yield db
+
+    def override_user():
+        return SimpleNamespace(id=owner_id, email=f"u{owner_id}@ex.com", role="ADMIN")
+
+    api_app.dependency_overrides[get_db] = override_db
+    api_app.dependency_overrides[get_current_browser_route_user] = override_user
+    api_app.dependency_overrides[require_single_tenant] = lambda: None
+    return TestClient(app, backend="asyncio"), api_app
+
+
+def _patch_registry(registry):
+    import zerg.services.remote_session_launch as module
+
+    original = module.get_machine_control_channel_registry
+    module.get_machine_control_channel_registry = lambda: registry
+    return original, module
+
+
+def test_http_endpoint_happy_path(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    registry = _StubRegistry()
+    _register_online(registry, owner_id=OWNER_ID, device_id="cinder")
+
+    original, module = _patch_registry(registry)
+    try:
+        client, api_app = _make_browser_client(SessionLocal)
+        try:
+            resp = client.post(
+                "/api/sessions/launch",
+                json={
+                    "device_id": "cinder",
+                    "provider": "codex",
+                    "cwd": "/Users/me/repo",
+                },
+            )
+        finally:
+            api_app.dependency_overrides.clear()
+    finally:
+        module.get_machine_control_channel_registry = original
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["launch_state"] == "live"
+    assert body["session_id"]
+
+
+def test_client_request_id_is_idempotent(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    registry = _StubRegistry()
+    _register_online(registry, owner_id=OWNER_ID, device_id="cinder")
+
+    params = RemoteLaunchParams(
+        owner_id=OWNER_ID,
+        device_id="cinder",
+        provider="codex",
+        cwd="/Users/me/repo",
+        client_request_id="tap-1",
+    )
+    with SessionLocal() as db:
+        first = asyncio.run(launch_remote_session(db, params, registry=registry))
+    with SessionLocal() as db:
+        second = asyncio.run(launch_remote_session(db, params, registry=registry))
+
+    assert first.session_id == second.session_id
+    assert len(registry.sent) == 1  # second call short-circuits
+
+
+def test_late_result_reconciliation_moves_unknown_to_live(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+
+    class _TimeoutRegistry(_StubRegistry):
+        async def send_command(self, **kwargs):
+            self.sent.append(kwargs)
+            return MachineControlCommandResponse(transport_ok=False, error="timed out")
+
+    registry = _TimeoutRegistry()
+    _register_online(registry, owner_id=OWNER_ID, device_id="cinder")
+
+    with SessionLocal() as db:
+        result = asyncio.run(
+            launch_remote_session(
+                db,
+                RemoteLaunchParams(
+                    owner_id=OWNER_ID,
+                    device_id="cinder",
+                    provider="codex",
+                    cwd="/Users/me/repo",
+                ),
+                registry=registry,
+            )
+        )
+    assert result.launch_state == "launching_unknown"
+
+    command_id = registry.sent[-1]["command_id"]
+    # Simulate late success
+    with SessionLocal() as db:
+        reconciled = reconcile_launch_from_command_result(
+            db,
+            {
+                "type": "command_result",
+                "command_id": command_id,
+                "ok": True,
+                "result": {"session_id": str(result.session_id)},
+            },
+        )
+    assert reconciled is True
+    with SessionLocal() as db:
+        row = db.get(AgentSession, result.session_id)
+        assert row.launch_state == "live"
+        assert row.launch_lease_until is None
+
+
+def test_late_result_reconciliation_ignores_unknown_command(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    with SessionLocal() as db:
+        reconciled = reconcile_launch_from_command_result(
+            db,
+            {
+                "type": "command_result",
+                "command_id": "launch-00000000-0000-0000-0000-000000000000",
+                "ok": True,
+            },
+        )
+    assert reconciled is False
+
+
+def test_reap_orphaned_launches_expires_stale_rows(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+
+    past = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
+    with SessionLocal() as db:
+        sid = uuid4()
+        db.add(
+            AgentSession(
+                id=sid,
+                provider="codex",
+                environment="development",
+                project="repo",
+                device_id="cinder",
+                cwd="/Users/me/repo",
+                started_at=past,
+                thread_root_session_id=sid,
+                continued_from_session_id=None,
+                continuation_kind="local",
+                origin_label="cinder",
+                user_messages=0,
+                assistant_messages=0,
+                tool_calls=0,
+                is_writable_head=1,
+                is_sidechain=0,
+                execution_home="managed_local",
+                launch_state="launching_unknown",
+                launch_command_id=f"launch-{sid}",
+                launch_lease_until=past.replace(year=past.year - 1),  # way in the past
+            )
+        )
+        db.commit()
+        reaped = reap_orphaned_launches(db)
+    assert reaped == 1
+    with SessionLocal() as db:
+        row = db.query(AgentSession).first()
+        assert row.launch_state == "launch_orphaned"
+        assert row.launch_lease_until is None
+        assert row.ended_at is not None
+
+
+def test_http_endpoint_offline_machine_is_409(tmp_path):
+    SessionLocal = _make_db(tmp_path)
+    _seed_user_and_device(SessionLocal)
+    registry = _StubRegistry()
+
+    original, module = _patch_registry(registry)
+    try:
+        client, api_app = _make_browser_client(SessionLocal)
+        try:
+            resp = client.post(
+                "/api/sessions/launch",
+                json={
+                    "device_id": "cinder",
+                    "provider": "codex",
+                    "cwd": "/Users/me/repo",
+                },
+            )
+        finally:
+            api_app.dependency_overrides.clear()
+    finally:
+        module.get_machine_control_channel_registry = original
+
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["code"] == "machine_offline"

--- a/server/tests_lite/test_session_runtime.py
+++ b/server/tests_lite/test_session_runtime.py
@@ -3078,6 +3078,7 @@ def test_runtime_view_aligns_codex_running_with_claude_semantics(tmp_path):
         view = build_runtime_view(state=state, session=session, now=now)
 
         assert state.phase == "running"
+        assert state.phase_source == "codex_bridge"
         assert state.active_tool == "shell"
         assert view.status == "working"
         assert view.runtime_phase == "running"

--- a/server/zerg/database.py
+++ b/server/zerg/database.py
@@ -652,6 +652,18 @@ def _migrate_agents_columns(engine: Engine) -> None:
                 conn.execute(text("ALTER TABLE sessions ADD COLUMN loop_thread_id INTEGER"))
             if "is_sidechain" not in columns:
                 conn.execute(text("ALTER TABLE sessions ADD COLUMN is_sidechain INTEGER NOT NULL DEFAULT 0"))
+            if "launch_state" not in columns:
+                conn.execute(text("ALTER TABLE sessions ADD COLUMN launch_state VARCHAR(32)"))
+            if "launch_error_code" not in columns:
+                conn.execute(text("ALTER TABLE sessions ADD COLUMN launch_error_code VARCHAR(64)"))
+            if "launch_error_message" not in columns:
+                conn.execute(text("ALTER TABLE sessions ADD COLUMN launch_error_message TEXT"))
+            if "launch_lease_until" not in columns:
+                conn.execute(text("ALTER TABLE sessions ADD COLUMN launch_lease_until DATETIME"))
+            if "launch_command_id" not in columns:
+                conn.execute(text("ALTER TABLE sessions ADD COLUMN launch_command_id VARCHAR(64)"))
+            if "launch_client_request_id" not in columns:
+                conn.execute(text("ALTER TABLE sessions ADD COLUMN launch_client_request_id VARCHAR(64)"))
             if "thread_root_session_id" not in columns:
                 conn.execute(text("ALTER TABLE sessions ADD COLUMN thread_root_session_id CHAR(36)"))
             if "continued_from_session_id" not in columns:

--- a/server/zerg/lifespan.py
+++ b/server/zerg/lifespan.py
@@ -248,6 +248,31 @@ async def lifespan(app: FastAPI):
                 failed.append(f"watch_renewal ({e})")
                 logger.exception("Failed to start watch_renewal_service")
 
+            # Remote launch reaper: orphan expired launch rows.
+            try:
+                from zerg.database import get_session_factory as _get_sf
+                from zerg.services.remote_session_launch import reap_orphaned_launches
+
+                async def _launch_reaper_loop() -> None:
+                    while True:
+                        try:
+                            await asyncio.sleep(60)
+                            db = _get_sf()()
+                            try:
+                                reap_orphaned_launches(db)
+                            finally:
+                                db.close()
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:  # noqa: BLE001
+                            logger.exception("Remote launch reaper tick failed")
+
+                asyncio.create_task(_launch_reaper_loop())
+                started.append("remote_launch_reaper")
+            except Exception as e:  # noqa: BLE001
+                failed.append(f"remote_launch_reaper ({e})")
+                logger.exception("Failed to start remote_launch_reaper")
+
             # Ingest task workers
             try:
                 from zerg.database import get_session_factory

--- a/server/zerg/models/agents.py
+++ b/server/zerg/models/agents.py
@@ -138,6 +138,15 @@ class AgentSession(AgentsBase):
     # Sidechain flag: True when session is a Task sub-agent (not a human-initiated session)
     is_sidechain = Column(Integer, nullable=False, server_default=text("0"))
 
+    # Remote-launch lifecycle (see docs/specs/remote-session-launch.md).
+    # NULL means "launched the old way"; treat as equivalent to 'live'.
+    launch_state = Column(String(32), nullable=True)
+    launch_error_code = Column(String(64), nullable=True)
+    launch_error_message = Column(Text, nullable=True)
+    launch_lease_until = Column(DateTime(timezone=True), nullable=True)
+    launch_command_id = Column(String(64), nullable=True, index=True)
+    launch_client_request_id = Column(String(64), nullable=True, index=True)
+
     # Relationships
     branches = relationship("AgentSessionBranch", back_populates="session", cascade="all, delete-orphan")
     events = relationship("AgentEvent", back_populates="session", cascade="all, delete-orphan")

--- a/server/zerg/routers/admin.py
+++ b/server/zerg/routers/admin.py
@@ -40,6 +40,7 @@ from zerg.services.runner_connection_manager import get_runner_connection_manage
 # Usage service
 from zerg.services.usage_service import get_all_users_usage
 from zerg.services.usage_service import get_user_usage_detail
+from zerg.utils.time import UTCBaseModel
 
 router = APIRouter(
     prefix="/admin",
@@ -693,3 +694,62 @@ async def get_user_usage_details(
     if result is None:
         raise HTTPException(status_code=404, detail="User not found")
     return result
+
+
+# ---------------------------------------------------------------------------
+# Remote launch debug view (Phase 4 of remote-session-launch epic)
+# ---------------------------------------------------------------------------
+
+
+class RemoteLaunchDebugEntry(UTCBaseModel):
+    session_id: str
+    device_id: str | None
+    provider: str
+    cwd: str | None
+    launch_state: str
+    launch_error_code: str | None
+    launch_error_message: str | None
+    launch_lease_until: datetime | None
+    started_at: datetime
+    ended_at: datetime | None
+
+
+class RemoteLaunchDebugResponse(UTCBaseModel):
+    entries: list[RemoteLaunchDebugEntry]
+    total: int
+
+
+@router.get("/launches/debug", response_model=RemoteLaunchDebugResponse)
+async def list_remote_launch_debug(
+    limit: int = Query(50, ge=1, le=200, description="Max rows to return"),
+    include_live: bool = Query(False, description="Include launch_state=live rows (default: only show non-healthy)"),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_admin),
+):
+    """Admin-only view of remote launches that are not cleanly live.
+
+    Surfaces launching / launching_unknown / launch_failed / launch_orphaned
+    rows so an operator can debug propagation or control-channel issues.
+    """
+    q = db.query(AgentSession).filter(AgentSession.launch_state.is_not(None))
+    if not include_live:
+        q = q.filter(AgentSession.launch_state != "live")
+    q = q.order_by(AgentSession.started_at.desc())
+    rows = q.limit(limit).all()
+    total = q.count()
+    entries = [
+        RemoteLaunchDebugEntry(
+            session_id=str(row.id),
+            device_id=row.device_id,
+            provider=row.provider,
+            cwd=row.cwd,
+            launch_state=row.launch_state,
+            launch_error_code=row.launch_error_code,
+            launch_error_message=row.launch_error_message,
+            launch_lease_until=row.launch_lease_until,
+            started_at=row.started_at,
+            ended_at=row.ended_at,
+        )
+        for row in rows
+    ]
+    return RemoteLaunchDebugResponse(entries=entries, total=total)

--- a/server/zerg/routers/agents_control.py
+++ b/server/zerg/routers/agents_control.py
@@ -16,6 +16,7 @@ from zerg.database import get_session_factory
 from zerg.models.device_token import DeviceToken
 from zerg.routers.device_tokens import validate_device_token
 from zerg.services.machine_control_channel import get_machine_control_channel_registry
+from zerg.services.remote_session_launch import reconcile_launch_from_command_result
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,14 @@ async def machine_control_websocket(websocket: WebSocket) -> None:
                 await registry.mark_seen(owner_id=owner_id, device_id=device_id)
             elif message_type == "command_result":
                 await registry.mark_seen(owner_id=owner_id, device_id=device_id)
-                await registry.complete_command(message, owner_id=owner_id, device_id=device_id)
+                matched = await registry.complete_command(message, owner_id=owner_id, device_id=device_id)
+                if not matched:
+                    # The original launcher call may have timed out; persist the
+                    # late outcome on the sessions row so the client can see it.
+                    try:
+                        reconcile_launch_from_command_result(db, message)
+                    except Exception:  # noqa: BLE001
+                        logger.exception("Failed to reconcile late launch result command_id=%s", message.get("command_id"))
             else:
                 logger.warning("Unknown machine control message type from %s: %s", device_id, message_type)
     finally:

--- a/server/zerg/routers/agents_machines.py
+++ b/server/zerg/routers/agents_machines.py
@@ -1,4 +1,10 @@
-"""Machine-facing health summaries built from latest heartbeat rows."""
+"""Machine-facing directory and health summaries.
+
+``/agents/machines`` is the per-owner directory of enrolled machines and
+their current control-channel status; it is the launch-sheet data source.
+``/agents/machines/health`` is the richer observability view used by
+operator dashboards.
+"""
 
 from __future__ import annotations
 
@@ -10,13 +16,30 @@ from sqlalchemy.orm import Session
 from zerg.database import get_db
 from zerg.dependencies.agents_auth import require_single_tenant
 from zerg.dependencies.agents_auth import verify_agents_token
+from zerg.models.device_token import DeviceToken
+from zerg.schemas.machines import MachineDirectoryEntry
+from zerg.schemas.machines import MachineDirectoryResponse
 from zerg.schemas.observability import MachineHealthListResponse
 from zerg.schemas.observability import MachineHealthStatus
 from zerg.services.agent_heartbeat_health import DEFAULT_MACHINE_HEARTBEAT_STALE_AFTER_SECONDS
 from zerg.services.agent_heartbeat_health import list_machine_transport_health
+from zerg.services.machines_directory import build_machines_directory
 from zerg.services.observability_views import build_machine_health_list_response
+from zerg.services.session_chat_impl import _resolve_agents_owner_id
 
 router = APIRouter(prefix="/agents/machines", tags=["agents"])
+
+
+@router.get("", response_model=MachineDirectoryResponse)
+async def list_machines(
+    db: Session = Depends(get_db),
+    device_token: DeviceToken | None = Depends(verify_agents_token),
+    _single: None = Depends(require_single_tenant),
+) -> MachineDirectoryResponse:
+    """List enrolled machines for this owner with live control-channel status."""
+    owner_id = _resolve_agents_owner_id(db, device_token)
+    entries = build_machines_directory(db, owner_id=owner_id)
+    return MachineDirectoryResponse(machines=[MachineDirectoryEntry(**entry.to_response()) for entry in entries])
 
 
 @router.get("/health", response_model=MachineHealthListResponse)

--- a/server/zerg/routers/agents_sessions.py
+++ b/server/zerg/routers/agents_sessions.py
@@ -23,12 +23,14 @@ from zerg.database import get_db
 from zerg.dependencies.agents_auth import require_single_tenant
 from zerg.dependencies.agents_auth import verify_agents_token
 from zerg.models.agents import AgentSession
+from zerg.models.device_token import DeviceToken
 from zerg.services.agents_store import AgentsStore
 from zerg.services.provisional_events import load_active_provisional_preview_map
 from zerg.services.session_archive import SessionArchiveBundleResponse
 from zerg.services.session_archive import SessionArchiveManifestResponse
 from zerg.services.session_archive import build_session_archive_bundle
 from zerg.services.session_archive import build_session_archive_manifest_item
+from zerg.services.session_chat_impl import _resolve_agents_owner_id
 from zerg.services.session_coordination import acknowledge_session_message as acknowledge_session_message_for_session
 from zerg.services.session_coordination import list_session_messages
 from zerg.services.session_coordination import load_session_tail
@@ -1037,13 +1039,21 @@ async def get_session_workspace(
     branch_mode: str = Query("head", description="Branch projection mode: head|all"),
     limit: int = Query(100, ge=1, le=1000, description="Max projected items"),
     db: Session = Depends(get_db),
-    _auth: None = Depends(verify_agents_token),
+    _auth: DeviceToken | ManagedLocalHookToken | None = Depends(verify_agents_token),
     _single: None = Depends(require_single_tenant),
 ) -> SessionWorkspaceResponse:
     """Get the focused session, its thread, and the first projection page in one round trip."""
     timing = ServerTimingRecorder()
     response.headers["Cache-Control"] = "private, max-age=5"
-    result = build_session_workspace(db=db, session_id=session_id, branch_mode=branch_mode, limit=limit, timing=timing)
+    owner_id = _resolve_agents_owner_id(db, _auth if isinstance(_auth, DeviceToken) else None)
+    result = build_session_workspace(
+        db=db,
+        session_id=session_id,
+        branch_mode=branch_mode,
+        limit=limit,
+        timing=timing,
+        owner_id=owner_id,
+    )
     timing.apply(response)
     return result
 

--- a/server/zerg/routers/session_chat.py
+++ b/server/zerg/routers/session_chat.py
@@ -33,6 +33,9 @@ from zerg.models.user import User
 from zerg.services.managed_local_launcher import ManagedLocalLaunchError
 from zerg.services.managed_local_launcher import ManagedLocalLaunchParams
 from zerg.services.managed_local_launcher import launch_managed_local_session
+from zerg.services.remote_session_launch import RemoteLaunchError
+from zerg.services.remote_session_launch import RemoteLaunchParams
+from zerg.services.remote_session_launch import launch_remote_session
 from zerg.services.session_chat_impl import ManagedLocalSessionLaunchResponse
 from zerg.services.session_chat_impl import SessionDraftReplyResponse
 from zerg.services.session_chat_impl import SessionLockInfo
@@ -86,6 +89,33 @@ class SessionDraftReplyRequest(BaseModel):
     """Request a suggested next user message without sending it."""
 
     max_chars: int = Field(1200, ge=100, le=4000, description="Maximum draft length")
+
+
+class RemoteSessionLaunchRequest(BaseModel):
+    """User-initiated remote session launch request."""
+
+    device_id: str = Field(..., min_length=1, description="Target enrolled device id")
+    provider: str = Field(..., description="Provider CLI to launch (v1: codex only)")
+    cwd: str = Field(..., min_length=1, description="Absolute working directory on the target machine")
+    git_repo: str | None = Field(None, description="Optional git repository path")
+    git_branch: str | None = Field(None, description="Optional git branch name")
+    project: str | None = Field(None, description="Optional project label")
+    display_name: str | None = Field(None, description="Optional display name")
+    client_request_id: str | None = Field(
+        None,
+        min_length=1,
+        max_length=64,
+        description="Optional idempotency key; repeated calls with the same value return the same session",
+    )
+
+
+class RemoteSessionLaunchResponse(BaseModel):
+    """Response from POST /api/sessions/launch."""
+
+    session_id: str
+    launch_state: str
+    launch_error_code: str | None = None
+    launch_error_message: str | None = None
 
 
 class ManagedLocalThisDeviceLaunchRequest(BaseModel):
@@ -488,6 +518,49 @@ async def launch_managed_local_this_device(
     )
 
     return _managed_local_launch_response(result)
+
+
+@router.post("/launch", response_model=RemoteSessionLaunchResponse)
+async def launch_remote_session_endpoint(
+    body: RemoteSessionLaunchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_browser_route_user),
+) -> RemoteSessionLaunchResponse:
+    """Start a session on a user-owned machine via the Machine Agent control channel.
+
+    See docs/specs/remote-session-launch.md. Pre-allocates a session UUID,
+    inserts the ``sessions`` row in ``launch_state=launching``, and dispatches
+    ``session.launch`` over the existing control WebSocket.
+    """
+    try:
+        result = await launch_remote_session(
+            db,
+            RemoteLaunchParams(
+                owner_id=int(current_user.id),
+                device_id=body.device_id,
+                provider=body.provider,
+                cwd=body.cwd,
+                git_repo=body.git_repo,
+                git_branch=body.git_branch,
+                project=body.project,
+                display_name=body.display_name,
+                client_request_id=body.client_request_id,
+            ),
+        )
+    except RemoteLaunchError as exc:
+        db.rollback()
+        raise HTTPException(status_code=exc.status_code, detail={"code": exc.code, "message": exc.detail}) from exc
+    except Exception:
+        db.rollback()
+        logger.exception("Remote session launch failed unexpectedly")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Remote session launch failed")
+
+    return RemoteSessionLaunchResponse(
+        session_id=str(result.session_id),
+        launch_state=result.launch_state,
+        launch_error_code=result.launch_error_code,
+        launch_error_message=result.launch_error_message,
+    )
 
 
 @router.get("/{session_id}/lock")

--- a/server/zerg/routers/timeline.py
+++ b/server/zerg/routers/timeline.py
@@ -40,6 +40,9 @@ from zerg.models.agents import AgentSession
 from zerg.routers import agents_demo as _demo_router
 from zerg.routers import agents_search as _search_router
 from zerg.routers import agents_sessions as _sessions_router
+from zerg.schemas.machines import MachineDirectoryEntry
+from zerg.schemas.machines import MachineDirectoryResponse
+from zerg.services.machines_directory import build_machines_directory
 from zerg.services.session_listing import SessionListingError
 from zerg.services.session_views import DemoSeedResponse
 from zerg.services.session_views import EventsListResponse
@@ -99,6 +102,16 @@ def _timeline_filters_cache_key(db: Session, *, days_back: int) -> tuple[str, in
     latest_session_update = db.query(func.max(AgentSession.updated_at)).scalar()
     latest_update_key = latest_session_update.isoformat() if latest_session_update is not None else None
     return bind_key, days_back, latest_update_key
+
+
+@router.get("/machines", response_model=MachineDirectoryResponse)
+async def list_browser_machines(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_browser_user),
+) -> MachineDirectoryResponse:
+    """Browser machines directory. Same body shape as ``/api/agents/machines``."""
+    entries = build_machines_directory(db, owner_id=int(current_user.id))
+    return MachineDirectoryResponse(machines=[MachineDirectoryEntry(**entry.to_response()) for entry in entries])
 
 
 @router.get("/sessions/semantic", response_model=SemanticSearchResponse)

--- a/server/zerg/routers/timeline.py
+++ b/server/zerg/routers/timeline.py
@@ -526,10 +526,18 @@ async def get_timeline_session_workspace(
     branch_mode: str = Query("head", description="Branch projection mode: head|all"),
     limit: int = Query(100, ge=1, le=1000, description="Max projected items"),
     db: Session = Depends(get_db),
+    current_user=Depends(get_current_browser_user),
 ):
     timing = ServerTimingRecorder()
     response.headers["Cache-Control"] = "private, max-age=5"
-    result = build_session_workspace(db=db, session_id=session_id, branch_mode=branch_mode, limit=limit, timing=timing)
+    result = build_session_workspace(
+        db=db,
+        session_id=session_id,
+        branch_mode=branch_mode,
+        limit=limit,
+        timing=timing,
+        owner_id=int(current_user.id),
+    )
     timing.apply(response)
     return result
 

--- a/server/zerg/schemas/machines.py
+++ b/server/zerg/schemas/machines.py
@@ -1,0 +1,31 @@
+"""Machines directory response schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import Field
+
+from zerg.utils.time import UTCBaseModel
+
+
+class MachineDirectoryEntry(UTCBaseModel):
+    device_id: str = Field(..., description="Canonical device id used for routing")
+    machine_name: str = Field(..., description="Display label; may equal device_id")
+    online: bool = Field(..., description="True iff the control channel is currently connected")
+    supports: list[str] = Field(
+        default_factory=list,
+        description="Capabilities announced by the Machine Agent on its last hello frame. Empty when offline.",
+    )
+    last_seen_at: datetime | None = Field(
+        default=None,
+        description="Most recent control-channel activity or device-token use; null if never observed.",
+    )
+    engine_build: str | None = Field(
+        default=None,
+        description="Engine build string from the last hello frame; null when offline.",
+    )
+
+
+class MachineDirectoryResponse(UTCBaseModel):
+    machines: list[MachineDirectoryEntry] = Field(default_factory=list)

--- a/server/zerg/services/machine_control_channel.py
+++ b/server/zerg/services/machine_control_channel.py
@@ -123,6 +123,10 @@ class MachineControlChannelRegistry:
         connection = self._connections.get((owner_id, device_id))
         return connection.info if connection is not None else None
 
+    def list_for_owner(self, *, owner_id: int) -> list[MachineControlConnectionInfo]:
+        """Return infos for every currently-connected machine belonging to owner."""
+        return [connection.info for (conn_owner, _device), connection in self._connections.items() if conn_owner == owner_id]
+
     def is_online(self, *, owner_id: int, device_id: str) -> bool:
         return (owner_id, device_id) in self._connections
 

--- a/server/zerg/services/machines_directory.py
+++ b/server/zerg/services/machines_directory.py
@@ -1,0 +1,126 @@
+"""Machines directory view shared by agents and timeline routes.
+
+Produces the small per-user machine list used by the launch sheet and the
+machines page. Joins the in-memory machine control channel registry
+(authoritative for online/supports/last_seen) with persisted device-token
+rows (authoritative for machines the user has enrolled but that are not
+currently connected).
+
+Intentionally thin: this is not a health dashboard. ``agents/machines/health``
+remains the richer view. The goal here is "what can I launch on right now,
+and what else does this user own."
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from zerg.models.device_token import DeviceToken
+from zerg.services.machine_control_channel import MachineControlChannelRegistry
+from zerg.services.machine_control_channel import get_machine_control_channel_registry
+
+
+@dataclass(frozen=True)
+class MachineEntry:
+    device_id: str
+    machine_name: str
+    online: bool
+    supports: tuple[str, ...]
+    last_seen_at: datetime | None
+    engine_build: str | None
+
+    def to_response(self) -> dict[str, object]:
+        return {
+            "device_id": self.device_id,
+            "machine_name": self.machine_name,
+            "online": self.online,
+            "supports": list(self.supports),
+            "last_seen_at": self.last_seen_at.isoformat() if self.last_seen_at else None,
+            "engine_build": self.engine_build,
+        }
+
+
+def _enrolled_device_ids(db: Session, owner_id: int) -> dict[str, datetime | None]:
+    """Return enrolled, non-revoked device ids for the owner with last_used_at."""
+    stmt = (
+        select(DeviceToken.device_id, DeviceToken.last_used_at, DeviceToken.created_at)
+        .where(DeviceToken.owner_id == owner_id)
+        .where(DeviceToken.revoked_at.is_(None))
+    )
+    latest: dict[str, datetime | None] = {}
+    for device_id, last_used_at, created_at in db.execute(stmt).all():
+        if not device_id:
+            continue
+        key = str(device_id)
+        best = last_used_at or created_at
+        existing = latest.get(key)
+        if existing is None or (best is not None and best > existing):
+            latest[key] = best
+    return latest
+
+
+def build_machines_directory(
+    db: Session,
+    *,
+    owner_id: int,
+    registry: MachineControlChannelRegistry | None = None,
+) -> list[MachineEntry]:
+    """Build the per-owner machines list.
+
+    Online machines come from the in-memory control-channel registry and
+    include current ``supports[]``. Offline-but-enrolled machines come from
+    ``device_tokens`` and are returned with empty ``supports`` — last-known
+    capabilities are intentionally not persisted to avoid implying stale
+    truth.
+    """
+    reg = registry or get_machine_control_channel_registry()
+    seen: dict[str, MachineEntry] = {}
+
+    # Online first — authoritative for supports, engine_build, and
+    # last_seen_at.
+    for conn_info in reg.list_for_owner(owner_id=owner_id):
+        entry = MachineEntry(
+            device_id=conn_info.device_id,
+            machine_name=conn_info.machine_name or conn_info.device_id,
+            online=True,
+            supports=tuple(sorted(conn_info.supports)),
+            last_seen_at=conn_info.last_seen_at,
+            engine_build=conn_info.engine_build,
+        )
+        seen[entry.device_id] = entry
+
+    # Offline enrolled — fill in anything not already present from control
+    # channel registry.
+    for device_id, last_used in _enrolled_device_ids(db, owner_id).items():
+        if device_id in seen:
+            continue
+        seen[device_id] = MachineEntry(
+            device_id=device_id,
+            machine_name=device_id,
+            online=False,
+            supports=(),
+            last_seen_at=_as_utc(last_used),
+            engine_build=None,
+        )
+
+    return sorted(
+        seen.values(),
+        key=lambda m: (
+            0 if m.online else 1,
+            -(m.last_seen_at or datetime.min.replace(tzinfo=timezone.utc)).timestamp(),
+            m.machine_name.lower(),
+        ),
+    )
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/server/zerg/services/remote_session_launch.py
+++ b/server/zerg/services/remote_session_launch.py
@@ -250,6 +250,14 @@ async def launch_remote_session(
         session.launch_lease_until = None
         db.commit()
         db.refresh(session)
+        elapsed_ms = int((datetime.now(timezone.utc) - now).total_seconds() * 1000)
+        logger.info(
+            "remote_launch session=%s device=%s provider=%s state=live duration_ms=%s",
+            session_uuid,
+            device_id,
+            provider,
+            elapsed_ms,
+        )
         return RemoteLaunchResult(session_id=session_uuid, launch_state="live")
 
     error = message.get("error") or {}
@@ -262,6 +270,13 @@ async def launch_remote_session(
     session.ended_at = datetime.now(timezone.utc)
     db.commit()
     db.refresh(session)
+    logger.warning(
+        "remote_launch session=%s device=%s provider=%s state=launch_failed code=%s",
+        session_uuid,
+        device_id,
+        provider,
+        code,
+    )
     return RemoteLaunchResult(
         session_id=session_uuid,
         launch_state="launch_failed",

--- a/server/zerg/services/remote_session_launch.py
+++ b/server/zerg/services/remote_session_launch.py
@@ -1,0 +1,344 @@
+"""Remote session launch — POST /api/sessions/launch.
+
+See docs/specs/remote-session-launch.md. The caller (user-auth'd browser or
+iOS) picks a target machine + cwd + provider. We verify ownership, confirm
+the Machine Agent is connected, pre-allocate the session UUID, insert the
+``sessions`` row in ``launch_state=launching``, dispatch the ``session.launch``
+command over the existing control WebSocket, and reconcile the row based on
+the typed result.
+
+Control-channel contract preserved: every command carries ``session_id``,
+including launch. The session id is the one we pre-allocated. No parallel
+``launch_requests`` table exists.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from pathlib import Path
+from uuid import UUID
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from zerg.models.agents import AgentSession
+from zerg.models.device_token import DeviceToken
+from zerg.services.machine_control_channel import MachineControlChannelRegistry
+from zerg.services.machine_control_channel import MachineControlCommandResponse
+from zerg.services.machine_control_channel import get_machine_control_channel_registry
+from zerg.session_execution_home import ManagedSessionTransport
+from zerg.session_execution_home import SessionExecutionHome
+from zerg.session_loop_mode import SessionLoopMode
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_PROVIDERS = {"codex"}
+LAUNCH_COMMAND_TIMEOUT_SECS = 30
+LAUNCH_LEASE_SECS = 120
+
+
+class RemoteLaunchError(RuntimeError):
+    """Expected remote-launch failure with user-facing detail."""
+
+    def __init__(self, detail: str, code: str, *, status_code: int = 400) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.code = code
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class RemoteLaunchParams:
+    owner_id: int
+    device_id: str
+    provider: str
+    cwd: str
+    git_repo: str | None = None
+    git_branch: str | None = None
+    project: str | None = None
+    display_name: str | None = None
+    client_request_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RemoteLaunchResult:
+    session_id: UUID
+    launch_state: str
+    launch_error_code: str | None = None
+    launch_error_message: str | None = None
+
+
+def _verify_device_owned_by(db: Session, *, owner_id: int, device_id: str) -> None:
+    """Require that ``device_id`` has a non-revoked device token for ``owner_id``."""
+    q = (
+        db.query(DeviceToken.id)
+        .filter(DeviceToken.owner_id == owner_id)
+        .filter(DeviceToken.device_id == device_id)
+        .filter(DeviceToken.revoked_at.is_(None))
+        .first()
+    )
+    if q is None:
+        raise RemoteLaunchError(
+            f"Device {device_id!r} is not enrolled for this user",
+            code="device_not_enrolled",
+            status_code=404,
+        )
+
+
+def _project_for(cwd: str, project: str | None) -> str:
+    if project and project.strip():
+        return project.strip()
+    return Path(cwd).name or "managed-local"
+
+
+async def launch_remote_session(
+    db: Session,
+    params: RemoteLaunchParams,
+    *,
+    registry: MachineControlChannelRegistry | None = None,
+) -> RemoteLaunchResult:
+    provider = (params.provider or "").strip().lower()
+    if provider not in SUPPORTED_PROVIDERS:
+        raise RemoteLaunchError(
+            f"provider {provider!r} is not supported for remote launch in v1",
+            code="provider_unsupported",
+            status_code=400,
+        )
+
+    device_id = (params.device_id or "").strip()
+    if not device_id:
+        raise RemoteLaunchError(
+            "device_id is required",
+            code="invalid_request",
+            status_code=400,
+        )
+    cwd = (params.cwd or "").strip()
+    if not cwd:
+        raise RemoteLaunchError(
+            "cwd is required",
+            code="invalid_request",
+            status_code=400,
+        )
+    if not cwd.startswith("/"):
+        raise RemoteLaunchError(
+            "cwd must be absolute",
+            code="cwd_not_allowed",
+            status_code=400,
+        )
+
+    _verify_device_owned_by(db, owner_id=params.owner_id, device_id=device_id)
+
+    client_request_id = (params.client_request_id or "").strip() or None
+    if client_request_id:
+        existing = (
+            db.query(AgentSession)
+            .filter(AgentSession.launch_client_request_id == client_request_id)
+            .filter(AgentSession.device_id == device_id)
+            .filter(AgentSession.provider == provider)
+            .order_by(AgentSession.started_at.desc())
+            .first()
+        )
+        if existing is not None:
+            return RemoteLaunchResult(
+                session_id=UUID(str(existing.id)),
+                launch_state=existing.launch_state or "live",
+                launch_error_code=existing.launch_error_code,
+                launch_error_message=existing.launch_error_message,
+            )
+
+    reg = registry or get_machine_control_channel_registry()
+    info = reg.info(owner_id=params.owner_id, device_id=device_id)
+    if info is None:
+        raise RemoteLaunchError(
+            f"Machine {device_id!r} is offline",
+            code="machine_offline",
+            status_code=409,
+        )
+    launch_cap = f"{provider}.launch"
+    if launch_cap not in info.supports:
+        raise RemoteLaunchError(
+            f"Machine {device_id!r} does not support {launch_cap}",
+            code="provider_unsupported",
+            status_code=409,
+        )
+
+    session_uuid = uuid4()
+    command_id = f"launch-{session_uuid}"
+    project = _project_for(cwd, params.project)
+    display_name = (params.display_name or project).strip() or project
+    now = datetime.now(timezone.utc)
+    lease_until = now + timedelta(seconds=LAUNCH_LEASE_SECS)
+
+    session = AgentSession(
+        id=session_uuid,
+        provider=provider,
+        environment="development",
+        project=project,
+        device_id=device_id,
+        device_name=info.machine_name or device_id,
+        cwd=cwd,
+        git_repo=params.git_repo,
+        git_branch=params.git_branch,
+        started_at=now,
+        ended_at=None,
+        provider_session_id=str(session_uuid),
+        thread_root_session_id=session_uuid,
+        continued_from_session_id=None,
+        continuation_kind="local",
+        origin_label=info.machine_name or device_id,
+        user_messages=0,
+        assistant_messages=0,
+        tool_calls=0,
+        is_writable_head=1,
+        is_sidechain=0,
+        loop_mode=SessionLoopMode.ASSIST.value,
+        execution_home=SessionExecutionHome.MANAGED_LOCAL.value,
+        managed_transport=ManagedSessionTransport.for_provider(provider).value,
+        source_runner_id=None,
+        source_runner_name=info.machine_name or device_id,
+        managed_session_name=display_name,
+        launch_state="launching",
+        launch_lease_until=lease_until,
+        launch_command_id=command_id,
+        launch_client_request_id=client_request_id,
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    payload = {
+        "provider": provider,
+        "cwd": cwd,
+        "git_repo": params.git_repo,
+        "git_branch": params.git_branch,
+        "project": project,
+        "display_name": display_name,
+    }
+    response: MachineControlCommandResponse = await reg.send_command(
+        owner_id=params.owner_id,
+        device_id=device_id,
+        session_id=str(session_uuid),
+        command_type="session.launch",
+        payload=payload,
+        timeout_secs=LAUNCH_COMMAND_TIMEOUT_SECS,
+        command_id=command_id,
+    )
+
+    if not response.transport_ok:
+        # Timeout or transport error — leave state as launching_unknown and let
+        # the reaper / late-result reconcile path finish the job.
+        session.launch_state = "launching_unknown"
+        session.launch_error_message = response.error or "control channel transport failed"
+        db.commit()
+        db.refresh(session)
+        return RemoteLaunchResult(
+            session_id=session_uuid,
+            launch_state=session.launch_state,
+            launch_error_code=None,
+            launch_error_message=session.launch_error_message,
+        )
+
+    message = response.message or {}
+    if message.get("ok"):
+        session.launch_state = "live"
+        session.launch_error_code = None
+        session.launch_error_message = None
+        session.launch_lease_until = None
+        db.commit()
+        db.refresh(session)
+        return RemoteLaunchResult(session_id=session_uuid, launch_state="live")
+
+    error = message.get("error") or {}
+    code = str(error.get("code") or "provider_launch_failed")
+    err_msg = str(error.get("message") or "unknown error")
+    session.launch_state = "launch_failed"
+    session.launch_error_code = code
+    session.launch_error_message = err_msg
+    session.launch_lease_until = None
+    session.ended_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(session)
+    return RemoteLaunchResult(
+        session_id=session_uuid,
+        launch_state="launch_failed",
+        launch_error_code=code,
+        launch_error_message=err_msg,
+    )
+
+
+def reconcile_launch_from_command_result(db: Session, message: dict) -> bool:
+    """Late-result reconciliation for a ``session.launch`` command.
+
+    Called from the control-channel WS handler whenever a ``command_result``
+    frame arrives that the in-memory registry did not map to an in-flight
+    request. If the frame belongs to a launch we dispatched earlier (matched
+    by ``launch_command_id``), flip the stored row from ``launching_unknown``
+    to the right terminal state.
+
+    Returns True if a row was reconciled.
+    """
+    command_id = str(message.get("command_id") or "").strip()
+    if not command_id or not command_id.startswith("launch-"):
+        return False
+    session = db.query(AgentSession).filter(AgentSession.launch_command_id == command_id).first()
+    if session is None:
+        return False
+    if session.launch_state not in {"launching", "launching_unknown"}:
+        return False
+    if message.get("ok"):
+        session.launch_state = "live"
+        session.launch_error_code = None
+        session.launch_error_message = None
+        session.launch_lease_until = None
+    else:
+        error = message.get("error") or {}
+        session.launch_state = "launch_failed"
+        session.launch_error_code = str(error.get("code") or "provider_launch_failed")
+        session.launch_error_message = str(error.get("message") or "unknown error")
+        session.launch_lease_until = None
+        if session.ended_at is None:
+            session.ended_at = datetime.now(timezone.utc)
+    db.commit()
+    return True
+
+
+def reap_orphaned_launches(db: Session, *, now: datetime | None = None) -> int:
+    """Move expired ``launching``/``launching_unknown`` rows to ``launch_orphaned``.
+
+    Returns the number of rows reaped. Intended to be called on a low-frequency
+    tick (every 30-60s) from a background task.
+    """
+    cutoff = now or datetime.now(timezone.utc)
+    stale = (
+        db.query(AgentSession)
+        .filter(AgentSession.launch_state.in_(["launching", "launching_unknown"]))
+        .filter(AgentSession.launch_lease_until.is_not(None))
+        .filter(AgentSession.launch_lease_until < cutoff)
+        .all()
+    )
+    for session in stale:
+        session.launch_state = "launch_orphaned"
+        session.launch_error_code = session.launch_error_code or "launch_timeout"
+        session.launch_error_message = session.launch_error_message or "Machine Agent did not report back before lease expired"
+        session.launch_lease_until = None
+        if session.ended_at is None:
+            session.ended_at = cutoff
+    if stale:
+        db.commit()
+    return len(stale)
+
+
+__all__ = [
+    "LAUNCH_COMMAND_TIMEOUT_SECS",
+    "LAUNCH_LEASE_SECS",
+    "RemoteLaunchError",
+    "RemoteLaunchParams",
+    "RemoteLaunchResult",
+    "launch_remote_session",
+    "reap_orphaned_launches",
+    "reconcile_launch_from_command_result",
+]

--- a/server/zerg/services/session_current_control.py
+++ b/server/zerg/services/session_current_control.py
@@ -20,7 +20,7 @@ from zerg.services.session_runtime import resolve_runtime_overlay
 from zerg.session_execution_home import ManagedSessionTransport
 
 
-def _engine_control_online(session: AgentSession, owner_id: int | None) -> bool:
+def engine_control_online(session: AgentSession, owner_id: int | None) -> bool:
     return (
         select_managed_control_transport(
             session,
@@ -31,7 +31,7 @@ def _engine_control_online(session: AgentSession, owner_id: int | None) -> bool:
     )
 
 
-def _with_engine_control_capability(
+def with_engine_control_capability(
     capability_flags: SessionCapabilityFlags,
     *,
     engine_control_online: bool,
@@ -63,7 +63,7 @@ def _with_engine_control_capability(
     )
 
 
-def _engine_bridge_attached(runtime_overlay) -> bool:
+def engine_bridge_attached(runtime_overlay) -> bool:
     source = str(getattr(runtime_overlay, "runtime_source", "") or "").strip().lower()
     phase = str(getattr(runtime_overlay, "runtime_phase", "") or "").strip()
     return source in MANAGED_CODEX_RUNTIME_SOURCES and getattr(runtime_overlay, "confidence", None) == "live" and bool(phase)
@@ -77,7 +77,7 @@ def current_session_capabilities(
 ) -> SessionCapabilityFlags:
     """Return user-action capabilities backed by current runtime truth."""
     capability_flags = build_session_capabilities(session)
-    engine_control_online = _engine_control_online(session, owner_id)
+    is_engine_control_online = engine_control_online(session, owner_id)
     now = datetime.now(timezone.utc)
     last_activity_at = (
         getattr(session, "last_activity_at", None) or getattr(session, "ended_at", None) or getattr(session, "started_at", None)
@@ -89,13 +89,13 @@ def current_session_capabilities(
         runtime_state_map=runtime_state_map,
         now=now,
     )
-    capability_flags = _with_engine_control_capability(
+    capability_flags = with_engine_control_capability(
         capability_flags,
-        engine_control_online=engine_control_online,
-        engine_bridge_attached=_engine_bridge_attached(runtime_overlay),
+        engine_control_online=is_engine_control_online,
+        engine_bridge_attached=engine_bridge_attached(runtime_overlay),
     )
     binding_host_state = None
-    if engine_control_online:
+    if is_engine_control_online:
         binding_host_state = "online"
     elif capability_flags.live_control_available or capability_flags.host_reattach_available:
         binding_host_state = managed_runner_host_state(db, session)
@@ -106,3 +106,11 @@ def current_session_capabilities(
         binding_host_state=binding_host_state,
     )
     return project_current_session_capabilities_from_facts(capability_flags, liveness_facts=liveness_facts, now=now)
+
+
+__all__ = [
+    "current_session_capabilities",
+    "engine_bridge_attached",
+    "engine_control_online",
+    "with_engine_control_capability",
+]

--- a/server/zerg/services/session_runtime.py
+++ b/server/zerg/services/session_runtime.py
@@ -771,7 +771,8 @@ def _apply_runtime_event(db: Session, event: RuntimeEventIngest) -> RuntimeEvent
                 state.timeline_anchor_at = occurred_at
             state.phase_started_at = occurred_at
         state.phase = next_phase
-        state.phase_source = str(event.source or "semantic").strip() or "semantic"
+        event_source = str(event.source or "").strip()
+        state.phase_source = event_source if event_source in MANAGED_CODEX_RUNTIME_SOURCES else "semantic"
         if next_phase in {"running", "blocked"}:
             state.active_tool = next_active_tool
         else:

--- a/server/zerg/services/session_runtime.py
+++ b/server/zerg/services/session_runtime.py
@@ -771,7 +771,7 @@ def _apply_runtime_event(db: Session, event: RuntimeEventIngest) -> RuntimeEvent
                 state.timeline_anchor_at = occurred_at
             state.phase_started_at = occurred_at
         state.phase = next_phase
-        state.phase_source = "semantic"
+        state.phase_source = str(event.source or "semantic").strip() or "semantic"
         if next_phase in {"running", "blocked"}:
             state.active_tool = next_active_tool
         else:

--- a/server/zerg/services/session_views.py
+++ b/server/zerg/services/session_views.py
@@ -549,6 +549,14 @@ class SessionResponse(UTCBaseModel):
     )
     loop_mode: SessionLoopMode = Field(SessionLoopMode.ASSIST, description="Session loop mode: assist|autopilot")
     user_state: str = Field("active", description="User classification: active|parked|snoozed|archived")
+    launch_state: Optional[str] = Field(
+        None,
+        description="Remote-launch lifecycle: launching|live|launching_unknown|launch_failed|launch_orphaned; null for pre-migration rows",
+    )
+    launch_error_code: Optional[str] = Field(None, description="Remote-launch error code when launch_state=launch_failed/launch_orphaned")
+    launch_error_message: Optional[str] = Field(
+        None, description="Remote-launch error message when launch_state=launch_failed/launch_orphaned"
+    )
 
 
 class SessionSummaryResponse(UTCBaseModel):
@@ -1127,6 +1135,9 @@ def build_session_response(
         ),
         loop_mode=_coerce_session_loop_mode(getattr(session, "loop_mode", None)),
         user_state=session.user_state or "active",
+        launch_state=getattr(session, "launch_state", None),
+        launch_error_code=getattr(session, "launch_error_code", None),
+        launch_error_message=getattr(session, "launch_error_message", None),
     )
 
 

--- a/server/zerg/services/session_views.py
+++ b/server/zerg/services/session_views.py
@@ -30,6 +30,9 @@ from zerg.services.session_capabilities import build_session_capabilities
 from zerg.services.session_capabilities import build_session_capability_display
 from zerg.services.session_capabilities import project_current_session_capabilities
 from zerg.services.session_capabilities import project_current_session_capabilities_from_facts
+from zerg.services.session_current_control import engine_bridge_attached
+from zerg.services.session_current_control import engine_control_online
+from zerg.services.session_current_control import with_engine_control_capability
 from zerg.services.session_liveness_facts import build_session_liveness_facts
 from zerg.services.session_runner_state import managed_runner_host_state
 from zerg.services.session_runtime import SessionRuntimeView
@@ -1030,17 +1033,27 @@ def build_session_response(
     match_score: float | None = None,
     binding_overlay=None,
     transcript_preview: TranscriptPreview | None = None,
+    owner_id: int | None = None,
 ) -> SessionResponse:
     cache = thread_cache if thread_cache is not None else {}
     thread_head_session_id, thread_continuation_count = get_thread_meta(store, session, cache)
     include_runtime = should_include_runtime_view(session=session, runtime_view=runtime_overlay)
     capability_flags = build_session_capabilities(session)
+    is_engine_control_online = engine_control_online(session, owner_id)
+    if is_engine_control_online:
+        capability_flags = with_engine_control_capability(
+            capability_flags,
+            engine_control_online=True,
+            engine_bridge_attached=engine_bridge_attached(runtime_overlay),
+        )
     binding_host_state = None
     binding_terminal_reason = None
     if binding_overlay is not None:
         binding_host_state = binding_overlay.host_state
         binding_terminal_reason = binding_overlay.terminal_reason
-    if capability_flags.live_control_available or capability_flags.host_reattach_available:
+    if is_engine_control_online:
+        binding_host_state = "online"
+    elif capability_flags.live_control_available or capability_flags.host_reattach_available:
         binding_host_state = managed_runner_host_state(store.db, session) or binding_host_state
     runtime_display = (
         build_session_runtime_display_response(

--- a/server/zerg/services/session_workspace.py
+++ b/server/zerg/services/session_workspace.py
@@ -31,6 +31,7 @@ def build_session_workspace(
     branch_mode: str = "head",
     limit: int = 100,
     timing: ServerTimingRecorder | None = None,
+    owner_id: int | None = None,
 ) -> SessionWorkspaceResponse:
     """Build the focused session, thread, and initial projected transcript page."""
     store = AgentsStore(db)
@@ -95,6 +96,7 @@ def build_session_workspace(
                 first_user_message=first_user_map.get(item.id),
                 binding_overlay=binding_overlay_map.get(item.id),
                 transcript_preview=transcript_preview_map.get(str(item.id)),
+                owner_id=owner_id,
             )
             for item in thread_sessions
         }
@@ -115,6 +117,7 @@ def build_session_workspace(
             first_user_message=first_user_map.get(session.id),
             binding_overlay=binding_overlay_map.get(session.id),
             transcript_preview=transcript_preview_map.get(str(session.id)),
+            owner_id=owner_id,
         )
 
     active_context_boundary_cache: dict[UUID, int | None] = {}

--- a/web/src/components/LaunchSessionModal.tsx
+++ b/web/src/components/LaunchSessionModal.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  ApiError,
+  launchRemoteSession,
+  listMachines,
+  type MachineDirectoryEntry,
+} from "../services/api";
+import { Button, Spinner } from "./ui";
+
+interface LaunchSessionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onLaunched: (sessionId: string) => void;
+}
+
+const PROVIDER = "codex"; // v1
+const LAUNCH_CAP = `${PROVIDER}.launch`;
+
+function machineCanLaunch(m: MachineDirectoryEntry): boolean {
+  return m.online && m.supports.includes(LAUNCH_CAP);
+}
+
+export default function LaunchSessionModal({
+  isOpen,
+  onClose,
+  onLaunched,
+}: LaunchSessionModalProps) {
+  const machinesQuery = useQuery({
+    queryKey: ["launch-machines"],
+    queryFn: listMachines,
+    enabled: isOpen,
+    refetchOnMount: "always",
+  });
+
+  const cwdInputRef = useRef<HTMLInputElement | null>(null);
+  const [deviceId, setDeviceId] = useState<string>("");
+  const [cwd, setCwd] = useState<string>("");
+  const [displayName, setDisplayName] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const launchable = useMemo(
+    () => machinesQuery.data?.machines.filter(machineCanLaunch) ?? [],
+    [machinesQuery.data],
+  );
+
+  // Auto-select the first launchable machine.
+  useEffect(() => {
+    if (!isOpen || !launchable.length || deviceId) return;
+    setDeviceId(launchable[0].device_id);
+  }, [isOpen, launchable, deviceId]);
+
+  // Clear state on close.
+  useEffect(() => {
+    if (isOpen) return;
+    setDeviceId("");
+    setCwd("");
+    setDisplayName("");
+    setSubmitting(false);
+    setError(null);
+  }, [isOpen]);
+
+  // Esc dismisses the modal.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isOpen, onClose]);
+
+  // Focus the cwd input once we have a launchable machine selected.
+  useEffect(() => {
+    if (!isOpen || !deviceId) return;
+    cwdInputRef.current?.focus();
+  }, [isOpen, deviceId]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!deviceId || !cwd.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await launchRemoteSession({
+        device_id: deviceId,
+        provider: PROVIDER,
+        cwd: cwd.trim(),
+        display_name: displayName.trim() || null,
+        client_request_id: `launch-${deviceId}-${Date.now()}`,
+      });
+      onLaunched(result.session_id);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("Launch failed");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [deviceId, cwd, displayName, onLaunched]);
+
+  if (!isOpen) return null;
+
+  const selectedMachine = launchable.find((m) => m.device_id === deviceId);
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal-container"
+        data-testid="launch-session-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h2>Start Session</h2>
+          <button
+            type="button"
+            className="modal-close-button"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="modal-content">
+          {machinesQuery.isPending ? (
+            <div className="modal-loading">
+              <Spinner size="md" />
+              <p>Loading machines…</p>
+            </div>
+          ) : machinesQuery.isError ? (
+            <p className="text-danger">Failed to load machines.</p>
+          ) : launchable.length === 0 ? (
+            <EmptyState machines={machinesQuery.data?.machines ?? []} />
+          ) : (
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                void handleSubmit();
+              }}
+            >
+              <label className="form-field">
+                <span>Machine</span>
+                <select
+                  value={deviceId}
+                  onChange={(e) => setDeviceId(e.target.value)}
+                  data-testid="launch-machine-select"
+                >
+                  {launchable.map((m) => (
+                    <option key={m.device_id} value={m.device_id}>
+                      {m.machine_name} {m.engine_build ? `(${m.engine_build})` : ""}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="form-field">
+                <span>Working directory on {selectedMachine?.machine_name ?? deviceId}</span>
+                <input
+                  ref={cwdInputRef}
+                  type="text"
+                  value={cwd}
+                  onChange={(e) => setCwd(e.target.value)}
+                  placeholder="/Users/you/git/your-repo"
+                  autoComplete="off"
+                  spellCheck={false}
+                  data-testid="launch-cwd-input"
+                />
+                <small>Must be absolute and under $HOME on the target machine.</small>
+              </label>
+
+              <label className="form-field">
+                <span>Display name (optional)</span>
+                <input
+                  type="text"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  placeholder="e.g. zerg — refactor launch"
+                  data-testid="launch-display-name"
+                />
+              </label>
+
+              {error && (
+                <p className="text-danger" data-testid="launch-error">
+                  {error}
+                </p>
+              )}
+
+              <div className="modal-actions">
+                <Button variant="ghost" onClick={onClose} type="button">
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  type="submit"
+                  disabled={submitting || !deviceId || !cwd.trim()}
+                  data-testid="launch-submit"
+                >
+                  {submitting ? "Starting…" : "Start"}
+                </Button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ machines }: { machines: MachineDirectoryEntry[] }) {
+  if (machines.length === 0) {
+    return (
+      <div className="modal-empty-state" data-testid="launch-no-machines">
+        <p>No enrolled machines yet.</p>
+        <p>
+          Install Longhouse on a machine with <code>longhouse connect</code> first. It will show up here once
+          it reports in.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="modal-empty-state" data-testid="launch-no-launchable">
+      <p>No machines are online with Codex support right now.</p>
+      <ul>
+        {machines.map((m) => (
+          <li key={m.device_id}>
+            <strong>{m.machine_name}</strong> — {m.online ? "online" : "offline"}
+            {!m.supports.includes(LAUNCH_CAP) ? " · does not advertise codex.launch" : ""}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/LaunchSessionModal.tsx
+++ b/web/src/components/LaunchSessionModal.tsx
@@ -91,7 +91,7 @@ export default function LaunchSessionModal({
         provider: PROVIDER,
         cwd: cwd.trim(),
         display_name: displayName.trim() || null,
-        client_request_id: `launch-${deviceId}-${Date.now()}`,
+        client_request_id: `launch-${crypto.randomUUID()}`,
       });
       onLaunched(result.session_id);
     } catch (err) {

--- a/web/src/components/__tests__/LaunchSessionModal.test.tsx
+++ b/web/src/components/__tests__/LaunchSessionModal.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import LaunchSessionModal from "../LaunchSessionModal";
+
+const apiMocks = vi.hoisted(() => ({
+  listMachines: vi.fn(),
+  launchRemoteSession: vi.fn(),
+}));
+
+vi.mock("../../services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/api")>();
+  return {
+    ...actual,
+    ...apiMocks,
+  };
+});
+
+function renderModal(props: Partial<React.ComponentProps<typeof LaunchSessionModal>> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const defaultProps: React.ComponentProps<typeof LaunchSessionModal> = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onLaunched: vi.fn(),
+    ...props,
+  };
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LaunchSessionModal {...defaultProps} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("LaunchSessionModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows an empty state when no machines are enrolled", async () => {
+    apiMocks.listMachines.mockResolvedValue({ machines: [] });
+
+    renderModal();
+
+    expect(await screen.findByTestId("launch-no-machines")).toBeInTheDocument();
+  });
+
+  it("shows offline-only state when no launchable machines are available", async () => {
+    apiMocks.listMachines.mockResolvedValue({
+      machines: [
+        {
+          device_id: "cinder",
+          machine_name: "cinder",
+          online: false,
+          supports: [],
+          last_seen_at: null,
+          engine_build: null,
+        },
+      ],
+    });
+    renderModal();
+    expect(await screen.findByTestId("launch-no-launchable")).toBeInTheDocument();
+  });
+
+  it("dismisses on Escape", async () => {
+    apiMocks.listMachines.mockResolvedValue({
+      machines: [
+        {
+          device_id: "cinder",
+          machine_name: "cinder",
+          online: true,
+          supports: ["codex.launch"],
+          last_seen_at: null,
+          engine_build: null,
+        },
+      ],
+    });
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderModal({ onClose });
+    await screen.findByTestId("launch-cwd-input");
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("submits a launch and invokes onLaunched with the session id", async () => {
+    apiMocks.listMachines.mockResolvedValue({
+      machines: [
+        {
+          device_id: "cinder",
+          machine_name: "cinder",
+          online: true,
+          supports: ["codex.launch"],
+          last_seen_at: "2026-05-12T13:00:00Z",
+          engine_build: "abc",
+        },
+      ],
+    });
+    apiMocks.launchRemoteSession.mockResolvedValue({
+      session_id: "new-session-id",
+      launch_state: "live",
+      launch_error_code: null,
+      launch_error_message: null,
+    });
+
+    const onLaunched = vi.fn();
+    const user = userEvent.setup();
+    renderModal({ onLaunched });
+
+    const cwdInput = await screen.findByTestId("launch-cwd-input");
+    await user.type(cwdInput, "/Users/me/repo");
+    await user.click(screen.getByTestId("launch-submit"));
+
+    await waitFor(() => expect(onLaunched).toHaveBeenCalledWith("new-session-id"));
+    expect(apiMocks.launchRemoteSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        device_id: "cinder",
+        provider: "codex",
+        cwd: "/Users/me/repo",
+      }),
+    );
+  });
+});

--- a/web/src/pages/SessionDetailPage.tsx
+++ b/web/src/pages/SessionDetailPage.tsx
@@ -218,12 +218,40 @@ function SessionDetailWorkspaceRoute({
       : "session-workspace-route--unmanaged",
   ].join(" ");
 
+  const launchPendingBanner = (() => {
+    const state = session.launch_state;
+    if (state === "launching" || state === "launching_unknown") {
+      return (
+        <div className="launch-pending-banner" role="status" data-testid="launch-pending-banner">
+          <Spinner size="sm" />
+          <span>
+            Starting session on {runtimeHostLabel}…{" "}
+            {state === "launching_unknown" ? "waiting for the machine to confirm." : ""}
+          </span>
+        </div>
+      );
+    }
+    if (state === "launch_failed" || state === "launch_orphaned") {
+      return (
+        <div className="launch-failed-banner" role="alert" data-testid="launch-failed-banner">
+          <strong>Launch failed</strong>
+          <span>
+            {session.launch_error_code ? `${session.launch_error_code}: ` : ""}
+            {session.launch_error_message || "The machine did not start this session."}
+          </span>
+        </div>
+      );
+    }
+    return null;
+  })();
+
   return (
     <div
       className={workspaceClassName}
       data-control-path={interaction.isManagedLocalSession ? "managed" : "unmanaged"}
       data-runtime-tone={runtime.tone}
     >
+      {launchPendingBanner}
       <WorkspaceShell
         sidebar={
           <SessionContextPane

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -39,6 +39,7 @@ import { useDebouncedValue } from "../hooks/useDebouncedValue";
 import { RecallPanel } from "../components/RecallPanel";
 import { SessionCard } from "../components/sessions/SessionCard";
 import { FilterChip, FilterPopover } from "../components/sessions/SessionsFilter";
+import LaunchSessionModal from "../components/LaunchSessionModal";
 import {
   type SortOrder,
   type SessionsUrlState,
@@ -360,6 +361,7 @@ export default function SessionsPage() {
     prefetchSessionWorkspace(thread.detail.id);
   }, [prefetchSessionWorkspace]);
 
+  const [launchModalOpen, setLaunchModalOpen] = useState(false);
   const headerActions = (
     <div className="sessions-header-actions">
       {threadCards.length > 0 && (
@@ -367,6 +369,14 @@ export default function SessionsPage() {
           {groupedQueryMode ? `${threadCards.length} results` : `${threadCards.length} tasks`}
         </span>
       )}
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={() => setLaunchModalOpen(true)}
+        data-testid="sessions-start-session"
+      >
+        Start session
+      </Button>
     </div>
   );
 
@@ -822,6 +832,14 @@ export default function SessionsPage() {
           </div>
         )}
       </div>
+      <LaunchSessionModal
+        isOpen={launchModalOpen}
+        onClose={() => setLaunchModalOpen(false)}
+        onLaunched={(sessionId) => {
+          setLaunchModalOpen(false);
+          navigate(`/timeline/${sessionId}`);
+        }}
+      />
     </PageShell>
   );
 }

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -538,6 +538,14 @@ export default function SessionsPage() {
                 <Button
                   variant="secondary"
                   size="md"
+                  onClick={() => setLaunchModalOpen(true)}
+                  data-testid="timeline-empty-start-session"
+                >
+                  Start session
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="md"
                   onClick={() => navigate("/runners")}
                   data-testid="timeline-empty-runner-action"
                 >
@@ -577,6 +585,14 @@ export default function SessionsPage() {
             </p>
           </div>
         </div>
+        <LaunchSessionModal
+          isOpen={launchModalOpen}
+          onClose={() => setLaunchModalOpen(false)}
+          onLaunched={(sessionId) => {
+            setLaunchModalOpen(false);
+            navigate(`/timeline/${sessionId}`);
+          }}
+        />
       </PageShell>
     );
   }

--- a/web/src/services/api/agents.ts
+++ b/web/src/services/api/agents.ts
@@ -68,6 +68,10 @@ export interface AgentSession {
   capabilities?: SessionCapabilities | null;
   loop_mode: SessionLoopMode;
   user_state?: string;
+  /** Remote-launch lifecycle state; null for sessions created before remote-launch. */
+  launch_state?: "launching" | "live" | "launching_unknown" | "launch_failed" | "launch_orphaned" | null;
+  launch_error_code?: string | null;
+  launch_error_message?: string | null;
 }
 
 export interface SessionTranscriptPreview {

--- a/web/src/services/api/base.ts
+++ b/web/src/services/api/base.ts
@@ -23,8 +23,18 @@ export class ApiError extends Error {
     let detailMessage = `Request failed (${status})`;
     if (isDemoReadOnlyBody(body)) {
       detailMessage = DEMO_READ_ONLY_MESSAGE;
-    } else if (body && typeof body === "object" && "detail" in body && typeof body.detail === "string") {
-      detailMessage = body.detail;
+    } else if (body && typeof body === "object" && "detail" in body) {
+      const detail = body.detail;
+      if (typeof detail === "string") {
+        detailMessage = detail;
+      } else if (
+        detail
+        && typeof detail === "object"
+        && "message" in detail
+        && typeof detail.message === "string"
+      ) {
+        detailMessage = detail.message;
+      }
     } else if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
       detailMessage = body.error;
     }

--- a/web/src/services/api/index.ts
+++ b/web/src/services/api/index.ts
@@ -8,3 +8,4 @@ export * from "./runners";
 export * from "./agents";
 export * from "./system";
 export * from "./sessionChat";
+export * from "./launch";

--- a/web/src/services/api/launch.ts
+++ b/web/src/services/api/launch.ts
@@ -1,0 +1,52 @@
+import { request } from "./base";
+
+export type MachineDirectoryEntry = {
+  device_id: string;
+  machine_name: string;
+  online: boolean;
+  supports: string[];
+  last_seen_at: string | null;
+  engine_build: string | null;
+};
+
+export type MachineDirectoryResponse = {
+  machines: MachineDirectoryEntry[];
+};
+
+export async function listMachines(): Promise<MachineDirectoryResponse> {
+  return request<MachineDirectoryResponse>("/timeline/machines");
+}
+
+export type LaunchState =
+  | "launching"
+  | "live"
+  | "launching_unknown"
+  | "launch_failed"
+  | "launch_orphaned";
+
+export type RemoteSessionLaunchRequest = {
+  device_id: string;
+  provider: string;
+  cwd: string;
+  git_repo?: string | null;
+  git_branch?: string | null;
+  project?: string | null;
+  display_name?: string | null;
+  client_request_id?: string | null;
+};
+
+export type RemoteSessionLaunchResponse = {
+  session_id: string;
+  launch_state: LaunchState;
+  launch_error_code: string | null;
+  launch_error_message: string | null;
+};
+
+export async function launchRemoteSession(
+  body: RemoteSessionLaunchRequest,
+): Promise<RemoteSessionLaunchResponse> {
+  return request<RemoteSessionLaunchResponse>("/sessions/launch", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}

--- a/web/src/styles/sessions.css
+++ b/web/src/styles/sessions.css
@@ -1537,6 +1537,31 @@
     color: var(--color-text-secondary);
   }
 
+  .launch-pending-banner,
+  .launch-failed-banner {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    margin: var(--space-3);
+    border-radius: var(--radius-md);
+    font-size: 0.9rem;
+  }
+
+  .launch-pending-banner {
+    background: color-mix(in srgb, rgba(100, 160, 220, 0.12) 80%, transparent);
+    border: 1px solid color-mix(in srgb, rgba(100, 160, 220, 0.28) 75%, transparent);
+    color: var(--color-text-secondary);
+  }
+
+  .launch-failed-banner {
+    background: color-mix(in srgb, rgba(220, 90, 90, 0.12) 80%, transparent);
+    border: 1px solid color-mix(in srgb, rgba(220, 90, 90, 0.32) 75%, transparent);
+    color: var(--color-text-primary);
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
   .session-branch-banner strong {
     color: var(--color-text-primary);
   }


### PR DESCRIPTION
## Summary
- add the owner-scoped machines directory and remote Codex session launch path
- add web and iOS launch sheets, launch-state UI, admin debug surface, reaper, and structured launch logs
- harden the dogfood path: headless Codex thread creation, cwd allowlist, launch idempotency, engine-control capability surfacing, and structured client error copy

## Release story
Longhouse can now start managed Codex sessions on an enrolled machine from browser or iOS, not just observe sessions that already exist. V1 is intentionally Codex-only, online-machine-only, and limited to git worktrees under `$HOME`.

## Validation
- `uv run pytest tests_lite/test_timeline_api_auth_boundary.py tests_lite/test_auth_domain_split.py tests_lite/test_remote_session_launch.py` — 37 passed
- `./run_backend_tests_lite.sh tests_lite/test_session_runtime.py tests_lite/test_remote_session_launch.py` — 67 passed
- `make test` — 1649 passed, 2 skipped
- `make test-engine` — passed
- `make test-frontend` — 258 passed, 4 skipped
- `xcodebuild -project ios/XcodeHarness/LonghouseIOS.xcodeproj -scheme Longhouse -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build` — BUILD SUCCEEDED
- GitHub CI run `25804054746` for `39b32749cb637c48a0eb8d6f83821daf1bd4a70b` — success, including backend, frontend/runner, engine, E2E, wheel packaging, OSS smoke, and iOS tests

## Dogfood notes
- After merge/ship, run `make dogfood-refresh` and restart the menu bar with `launchctl kickstart -k gui/$(id -u)/ai.longhouse.app`.
- iOS is not shipped by hosted deploy; David still needs to build/run from Xcode for device dogfooding.
