### PR TITLE
Promote interrupt to first-class composer button

### DIFF
--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -455,8 +455,8 @@ export function SessionChat({
     [queryClient, queuedInputsQuery, session.id],
   );
 
-  const handleInterruptStalledTurn = useCallback(async () => {
-    if (!isManagedLocal || !isStalled || isInterrupting) return;
+  const handleInterrupt = useCallback(async () => {
+    if (!isManagedLocal || isInterrupting) return;
     setIsInterrupting(true);
     setError(null);
     try {
@@ -469,14 +469,18 @@ export function SessionChat({
       });
       await refreshCurrentSessionWorkspace();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not interrupt stalled turn");
+      setError(e instanceof Error ? e.message : "Could not interrupt running turn");
     } finally {
       setIsInterrupting(false);
     }
-  }, [isInterrupting, isManagedLocal, isStalled, queryClient, refreshCurrentSessionWorkspace, session.id]);
+  }, [isInterrupting, isManagedLocal, queryClient, refreshCurrentSessionWorkspace, session.id]);
 
   const canSteerNow = isSendLocked && canSteerActiveTurn;
   const canQueueNow = isSendLocked && canQueueNextInput && !queueFull;
+  // Inline interrupt is offered for any locked managed-local turn. When the
+  // stall-recovery card is showing it already exposes the same action, so we
+  // hide the composer copy to avoid two buttons doing the identical thing.
+  const showInlineInterrupt = isManagedLocal && isSendLocked && !isStalled;
   // When steer is available, the primary action is steer. Queue-next becomes
   // a secondary escape hatch. If only queue is available, primary = queue.
   const primaryIntent: "auto" | "queue" | "steer" = !isSendLocked
@@ -726,7 +730,7 @@ export function SessionChat({
             type="button"
             variant="secondary"
             size="sm"
-            onClick={() => void handleInterruptStalledTurn()}
+            onClick={() => void handleInterrupt()}
             disabled={isInterrupting}
           >
             {isInterrupting ? "Interrupting" : "Interrupt"}
@@ -738,10 +742,10 @@ export function SessionChat({
         <div className="session-chat-turn-notice">
           <span>
             {canSteerNow
-              ? "Agent is working. Click Send update to inject mid-turn, or Queue next to wait — Enter will not send while working."
+              ? "Agent is working. Send update injects mid-turn, Queue next waits, Stop interrupts — Enter will not send while working."
               : canQueueNextInput
-              ? "Agent is working. Click Queue next to auto-send at the next turn boundary — Enter will not queue."
-              : "Agent is working. You can draft the next message; sending will be available when it is ready."}
+              ? "Agent is working. Queue next auto-sends at the next turn boundary, Stop interrupts — Enter will not queue."
+              : "Agent is working. Draft a message or Stop to interrupt; sending will be available when it is ready."}
           </span>
         </div>
       )}
@@ -926,6 +930,18 @@ export function SessionChat({
                   </Button>
                 ) : (
                   <>
+                    {showInlineInterrupt ? (
+                      <Button
+                        type="button"
+                        variant="danger"
+                        size="sm"
+                        onClick={() => void handleInterrupt()}
+                        disabled={isInterrupting}
+                        data-testid="session-chat-interrupt"
+                      >
+                        {isInterrupting ? "Stopping" : "Stop"}
+                      </Button>
+                    ) : null}
                     {canSteerNow && canQueueNow ? (
                       <Button
                         type="button"
@@ -967,6 +983,18 @@ export function SessionChat({
                     </Button>
                   ) : (
                     <>
+                      {showInlineInterrupt ? (
+                        <Button
+                          type="button"
+                          variant="danger"
+                          size="sm"
+                          onClick={() => void handleInterrupt()}
+                          disabled={isInterrupting}
+                          data-testid="session-chat-interrupt"
+                        >
+                          {isInterrupting ? "Stopping" : "Stop"}
+                        </Button>
+                      ) : null}
                       {canSteerNow && canQueueNow ? (
                         <Button
                           type="button"

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -477,10 +477,11 @@ export function SessionChat({
 
   const canSteerNow = isSendLocked && canSteerActiveTurn;
   const canQueueNow = isSendLocked && canQueueNextInput && !queueFull;
+  const canInterruptTurn = isManagedLocal && isSendLocked;
   // Inline interrupt is offered for any locked managed-local turn. When the
   // stall-recovery card is showing it already exposes the same action, so we
   // hide the composer copy to avoid two buttons doing the identical thing.
-  const showInlineInterrupt = isManagedLocal && isSendLocked && !isStalled;
+  const showInlineInterrupt = canInterruptTurn && !isStalled;
   // When steer is available, the primary action is steer. Queue-next becomes
   // a secondary escape hatch. If only queue is available, primary = queue.
   const primaryIntent: "auto" | "queue" | "steer" = !isSendLocked
@@ -621,6 +622,34 @@ export function SessionChat({
     : queueFull
     ? "Queue full"
     : "Waiting";
+  let turnNoticeText =
+    "Agent is working. You can draft the next message; sending will be available when it is ready.";
+  if (canSteerNow) {
+    if (canQueueNow && canInterruptTurn) {
+      turnNoticeText =
+        "Agent is working. Send update injects mid-turn, Queue next waits, Stop interrupts - Enter will not send while working.";
+    } else if (canInterruptTurn) {
+      turnNoticeText =
+        "Agent is working. Send update injects mid-turn, Stop interrupts - Enter will not send while working.";
+    } else if (canQueueNow) {
+      turnNoticeText =
+        "Agent is working. Send update injects mid-turn, or Queue next waits - Enter will not send while working.";
+    } else {
+      turnNoticeText =
+        "Agent is working. Send update injects mid-turn - Enter will not send while working.";
+    }
+  } else if (canQueueNow) {
+    turnNoticeText = canInterruptTurn
+      ? "Agent is working. Queue next auto-sends at the next turn boundary, Stop interrupts - Enter will not queue."
+      : "Agent is working. Queue next auto-sends at the next turn boundary - Enter will not queue.";
+  } else if (canQueueNextInput && queueFull) {
+    turnNoticeText = canInterruptTurn
+      ? "Agent is working. The queue is full, but Stop can interrupt the current turn."
+      : "Agent is working. The queue is full; sending will be available when space opens.";
+  } else if (canInterruptTurn) {
+    turnNoticeText =
+      "Agent is working. Draft a message or Stop to interrupt; sending will be available when it is ready.";
+  }
 
   const renderMessages = () =>
     messages.map((msg) => (
@@ -740,13 +769,7 @@ export function SessionChat({
 
       {isSendLocked && !isStreaming && !isStalled && (
         <div className="session-chat-turn-notice">
-          <span>
-            {canSteerNow
-              ? "Agent is working. Send update injects mid-turn, Queue next waits, Stop interrupts — Enter will not send while working."
-              : canQueueNextInput
-              ? "Agent is working. Queue next auto-sends at the next turn boundary, Stop interrupts — Enter will not queue."
-              : "Agent is working. Draft a message or Stop to interrupt; sending will be available when it is ready."}
-          </span>
+          <span>{turnNoticeText}</span>
         </div>
       )}
 

--- a/web/src/components/__tests__/SessionChat.test.tsx
+++ b/web/src/components/__tests__/SessionChat.test.tsx
@@ -194,10 +194,59 @@ describe("SessionChat", () => {
 
     const recovery = await screen.findByTestId("session-chat-stall-recovery");
     expect(recovery).toHaveTextContent(/managed session appears stalled/i);
-    expect(screen.queryByText(/click queue next to auto-send/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /stop/i })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /interrupt/i }));
     await waitFor(() => expect(interruptCalls).toBe(1));
+  });
+
+  it("shows an inline Stop button for locked managed-local sessions", async () => {
+    const user = userEvent.setup();
+    let interruptCalls = 0;
+    requestMock.mockImplementation((path: string, init?: RequestInit) => {
+      if (String(path).endsWith("/lock")) {
+        return Promise.resolve({ locked: true, fork_available: true });
+      }
+      if (String(path).endsWith("/interrupt-live") && init?.method === "POST") {
+        interruptCalls += 1;
+        return Promise.resolve({
+          interrupt_dispatched: true,
+          confirmed_stopped: false,
+          session_id: "sess-1",
+          exit_code: 0,
+          error: null,
+          released_lock: true,
+        });
+      }
+      return Promise.reject(new Error(`Unexpected request: ${path}`));
+    });
+
+    renderSessionChat({
+      chatMode: "managed_local",
+    });
+
+    expect(await screen.findByRole("button", { name: /stop/i })).toBeEnabled();
+    expect(screen.getByText(/stop to interrupt/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /stop/i }));
+    await waitFor(() => expect(interruptCalls).toBe(1));
+  });
+
+  it("does not mention Stop when a locked session is not interruptible", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData<SessionLockInfo | null>(["session-lock", "sess-1"], {
+      locked: true,
+      holder: null,
+      time_remaining_seconds: null,
+      fork_available: true,
+    });
+
+    renderSessionChat({}, { queryClient });
+
+    expect(screen.getByText(/you can draft the next message/i)).not.toHaveTextContent(/Stop/i);
+    expect(screen.queryByRole("button", { name: /stop/i })).not.toBeInTheDocument();
   });
 
   it("keeps the dock visible but replaces disabled composer controls when control is offline", () => {
@@ -537,8 +586,9 @@ describe("SessionChat", () => {
 
     // Lock notice adapts to the queue-next affordance.
     expect(
-      screen.getByText(/click queue next to auto-send/i),
+      screen.getByText(/queue next auto-sends at the next turn boundary/i),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /stop/i })).toBeEnabled();
 
     await user.type(screen.getByRole("textbox"), "wait for it");
     // Button says "Queue next" while working with queue capability, and is


### PR DESCRIPTION
## Summary
- Stop button now appears in both dock and panel composers whenever a managed-local session is locked, not only when the stall heuristic trips.
- Removes the artificial `isStalled` gate on the existing interrupt handler. Backend (`POST /sessions/{id}/interrupt-live`) and API client (`interruptLiveSession`) already supported the call — UI just wasn't surfacing it.
- Stall-recovery card hides the inline Stop while it is showing its own Interrupt button to avoid two buttons doing the same thing.
- Working-turn notice copy updated to mention Stop.

## Why
Coffee-shop scenario: spot the agent going off the rails from a phone, hit Stop without waiting for the stall heuristic to trip. Closes the audit's "promote interrupt to first-class" item.

## Test plan
- [ ] CI typecheck + tests green
- [ ] Manually verify Stop appears in dock composer while a managed-local session is locked and successfully interrupts
- [ ] Verify stall-recovery card still works and inline Stop is hidden when it is showing