### PR TITLE
Codex image attach: web + iOS + engine

### DIFF
--- a/docs/specs/codex-image-attach.md
+++ b/docs/specs/codex-image-attach.md
@@ -1,0 +1,171 @@
+# Codex image attach — working spec
+
+**Status:** working draft for the image-attach-feature branch.
+**Delete before merge:** yes (doc-sprawl rule).
+
+## Goal
+
+Let the web composer attach images to messages going to managed-local Codex
+sessions, so David can screenshot from a coffee shop and have Codex see what
+he's looking at — same as dragging an image into the local terminal.
+
+Codex only this iteration. Claude/opencode/antigravity get capability-gated
+"image attach not available on this provider" via the same pattern that
+already gates text send.
+
+## Why this is small
+
+Codex's app-server protocol already accepts image attachments natively:
+
+```rust
+pub enum UserInput {
+    Text { text, text_elements },
+    Image { url },                  // remote http(s)
+    LocalImage { path: PathBuf },   // local fs path — what we use
+    Skill { ... },
+    Mention { ... },
+}
+```
+
+Both `turn/start` and `turn/steer` take `input: Vec<UserInput>`. The Machine
+Agent runs on the same machine as the `codex` binary, so we hand it a local
+path and the codex binary handles loading. **No base64, no data URIs in IPC.**
+
+## Data flow
+
+```
+┌─────────────┐  POST multipart  ┌─────────────┐  command stamp  ┌──────────┐
+│ Web         │ ───────────────▶│ Runtime Host│ ──────────────▶│ Machine  │
+│ composer    │  text + files[] │             │  + attach refs  │ Agent    │
+└─────────────┘                 └─────────────┘                 └────┬─────┘
+                                  stores blobs                        │
+                                  TTL 24h                             │ HTTP fetch
+                                                                      ▼
+                                                              /tmp/lh-attach/
+                                                              {session}/{uuid}.png
+                                                                      │
+                                                                      ▼
+                                                              codex IPC
+                                                              UserInput::LocalImage
+```
+
+## Pieces
+
+### Backend (Runtime Host)
+
+- New table `session_input_attachments`:
+  - `id` (uuid pk)
+  - `session_input_id` (fk)
+  - `mime_type` (text)
+  - `byte_size` (int)
+  - `sha256` (text)
+  - `blob_path` (text — relative to attach blob root)
+  - `created_at`
+- `POST /sessions/{id}/inputs` becomes multipart:
+  - `text` field (required)
+  - `intent` (auto/queue/steer)
+  - `client_request_id`
+  - `attachments` (zero or more files)
+  - Validates: file count ≤ 4, each ≤ 5 MB, mime in {png, jpeg, webp, gif}
+- New `GET /api/agents/sessions/{id}/inputs/{input_id}/attachments/{attach_id}/blob`
+  - Machine-token auth (`X-Agents-Token`)
+  - Streams the blob bytes to the engine
+- Blob storage: `data/attachments/{session_id}/{attach_uuid}.bin` on the
+  Runtime Host filesystem. Self-host installs already manage `data/` for SQLite.
+- Cleanup: hourly job drops blobs whose parent `session_input` is in
+  status=delivered/failed AND older than 24h. Belt + braces: foreign-key
+  cascade on session_input row delete.
+- `QueuedInputSummary` API gains `attachment_count: int`.
+
+### Engine (Rust, longhouse-engine)
+
+- `IpcCommand::TurnStart` and `IpcCommand::Steer` payload extended with
+  optional `attachments: Vec<AttachmentRef>` where:
+  ```rust
+  struct AttachmentRef {
+      id: String,         // attachment uuid
+      mime_type: String,
+      blob_url: String,   // signed URL or RH path
+  }
+  ```
+- New helper `fetch_attachments_to_tmp(session_id, attachments) -> Vec<PathBuf>`:
+  - Authenticates with the existing machine token already used for shipping
+  - Writes to `/tmp/lh-attach/{session_id}/{uuid}.{ext}`
+  - Validates sha256 against the attachment row before yielding
+  - On success, builds `UserInput::LocalImage { path }` items and prepends them
+    to the existing `UserInput::Text { text }` item
+- Lifecycle: tmpfile cleanup on `Stop` IpcCommand and on engine shutdown.
+
+### Web (SessionChat.tsx)
+
+- Paperclip button next to the existing dock controls
+- Hidden `<input type="file" accept="image/png,image/jpeg,image/webp,image/gif" multiple>`
+- Paste handler: intercepts `ClipboardEvent` items with `kind === "file"` and
+  `type.startsWith("image/")`
+- Drag-drop on the messages area (whole panel becomes drop target while a file
+  drag is in progress)
+- Thumbnail strip above the textarea (chip-style: 64px square + filename + ×)
+- `postSessionInput` becomes multipart when attachments are present
+- Capability gate: only show paperclip when
+  `session.capabilities.attach_images === true` (new field, true only for
+  codex_app_server transport this iteration)
+
+### iOS
+
+Out of scope this iteration. iOS gets capability-gated to "not supported" and
+ships when David is ready to do an Xcode build for it.
+
+## Capability gate
+
+New field on `session_capabilities`:
+```python
+attach_images: bool  # True iff transport is codex_app_server
+```
+
+Computed in `session_capabilities.py` from the existing transport check.
+Rendered in `display_label` is **not** changed — keep the existing strings.
+
+## Errors and edge cases
+
+- Attachment blob fetch fails on engine → bridge surfaces "attachment unavailable"
+  in the IPC reply; UI shows the failed input row with `last_error="attachment_fetch_failed"`,
+  same UI pattern as existing failed-input chips.
+- User sends 0 attachments → behaves identically to today (no regression risk).
+- Sha256 mismatch on engine → treat as fetch failure; do not retry.
+- Image too large → 413 from upload endpoint; UI shows toast "Image too large
+  (max 5 MB)" before send.
+
+## What we deliberately do NOT do
+
+- Mid-turn image steer. Both providers accept images on user messages, so they
+  ride along with whatever text the user is sending. If the user adds an image
+  while the agent is mid-turn, that's a queued or steer input that already has
+  an explicit text component — the image just rides on the same row.
+- Image preview in the timeline beyond what Codex itself renders today (parser
+  already handles input_image and emits `[image attached]` placeholder text).
+  We can polish the timeline rendering in a follow-up.
+- Anti-virus scanning, EXIF stripping. David is the user; he can paste a
+  screenshot. Pre-launch.
+
+## Smoke test plan
+
+1. **Codex app_server**: paste a screenshot of an error log. Codex should
+   describe the error.
+2. **Codex WS relay**: same input, same expected behavior — proves the IPC
+   schema reaches the relay path too.
+3. **Claude / opencode / antigravity**: verify paperclip is hidden and
+   `attach_images=false` on the capability response.
+4. **Failure injection**: send with a corrupt blob (manually edit on RH);
+   verify failed-input chip surfaces.
+
+## Sequence of commits in the worktree
+
+1. Spec (this file).
+2. Backend: schema + multipart endpoint + tests_lite.
+3. Engine: IPC schema + LocalImage builder + Rust tests.
+4. **Codex review pause.**
+5. Web: composer UI + multipart client + vitest.
+6. Smoke test (Codex sessions on David's machine).
+7. **Final codex review pause.**
+8. Delete this spec.
+9. PR → main → merge → ship → dogfood-refresh.

--- a/docs/specs/codex-image-attach.md
+++ b/docs/specs/codex-image-attach.md
@@ -5,15 +5,55 @@
 
 ## Goal
 
-Let the web composer attach images to messages going to managed-local Codex
-sessions, so David can screenshot from a coffee shop and have Codex see what
-he's looking at — same as dragging an image into the local terminal.
+Web AND iOS composers can attach images to messages going to managed-local
+Codex sessions. Coffee-shop ergonomics: paste a screenshot, hit send, agent
+sees what you're looking at. Same as dragging an image into the local
+terminal, but from anywhere.
 
-Codex only this iteration. Claude/opencode/antigravity get capability-gated
-"image attach not available on this provider" via the same pattern that
-already gates text send.
+## Provider scope
 
-## Why this is small
+- **Codex** (`codex_app_server`, WS relay): full support.
+- **Claude / opencode / antigravity**: capability-gated to "image attach not
+  available on this provider" via the existing transport gate. Same UX
+  pattern as today's text-send guard.
+
+## The size problem (the actual user-journey risk)
+
+Sources of attached images, by frequency:
+
+| Source | Typical raw size | Risk |
+|---|---|---|
+| iPhone screenshot | 200 KB – 2 MB | Low |
+| iPhone photo (HEIC) | 2 – 5 MB | Medium |
+| macOS native screenshot (Cmd-Shift-4) | 1 – 3 MB | Low |
+| macOS full-screen retina screenshot | **3 – 8 MB** | **HIGH — kills coffee-shop wifi** |
+
+**Solution: client-side compression before upload, on every platform.**
+Compression is non-negotiable. A naive web flow that uploads a 6 MB retina
+PNG over coffee-shop 4G to a self-hosted home Mac mini is the user-journey
+killer.
+
+### Compression policy (web + iOS)
+
+- Target: longest edge ≤ **1568 px** (matches the inner resolution most
+  vision models downscale to anyway — anything larger is bandwidth waste).
+- Output format: **JPEG quality 0.85** for photos, **PNG** preserved when
+  the source has transparency.
+- Soft cap: target output ≤ **1 MB**. If first encode exceeds, drop to
+  quality 0.75 and re-encode once.
+- Hard reject: original > 20 MB before compression (pathological case;
+  rare; clearer error than silently OOM-ing).
+- EXIF stripped naturally via canvas/Core Graphics re-encode.
+- File metadata in upload: original filename, original byte size,
+  compressed byte size — surfaced in telemetry so we can tune.
+
+### Backend stays format-agnostic
+
+Backend just stores what the client sent. No server-side compression. Server
+limits: ≤ **2 MB per attachment** post-compression (with 100 KB headroom
+above the soft client cap), ≤ **4 attachments per input row**.
+
+## Why the engine integration is small
 
 Codex's app-server protocol already accepts image attachments natively:
 
@@ -28,53 +68,78 @@ pub enum UserInput {
 ```
 
 Both `turn/start` and `turn/steer` take `input: Vec<UserInput>`. The Machine
-Agent runs on the same machine as the `codex` binary, so we hand it a local
-path and the codex binary handles loading. **No base64, no data URIs in IPC.**
+Agent runs on the same box as the `codex` binary, so we hand it a local
+path and the codex binary handles loading. **No base64, no data URIs in
+IPC.**
 
-## Data flow
+## End-to-end data flow
 
 ```
 ┌─────────────┐  POST multipart  ┌─────────────┐  command stamp  ┌──────────┐
-│ Web         │ ───────────────▶│ Runtime Host│ ──────────────▶│ Machine  │
+│ Web/iOS     │ ───────────────▶│ Runtime Host│ ──────────────▶│ Machine  │
 │ composer    │  text + files[] │             │  + attach refs  │ Agent    │
-└─────────────┘                 └─────────────┘                 └────┬─────┘
-                                  stores blobs                        │
-                                  TTL 24h                             │ HTTP fetch
-                                                                      ▼
-                                                              /tmp/lh-attach/
-                                                              {session}/{uuid}.png
+│ (compressed)│                 └──────┬──────┘                 └────┬─────┘
+└─────────────┘                        │ stores blobs                │
+                                       │ TTL 24h                     │ HTTP fetch
+                                       ▼                             ▼
+                              data/attachments/...           /tmp/lh-attach/
+                                                             {session}/{uuid}.png
                                                                       │
                                                                       ▼
                                                               codex IPC
                                                               UserInput::LocalImage
 ```
 
-## Pieces
+## Modules (anti-sprawl discipline)
+
+Each piece lives in its own file. SessionChat.tsx is already 1000 lines;
+do not grow it.
+
+| Module | Purpose |
+|---|---|
+| `server/zerg/models/session_input_attachment.py` | SQLAlchemy model |
+| `server/zerg/services/session_input_attachments.py` | Lifecycle: create, fetch-by-id, cleanup-stale |
+| `server/zerg/routers/session_inputs_attachments.py` | Multipart upload endpoint + machine-token blob fetch endpoint |
+| `engine/src/codex_attachments.rs` | Fetch blob → tmpfile, sha256 verify, cleanup, build LocalImage items |
+| `web/src/lib/imageCompression.ts` | Pure function: File → compressed Blob + metadata |
+| `web/src/components/composer/AttachmentTray.tsx` | Thumbnail strip + remove × |
+| `web/src/components/composer/useComposerAttachments.ts` | Hook: paste/drop/picker → state |
+| `ios/Sources/Shared/ImageCompression.swift` | UIImage → compressed Data + metadata |
+| `ios/Sources/LonghouseApp/Composer/AttachmentTray.swift` | Same role as web tray |
+
+SessionChat.tsx grows by ≤ 50 lines: import the hook + tray, pipe through
+multipart args. iOS Composer view: same.
+
+## Pieces, in detail
 
 ### Backend (Runtime Host)
 
 - New table `session_input_attachments`:
   - `id` (uuid pk)
-  - `session_input_id` (fk)
+  - `session_input_id` (fk, cascade)
   - `mime_type` (text)
   - `byte_size` (int)
   - `sha256` (text)
   - `blob_path` (text — relative to attach blob root)
+  - `original_filename` (text, nullable)
+  - `original_byte_size` (int, nullable)
   - `created_at`
-- `POST /sessions/{id}/inputs` becomes multipart:
-  - `text` field (required)
-  - `intent` (auto/queue/steer)
-  - `client_request_id`
-  - `attachments` (zero or more files)
-  - Validates: file count ≤ 4, each ≤ 5 MB, mime in {png, jpeg, webp, gif}
-- New `GET /api/agents/sessions/{id}/inputs/{input_id}/attachments/{attach_id}/blob`
+- Schema migration via the existing `_auto_add_missing_columns()` path.
+- `POST /sessions/{id}/inputs` becomes multipart (alongside existing JSON):
+  - `text`, `intent`, `client_request_id` as form fields
+  - `attachments` as files (zero or more)
+  - Validates: file count ≤ 4, each ≤ 2 MB, mime in {png, jpeg, webp, gif}
+  - JSON content-type still works (no attachments) — backwards compatible.
+- `GET /api/agents/sessions/{sid}/inputs/{iid}/attachments/{aid}/blob`
   - Machine-token auth (`X-Agents-Token`)
-  - Streams the blob bytes to the engine
-- Blob storage: `data/attachments/{session_id}/{attach_uuid}.bin` on the
-  Runtime Host filesystem. Self-host installs already manage `data/` for SQLite.
-- Cleanup: hourly job drops blobs whose parent `session_input` is in
-  status=delivered/failed AND older than 24h. Belt + braces: foreign-key
-  cascade on session_input row delete.
+  - Streams the blob bytes
+  - 404 on missing/wrong session/wrong input — never leaks across sessions
+- Blob storage: `data/attachments/{session_id}/{attach_uuid}.bin`. Self-host
+  installs already manage `data/`. Hosted instance: this dir is in the
+  Coolify volume mount alongside SQLite.
+- Cleanup job: hourly, drops blobs whose parent `session_input` is in
+  status=delivered/failed AND older than 24h. Foreign-key cascade also
+  deletes blobs when a session_input is hard-deleted.
 - `QueuedInputSummary` API gains `attachment_count: int`.
 
 ### Engine (Rust, longhouse-engine)
@@ -85,87 +150,150 @@ path and the codex binary handles loading. **No base64, no data URIs in IPC.**
   struct AttachmentRef {
       id: String,         // attachment uuid
       mime_type: String,
-      blob_url: String,   // signed URL or RH path
+      sha256: String,
+      blob_url: String,   // RH https URL
   }
   ```
-- New helper `fetch_attachments_to_tmp(session_id, attachments) -> Vec<PathBuf>`:
-  - Authenticates with the existing machine token already used for shipping
-  - Writes to `/tmp/lh-attach/{session_id}/{uuid}.{ext}`
-  - Validates sha256 against the attachment row before yielding
-  - On success, builds `UserInput::LocalImage { path }` items and prepends them
-    to the existing `UserInput::Text { text }` item
-- Lifecycle: tmpfile cleanup on `Stop` IpcCommand and on engine shutdown.
+- New module `codex_attachments.rs`:
+  - `fetch_attachments_to_tmp(session_id, attachments) -> Vec<PathBuf>`:
+    - Authenticates with the existing machine token from shipping client
+    - Writes to `/tmp/lh-attach/{session_id}/{uuid}.{ext}` (mode 0600)
+    - Validates sha256 against the attachment row before yielding
+    - Cleans tmpdir on engine shutdown and on `Stop` IpcCommand
+  - `build_user_input_items(text, paths) -> Vec<Value>`:
+    - Builds `UserInput::LocalImage { path }` items first, then the
+      `UserInput::Text { text }` item — matches CLI's drag-drop ordering.
+    - When `text` is empty AND attachments present, sends a single
+      `UserInput::Text { text: "" }` text element so codex always has a
+      conversational anchor (prevents some app-server edge cases).
+- Existing `handle_ipc_turn_start` / `handle_ipc_steer` call the helpers
+  before invoking `send_request_with_runtime`.
 
-### Web (SessionChat.tsx)
+### Web (composer)
 
-- Paperclip button next to the existing dock controls
-- Hidden `<input type="file" accept="image/png,image/jpeg,image/webp,image/gif" multiple>`
-- Paste handler: intercepts `ClipboardEvent` items with `kind === "file"` and
-  `type.startsWith("image/")`
-- Drag-drop on the messages area (whole panel becomes drop target while a file
-  drag is in progress)
-- Thumbnail strip above the textarea (chip-style: 64px square + filename + ×)
-- `postSessionInput` becomes multipart when attachments are present
-- Capability gate: only show paperclip when
-  `session.capabilities.attach_images === true` (new field, true only for
-  codex_app_server transport this iteration)
+- `useComposerAttachments()` hook: file-picker open, paste handler on the
+  composer textarea, drag-drop on the panel container.
+- Compression runs in a Web Worker (off the main thread) so a 6 MB retina
+  PNG doesn't freeze the composer for 500 ms.
+  - `web/src/lib/imageCompression.worker.ts`
+  - Falls back to inline compression if Worker init fails (Safari edge
+    cases).
+- `AttachmentTray` renders thumbnails as data-URLs (small, after
+  compression — ≤ 1 MB total in memory worst case).
+- Paperclip button: hidden when `session.capabilities.attach_images === false`.
+- Send: when attachments present, FormData; otherwise existing JSON POST.
 
-### iOS
+### iOS (composer)
 
-Out of scope this iteration. iOS gets capability-gated to "not supported" and
-ships when David is ready to do an Xcode build for it.
+- `ImageCompression.swift`:
+  - `compress(image: UIImage, sourceFilename: String?) -> AttachmentPayload`
+  - Uses `UIGraphicsImageRenderer` for resize, `jpegData(compressionQuality:)`
+    for encode. PNG preserved only if image has alpha.
+- Picker:
+  - `PHPickerViewController` (multi-select up to 4)
+  - "Take photo" via existing camera intent if any (otherwise PHPicker only
+    is fine for this iteration)
+  - Paste via `UIPasteboard` — supported in the existing composer textarea.
+- Multipart upload through the existing session-input mirror.
+- iOS does NOT deploy on push. David Xcode-builds when ready. Spec is
+  explicit: iOS code lands in worktree, smoke test happens locally on
+  David's phone.
 
 ## Capability gate
 
 New field on `session_capabilities`:
 ```python
-attach_images: bool  # True iff transport is codex_app_server
+attach_images: bool  # True iff transport in {codex_app_server, codex_ws_relay}
 ```
 
 Computed in `session_capabilities.py` from the existing transport check.
-Rendered in `display_label` is **not** changed — keep the existing strings.
+Surfaces as `session.capabilities.attach_images` on the API. Web and iOS
+both check this before showing attach affordances.
+
+## Telemetry
+
+Three layers, lightweight:
+
+1. **Client-side timings** (web + iOS), emitted through existing
+   `/api/observability/client-event` (or equivalent — verify endpoint):
+   - `image_attach.compress_ms` (per file)
+   - `image_attach.compress_ratio` (compressed / original)
+   - `image_attach.upload_ms` (multipart total)
+   - `image_attach.attachment_count`
+2. **Server-side**:
+   - Structured log line at upload completion: bytes received, count, sha256.
+   - Metric counter `session_input_attachments_uploaded_total{provider}`.
+   - Metric histogram `session_input_attachments_blob_size_bytes`.
+3. **Engine-side**:
+   - Structured log on each `fetch_attachments_to_tmp`: blob URL, bytes
+     fetched, fetch_ms, sha256 verify_ms.
+   - Counter `engine_attachments_fetched_total{result}` where result is
+     `ok|sha256_mismatch|http_error`.
+
+These hook into existing observability paths — no new dashboards required
+for v1, just searchable logs and counters.
 
 ## Errors and edge cases
 
-- Attachment blob fetch fails on engine → bridge surfaces "attachment unavailable"
-  in the IPC reply; UI shows the failed input row with `last_error="attachment_fetch_failed"`,
-  same UI pattern as existing failed-input chips.
-- User sends 0 attachments → behaves identically to today (no regression risk).
-- Sha256 mismatch on engine → treat as fetch failure; do not retry.
-- Image too large → 413 from upload endpoint; UI shows toast "Image too large
-  (max 5 MB)" before send.
+| Case | Behavior |
+|---|---|
+| Pre-compression file > 20 MB | Reject in client with toast: "Image too large (max 20 MB before compression)" |
+| Compressed blob > 2 MB after retry | Reject: "Image still too large after compression — try a smaller crop" |
+| Network failure during upload | Standard fetch retry once with exponential backoff; on second failure, show inline error on the input chip with retry button |
+| Engine fetch fails (network/404/sha mismatch) | IPC reply includes `attachment_fetch_failed`; UI shows failed-input chip with `last_error="attachment_fetch_failed"` (existing pattern) |
+| User sends with 0 attachments | Identical to today's JSON path — no regression |
+| Image format not in allowlist | Client rejects before upload with toast |
+| Backend disk full on blob write | 500 with clear error code; client retries once; if still 500, surface "storage unavailable" (operator alert) |
+| RH restarts mid-upload | Multipart fails cleanly; row not created; client retries |
+| Engine restarts after blob fetch but before turn/start | tmpdir cleanup on startup wipes orphans; row gets re-fetched on retry |
 
 ## What we deliberately do NOT do
 
-- Mid-turn image steer. Both providers accept images on user messages, so they
-  ride along with whatever text the user is sending. If the user adds an image
-  while the agent is mid-turn, that's a queued or steer input that already has
-  an explicit text component — the image just rides on the same row.
-- Image preview in the timeline beyond what Codex itself renders today (parser
-  already handles input_image and emits `[image attached]` placeholder text).
-  We can polish the timeline rendering in a follow-up.
-- Anti-virus scanning, EXIF stripping. David is the user; he can paste a
-  screenshot. Pre-launch.
+- Mid-turn image-only steer. Images ride on text input rows (turn/start or
+  turn/steer). Adding a "send image with no text" button is a user-confusion
+  trap and a separate provider verb.
+- Image preview rendering in the timeline beyond the existing Codex
+  `[image attached]` placeholder. Polish in a follow-up if it actually
+  matters.
+- Anti-virus, EXIF inspection beyond stripping via re-encode. Pre-launch,
+  one user.
+- A pluggable abstraction for future providers. Codex is the only provider
+  with an enum-typed image input. When/if Claude grows one, we extend then.
+- Server-side recompression. Trust the client; verify with sha256.
+- Image search / "find that screenshot from last week." Not in scope.
 
 ## Smoke test plan
 
-1. **Codex app_server**: paste a screenshot of an error log. Codex should
-   describe the error.
-2. **Codex WS relay**: same input, same expected behavior — proves the IPC
-   schema reaches the relay path too.
-3. **Claude / opencode / antigravity**: verify paperclip is hidden and
-   `attach_images=false` on the capability response.
-4. **Failure injection**: send with a corrupt blob (manually edit on RH);
-   verify failed-input chip surfaces.
+End-to-end, on David's machine:
+
+1. **Web → Codex app_server**: paste a screenshot of an error log.
+   Expect Codex to describe the error.
+2. **Web → Codex WS relay**: same, different transport. Proves the
+   IPC schema reaches the relay path.
+3. **iOS → Codex**: take a screenshot on phone, attach in app, send.
+   Expect same agent response.
+4. **macOS retina full-screen**: 6 MB+ source PNG. Verify compression
+   keeps it ≤ 1 MB upload, total UX < 3 s on home wifi.
+5. **Capability gate**: launch a Claude session, verify paperclip is
+   hidden and `attach_images=false` on the capability response. Same
+   for opencode and antigravity.
+6. **Failure injection**: corrupt the blob on RH between upload and
+   engine fetch; verify failed-input chip surfaces cleanly.
+
+Telemetry sanity check after smokes: verify all three layers emitted
+events for at least one successful end-to-end flow.
 
 ## Sequence of commits in the worktree
 
-1. Spec (this file).
-2. Backend: schema + multipart endpoint + tests_lite.
-3. Engine: IPC schema + LocalImage builder + Rust tests.
-4. **Codex review pause.**
-5. Web: composer UI + multipart client + vitest.
-6. Smoke test (Codex sessions on David's machine).
-7. **Final codex review pause.**
-8. Delete this spec.
-9. PR → main → merge → ship → dogfood-refresh.
+1. **DONE** Spec (this file).
+2. Backend: schema + multipart endpoint + machine-token blob endpoint + tests_lite.
+3. Engine: IPC schema + LocalImage builder + Rust unit tests.
+4. **Codex review pause** (hatch_codex on backend+engine diff).
+5. Web: imageCompression.worker.ts + AttachmentTray + useComposerAttachments + SessionChat wiring + vitest.
+6. iOS: ImageCompression.swift + AttachmentTray.swift + composer wiring.
+7. Telemetry hookup across all three layers.
+8. Smoke test (David).
+9. **Final codex review pause** (hatch_codex on full diff).
+10. Delete this spec.
+11. PR → main → CI → merge → ship → dogfood-refresh. iOS: explicit
+    Xcode-build prompt to David.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "signal-hook",
  "temp-env",
  "tempfile",
@@ -1927,6 +1928,17 @@ name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -61,6 +61,9 @@ chrono = { version = "0.4", features = ["serde"] }
 # UUID
 uuid = { version = "1", features = ["v4", "v5"] }
 
+# Hashing (attachment sha256 verify)
+sha2 = "0.10"
+
 # Signal handling
 signal-hook = "0.3"
 

--- a/engine/src/codex_attachments.rs
+++ b/engine/src/codex_attachments.rs
@@ -10,13 +10,14 @@
 //! Codex itself loads the file off disk — we never hand it base64.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 const ATTACHMENT_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 const TMP_ROOT_NAME: &str = "lh-attach";
@@ -63,24 +64,52 @@ pub fn parse_attachments(request: &Value) -> Result<Vec<AttachmentRef>> {
     for (idx, item) in array.iter().enumerate() {
         let parsed: AttachmentRef = serde_json::from_value(item.clone())
             .with_context(|| format!("attachments[{idx}] is not a valid AttachmentRef"))?;
-        if parsed.id.trim().is_empty() {
-            bail!("attachments[{idx}].id is empty");
+        if Uuid::parse_str(&parsed.id).is_err() {
+            bail!("attachments[{idx}].id is not a valid UUID");
         }
-        if parsed.sha256.len() != 64 {
+        if parsed.sha256.len() != 64 || !parsed.sha256.chars().all(|c| c.is_ascii_hexdigit()) {
             bail!("attachments[{idx}].sha256 must be 64 hex chars");
         }
-        if parsed.blob_url.trim().is_empty() {
-            bail!("attachments[{idx}].blob_url is empty");
-        }
+        validate_blob_url(&parsed.blob_url)
+            .with_context(|| format!("attachments[{idx}].blob_url"))?;
         out.push(parsed);
     }
     Ok(out)
 }
 
+/// Reject anything that isn't a relative path under `/api/agents/`.
+///
+/// The engine forwards `X-Agents-Token` to whatever URL we resolve, so an
+/// absolute URL — even with the right scheme — would let a leaked or
+/// malformed payload exfiltrate the machine token. Keeping this strict
+/// also means tests can only assert one canonical resolution path.
+fn validate_blob_url(blob_url: &str) -> Result<()> {
+    let trimmed = blob_url.trim();
+    if trimmed.is_empty() {
+        bail!("is empty");
+    }
+    if !trimmed.starts_with('/') {
+        bail!("must be a relative path starting with '/'");
+    }
+    if !trimmed.starts_with("/api/agents/") {
+        bail!("must point at /api/agents/");
+    }
+    if trimmed.contains("..") {
+        bail!("must not contain '..'");
+    }
+    Ok(())
+}
+
 /// Per-session tmpdir for attachment blobs. Lives under `$TMPDIR/lh-attach`
-/// so cleanup on engine restart is straightforward.
+/// so cleanup on engine restart is straightforward. Session id is verified
+/// to be a UUID before reaching here so `..` / `/` can never escape.
 pub fn session_tmpdir(session_id: &str) -> PathBuf {
     std::env::temp_dir().join(TMP_ROOT_NAME).join(session_id)
+}
+
+/// Root tmpdir for all sessions. Used by startup orphan cleanup.
+pub fn tmp_root() -> PathBuf {
+    std::env::temp_dir().join(TMP_ROOT_NAME)
 }
 
 fn extension_for_mime(mime: &str) -> &'static str {
@@ -93,20 +122,14 @@ fn extension_for_mime(mime: &str) -> &'static str {
     }
 }
 
-/// Resolve `blob_url` against the engine's configured `api_url`. Absolute
-/// URLs (`https://...`) pass through unchanged; relative paths starting
-/// with `/` are joined onto the api base so the backend doesn't need to
-/// know what hostname the engine actually reaches it at.
+/// Resolve `blob_url` against the engine's configured `api_url`.
+/// `validate_blob_url` already enforced relative + `/api/agents/` prefix,
+/// so we just join here. The backend never has to know what hostname the
+/// engine actually reaches it at, and we never send the machine token to
+/// an arbitrary origin.
 fn resolve_blob_url(api_url: &str, blob_url: &str) -> String {
-    if blob_url.starts_with("http://") || blob_url.starts_with("https://") {
-        return blob_url.to_string();
-    }
     let base = api_url.trim_end_matches('/');
-    if blob_url.starts_with('/') {
-        format!("{base}{blob_url}")
-    } else {
-        format!("{base}/{blob_url}")
-    }
+    format!("{base}{blob_url}")
 }
 
 /// Fetch one attachment over HTTP, verify sha256, and write it under
@@ -118,6 +141,13 @@ pub async fn fetch_one(
     session_id: &str,
     attachment: &AttachmentRef,
 ) -> Result<FetchedAttachment> {
+    if Uuid::parse_str(session_id).is_err() {
+        bail!("session_id {session_id:?} is not a valid UUID");
+    }
+    if Uuid::parse_str(&attachment.id).is_err() {
+        bail!("attachment id {:?} is not a valid UUID", attachment.id);
+    }
+    validate_blob_url(&attachment.blob_url)?;
     let started = Instant::now();
     let resolved_url = resolve_blob_url(api_url, &attachment.blob_url);
     let response = http
@@ -163,16 +193,15 @@ pub async fn fetch_one(
     }
 
     let dir = session_tmpdir(session_id);
-    fs::create_dir_all(&dir)
+    create_dir_owner_only(&dir)
         .with_context(|| format!("creating attachment tmpdir {}", dir.display()))?;
     let path = dir.join(format!(
         "{}.{}",
         attachment.id,
         extension_for_mime(&attachment.mime_type)
     ));
-    fs::write(&path, &bytes)
+    write_owner_only(&path, &bytes)
         .with_context(|| format!("writing attachment blob {}", path.display()))?;
-    set_owner_only_perms(&path)?;
 
     let elapsed_ms = started.elapsed().as_millis();
     eprintln!(
@@ -192,16 +221,41 @@ pub async fn fetch_one(
 }
 
 #[cfg(unix)]
-fn set_owner_only_perms(path: &Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut perms = fs::metadata(path)?.permissions();
-    perms.set_mode(0o600);
-    fs::set_permissions(path, perms)?;
+fn create_dir_owner_only(dir: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    if dir.exists() {
+        return Ok(());
+    }
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700);
+    builder.create(dir)?;
     Ok(())
 }
 
 #[cfg(not(unix))]
-fn set_owner_only_perms(_path: &Path) -> Result<()> {
+fn create_dir_owner_only(dir: &std::path::Path) -> Result<()> {
+    fs::create_dir_all(dir)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_owner_only(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_owner_only(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
+    fs::write(path, bytes)?;
     Ok(())
 }
 
@@ -267,6 +321,30 @@ pub fn cleanup_session_tmpdir(session_id: &str) {
     }
 }
 
+/// Wipe every per-session attachment tmpdir under `$TMPDIR/lh-attach`.
+///
+/// Called once at engine startup. A previous engine process may have
+/// crashed mid-turn and left blobs on disk; we'd rather drop them than
+/// leak them into a fresh session by accident.
+pub fn cleanup_orphan_tmpdirs() {
+    let root = tmp_root();
+    if !root.exists() {
+        return;
+    }
+    match fs::remove_dir_all(&root) {
+        Ok(_) => {
+            eprintln!("[codex-attach] cleared orphan tmpdir {}", root.display());
+        }
+        Err(err) => {
+            eprintln!(
+                "[codex-attach] startup cleanup of {} failed: {}",
+                root.display(),
+                err
+            );
+        }
+    }
+}
+
 /// Build the `input` array for `turn/start` / `turn/steer`. LocalImage
 /// items come first, then a Text item — matches Codex's CLI drag-drop
 /// ordering. When `text` is empty and there are attachments, we still
@@ -305,45 +383,89 @@ mod tests {
         assert!(parse_attachments(&req).unwrap().is_empty());
     }
 
+    fn sample_id() -> String {
+        Uuid::new_v4().to_string()
+    }
+
+    fn sample_blob_url(id: &str) -> String {
+        format!(
+            "/api/agents/sessions/{}/inputs/1/attachments/{}/blob",
+            sample_id(),
+            id,
+        )
+    }
+
     #[test]
     fn parse_attachments_round_trips_one() {
+        let id = sample_id();
         let sha = "a".repeat(64);
         let req = json!({
             "attachments": [{
-                "id": "abc",
+                "id": id,
                 "mime_type": "image/png",
                 "sha256": sha,
-                "blob_url": "https://example/x",
+                "blob_url": sample_blob_url(&id),
             }]
         });
         let parsed = parse_attachments(&req).unwrap();
         assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].id, "abc");
+        assert_eq!(parsed[0].id, id);
         assert_eq!(parsed[0].mime_type, "image/png");
     }
 
     #[test]
     fn parse_attachments_rejects_short_sha() {
+        let id = sample_id();
         let req = json!({
             "attachments": [{
-                "id": "abc",
+                "id": id,
                 "mime_type": "image/png",
                 "sha256": "short",
-                "blob_url": "https://example/x",
+                "blob_url": sample_blob_url(&id),
             }]
         });
         assert!(parse_attachments(&req).is_err());
     }
 
     #[test]
-    fn parse_attachments_rejects_empty_id() {
+    fn parse_attachments_rejects_non_uuid_id() {
         let sha = "a".repeat(64);
         let req = json!({
             "attachments": [{
-                "id": "",
+                "id": "../etc/passwd",
                 "mime_type": "image/png",
                 "sha256": sha,
-                "blob_url": "https://example/x",
+                "blob_url": "/api/agents/sessions/x/inputs/1/attachments/y/blob",
+            }]
+        });
+        assert!(parse_attachments(&req).is_err());
+    }
+
+    #[test]
+    fn parse_attachments_rejects_absolute_blob_url() {
+        let id = sample_id();
+        let sha = "a".repeat(64);
+        let req = json!({
+            "attachments": [{
+                "id": id,
+                "mime_type": "image/png",
+                "sha256": sha,
+                "blob_url": "https://attacker.example/api/agents/sessions/x/blob",
+            }]
+        });
+        assert!(parse_attachments(&req).is_err());
+    }
+
+    #[test]
+    fn parse_attachments_rejects_path_traversal() {
+        let id = sample_id();
+        let sha = "a".repeat(64);
+        let req = json!({
+            "attachments": [{
+                "id": id,
+                "mime_type": "image/png",
+                "sha256": sha,
+                "blob_url": "/api/agents/../private",
             }]
         });
         assert!(parse_attachments(&req).is_err());
@@ -398,18 +520,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_blob_url_passes_absolute_through() {
-        assert_eq!(
-            resolve_blob_url("https://api.example", "https://other/x.bin"),
-            "https://other/x.bin"
-        );
-        assert_eq!(
-            resolve_blob_url("https://api.example", "http://internal/x.bin"),
-            "http://internal/x.bin"
-        );
-    }
-
-    #[test]
     fn resolve_blob_url_joins_relative_path() {
         assert_eq!(
             resolve_blob_url("https://api.example", "/api/agents/sessions/s/inputs/1/blob"),
@@ -417,10 +527,6 @@ mod tests {
         );
         assert_eq!(
             resolve_blob_url("https://api.example/", "/api/agents/x"),
-            "https://api.example/api/agents/x"
-        );
-        assert_eq!(
-            resolve_blob_url("https://api.example/", "api/agents/x"),
             "https://api.example/api/agents/x"
         );
     }

--- a/engine/src/codex_attachments.rs
+++ b/engine/src/codex_attachments.rs
@@ -271,6 +271,7 @@ pub async fn fetch_all(
     if attachments.is_empty() {
         return Ok(Vec::new());
     }
+    let started = Instant::now();
     let mut handles = Vec::with_capacity(attachments.len());
     for attachment in attachments {
         let http = http.clone();
@@ -301,8 +302,23 @@ pub async fn fetch_all(
     }
     if let Some(err) = first_err {
         cleanup_session_tmpdir(session_id);
+        eprintln!(
+            "[codex-attach] fetch_all failed session={} count={} elapsed_ms={} error={}",
+            session_id,
+            attachments.len(),
+            started.elapsed().as_millis(),
+            err
+        );
         return Err(err);
     }
+    let total_bytes: usize = fetched.iter().map(|f| f.bytes).sum();
+    eprintln!(
+        "[codex-attach] fetch_all ok session={} count={} total_bytes={} elapsed_ms={}",
+        session_id,
+        fetched.len(),
+        total_bytes,
+        started.elapsed().as_millis()
+    );
     Ok(fetched)
 }
 

--- a/engine/src/codex_attachments.rs
+++ b/engine/src/codex_attachments.rs
@@ -1,0 +1,436 @@
+//! Image attachment fetch + LocalImage payload builder for the codex bridge.
+//!
+//! The runtime host stores attachment blobs and stamps their machine URLs
+//! into the IPC payload that the backend hands to `codex-bridge send`.
+//! This module pulls the bytes back over `X-Agents-Token`, writes them
+//! into a per-session tmpdir, verifies sha256 against the runtime-host
+//! row, and returns paths the bridge can hand to Codex via
+//! `UserInput::LocalImage`.
+//!
+//! Codex itself loads the file off disk — we never hand it base64.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+const ATTACHMENT_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
+const TMP_ROOT_NAME: &str = "lh-attach";
+const MAX_BLOB_BYTES: usize = 4 * 1024 * 1024; // 2 MB server cap + ample headroom
+
+/// Reference to a single blob the engine should fetch from the runtime
+/// host before invoking turn/start or turn/steer.
+///
+/// Mirrors the JSON the backend stamps into the IPC payload:
+/// `{"id": "...", "mime_type": "image/png", "sha256": "...", "blob_url": "https://..."}`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AttachmentRef {
+    pub id: String,
+    pub mime_type: String,
+    pub sha256: String,
+    pub blob_url: String,
+}
+
+/// Outcome of fetching one attachment to disk.
+#[derive(Debug, Clone)]
+pub struct FetchedAttachment {
+    pub id: String,
+    pub mime_type: String,
+    pub path: PathBuf,
+    pub bytes: usize,
+}
+
+/// Parse the optional `attachments` array from an IPC request.
+///
+/// Returns `Ok(vec![])` when the array is missing or empty so the no-image
+/// path stays a free zero-overhead branch. Surfaces a clear error when the
+/// shape is wrong rather than silently dropping fields.
+pub fn parse_attachments(request: &Value) -> Result<Vec<AttachmentRef>> {
+    let Some(value) = request.get("attachments") else {
+        return Ok(Vec::new());
+    };
+    if value.is_null() {
+        return Ok(Vec::new());
+    }
+    let array = value
+        .as_array()
+        .context("'attachments' must be a JSON array")?;
+    let mut out = Vec::with_capacity(array.len());
+    for (idx, item) in array.iter().enumerate() {
+        let parsed: AttachmentRef = serde_json::from_value(item.clone())
+            .with_context(|| format!("attachments[{idx}] is not a valid AttachmentRef"))?;
+        if parsed.id.trim().is_empty() {
+            bail!("attachments[{idx}].id is empty");
+        }
+        if parsed.sha256.len() != 64 {
+            bail!("attachments[{idx}].sha256 must be 64 hex chars");
+        }
+        if parsed.blob_url.trim().is_empty() {
+            bail!("attachments[{idx}].blob_url is empty");
+        }
+        out.push(parsed);
+    }
+    Ok(out)
+}
+
+/// Per-session tmpdir for attachment blobs. Lives under `$TMPDIR/lh-attach`
+/// so cleanup on engine restart is straightforward.
+pub fn session_tmpdir(session_id: &str) -> PathBuf {
+    std::env::temp_dir().join(TMP_ROOT_NAME).join(session_id)
+}
+
+fn extension_for_mime(mime: &str) -> &'static str {
+    match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/webp" => "webp",
+        "image/gif" => "gif",
+        _ => "bin",
+    }
+}
+
+/// Resolve `blob_url` against the engine's configured `api_url`. Absolute
+/// URLs (`https://...`) pass through unchanged; relative paths starting
+/// with `/` are joined onto the api base so the backend doesn't need to
+/// know what hostname the engine actually reaches it at.
+fn resolve_blob_url(api_url: &str, blob_url: &str) -> String {
+    if blob_url.starts_with("http://") || blob_url.starts_with("https://") {
+        return blob_url.to_string();
+    }
+    let base = api_url.trim_end_matches('/');
+    if blob_url.starts_with('/') {
+        format!("{base}{blob_url}")
+    } else {
+        format!("{base}/{blob_url}")
+    }
+}
+
+/// Fetch one attachment over HTTP, verify sha256, and write it under
+/// `session_tmpdir(session_id)` with mode 0600.
+pub async fn fetch_one(
+    http: &reqwest::Client,
+    api_url: &str,
+    api_token: &str,
+    session_id: &str,
+    attachment: &AttachmentRef,
+) -> Result<FetchedAttachment> {
+    let started = Instant::now();
+    let resolved_url = resolve_blob_url(api_url, &attachment.blob_url);
+    let response = http
+        .get(&resolved_url)
+        .header("X-Agents-Token", api_token)
+        .timeout(ATTACHMENT_FETCH_TIMEOUT)
+        .send()
+        .await
+        .with_context(|| format!("fetching attachment {} from {}", attachment.id, resolved_url))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        bail!(
+            "attachment_fetch_failed: HTTP {} fetching {} ({})",
+            status,
+            attachment.id,
+            body.chars().take(200).collect::<String>()
+        );
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .with_context(|| format!("reading body for attachment {}", attachment.id))?;
+    if bytes.len() > MAX_BLOB_BYTES {
+        bail!(
+            "attachment_fetch_failed: blob {} is {} bytes, exceeds engine cap of {}",
+            attachment.id,
+            bytes.len(),
+            MAX_BLOB_BYTES
+        );
+    }
+
+    let actual = format!("{:x}", Sha256::digest(&bytes));
+    if !actual.eq_ignore_ascii_case(&attachment.sha256) {
+        bail!(
+            "attachment_fetch_failed: sha256 mismatch for {} (expected {}, got {})",
+            attachment.id,
+            attachment.sha256,
+            actual
+        );
+    }
+
+    let dir = session_tmpdir(session_id);
+    fs::create_dir_all(&dir)
+        .with_context(|| format!("creating attachment tmpdir {}", dir.display()))?;
+    let path = dir.join(format!(
+        "{}.{}",
+        attachment.id,
+        extension_for_mime(&attachment.mime_type)
+    ));
+    fs::write(&path, &bytes)
+        .with_context(|| format!("writing attachment blob {}", path.display()))?;
+    set_owner_only_perms(&path)?;
+
+    let elapsed_ms = started.elapsed().as_millis();
+    eprintln!(
+        "[codex-attach] fetched id={} bytes={} elapsed_ms={} path={}",
+        attachment.id,
+        bytes.len(),
+        elapsed_ms,
+        path.display()
+    );
+
+    Ok(FetchedAttachment {
+        id: attachment.id.clone(),
+        mime_type: attachment.mime_type.clone(),
+        path,
+        bytes: bytes.len(),
+    })
+}
+
+#[cfg(unix)]
+fn set_owner_only_perms(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o600);
+    fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_perms(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Fetch all attachments concurrently. On any failure, deletes the
+/// per-session tmpdir so the bridge never hands Codex a partial set.
+pub async fn fetch_all(
+    http: &reqwest::Client,
+    api_url: &str,
+    api_token: &str,
+    session_id: &str,
+    attachments: &[AttachmentRef],
+) -> Result<Vec<FetchedAttachment>> {
+    if attachments.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut handles = Vec::with_capacity(attachments.len());
+    for attachment in attachments {
+        let http = http.clone();
+        let api_url = api_url.to_string();
+        let token = api_token.to_string();
+        let session = session_id.to_string();
+        let attachment = attachment.clone();
+        handles.push(tokio::spawn(async move {
+            fetch_one(&http, &api_url, &token, &session, &attachment).await
+        }));
+    }
+    let mut fetched = Vec::with_capacity(attachments.len());
+    let mut first_err: Option<anyhow::Error> = None;
+    for handle in handles {
+        match handle.await {
+            Ok(Ok(item)) => fetched.push(item),
+            Ok(Err(err)) => {
+                if first_err.is_none() {
+                    first_err = Some(err);
+                }
+            }
+            Err(join_err) => {
+                if first_err.is_none() {
+                    first_err = Some(anyhow!("attachment fetch task panicked: {join_err}"));
+                }
+            }
+        }
+    }
+    if let Some(err) = first_err {
+        cleanup_session_tmpdir(session_id);
+        return Err(err);
+    }
+    Ok(fetched)
+}
+
+/// Best-effort wipe of a session's attachment tmpdir. Called on Stop and
+/// when fetch_all bails partway through.
+pub fn cleanup_session_tmpdir(session_id: &str) {
+    let dir = session_tmpdir(session_id);
+    if dir.exists() {
+        if let Err(err) = fs::remove_dir_all(&dir) {
+            eprintln!(
+                "[codex-attach] cleanup tmpdir {} failed: {}",
+                dir.display(),
+                err
+            );
+        }
+    }
+}
+
+/// Build the `input` array for `turn/start` / `turn/steer`. LocalImage
+/// items come first, then a Text item — matches Codex's CLI drag-drop
+/// ordering. When `text` is empty and there are attachments, we still
+/// emit an empty Text element so app-server always has an anchor.
+pub fn build_user_input_items(text: &str, fetched: &[FetchedAttachment]) -> Vec<Value> {
+    let mut items: Vec<Value> = fetched
+        .iter()
+        .map(|item| {
+            json!({
+                "type": "localImage",
+                "path": item.path.to_string_lossy(),
+            })
+        })
+        .collect();
+    if !text.is_empty() || items.is_empty() {
+        items.push(json!({ "type": "text", "text": text }));
+    } else {
+        items.push(json!({ "type": "text", "text": "" }));
+    }
+    items
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_attachments_handles_missing_field() {
+        let req = json!({"text": "hi"});
+        assert!(parse_attachments(&req).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_attachments_handles_null() {
+        let req = json!({"attachments": null});
+        assert!(parse_attachments(&req).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_attachments_round_trips_one() {
+        let sha = "a".repeat(64);
+        let req = json!({
+            "attachments": [{
+                "id": "abc",
+                "mime_type": "image/png",
+                "sha256": sha,
+                "blob_url": "https://example/x",
+            }]
+        });
+        let parsed = parse_attachments(&req).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].id, "abc");
+        assert_eq!(parsed[0].mime_type, "image/png");
+    }
+
+    #[test]
+    fn parse_attachments_rejects_short_sha() {
+        let req = json!({
+            "attachments": [{
+                "id": "abc",
+                "mime_type": "image/png",
+                "sha256": "short",
+                "blob_url": "https://example/x",
+            }]
+        });
+        assert!(parse_attachments(&req).is_err());
+    }
+
+    #[test]
+    fn parse_attachments_rejects_empty_id() {
+        let sha = "a".repeat(64);
+        let req = json!({
+            "attachments": [{
+                "id": "",
+                "mime_type": "image/png",
+                "sha256": sha,
+                "blob_url": "https://example/x",
+            }]
+        });
+        assert!(parse_attachments(&req).is_err());
+    }
+
+    #[test]
+    fn build_user_input_orders_images_before_text() {
+        let fetched = vec![
+            FetchedAttachment {
+                id: "1".into(),
+                mime_type: "image/png".into(),
+                path: PathBuf::from("/tmp/a.png"),
+                bytes: 10,
+            },
+            FetchedAttachment {
+                id: "2".into(),
+                mime_type: "image/jpeg".into(),
+                path: PathBuf::from("/tmp/b.jpg"),
+                bytes: 20,
+            },
+        ];
+        let items = build_user_input_items("look", &fetched);
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0]["type"], "localImage");
+        assert_eq!(items[0]["path"], "/tmp/a.png");
+        assert_eq!(items[1]["type"], "localImage");
+        assert_eq!(items[2]["type"], "text");
+        assert_eq!(items[2]["text"], "look");
+    }
+
+    #[test]
+    fn build_user_input_keeps_text_when_no_attachments() {
+        let items = build_user_input_items("hello", &[]);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["type"], "text");
+        assert_eq!(items[0]["text"], "hello");
+    }
+
+    #[test]
+    fn build_user_input_emits_empty_text_when_only_images() {
+        let fetched = vec![FetchedAttachment {
+            id: "1".into(),
+            mime_type: "image/png".into(),
+            path: PathBuf::from("/tmp/a.png"),
+            bytes: 10,
+        }];
+        let items = build_user_input_items("", &fetched);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["type"], "localImage");
+        assert_eq!(items[1]["type"], "text");
+        assert_eq!(items[1]["text"], "");
+    }
+
+    #[test]
+    fn resolve_blob_url_passes_absolute_through() {
+        assert_eq!(
+            resolve_blob_url("https://api.example", "https://other/x.bin"),
+            "https://other/x.bin"
+        );
+        assert_eq!(
+            resolve_blob_url("https://api.example", "http://internal/x.bin"),
+            "http://internal/x.bin"
+        );
+    }
+
+    #[test]
+    fn resolve_blob_url_joins_relative_path() {
+        assert_eq!(
+            resolve_blob_url("https://api.example", "/api/agents/sessions/s/inputs/1/blob"),
+            "https://api.example/api/agents/sessions/s/inputs/1/blob"
+        );
+        assert_eq!(
+            resolve_blob_url("https://api.example/", "/api/agents/x"),
+            "https://api.example/api/agents/x"
+        );
+        assert_eq!(
+            resolve_blob_url("https://api.example/", "api/agents/x"),
+            "https://api.example/api/agents/x"
+        );
+    }
+
+    #[test]
+    fn extension_for_mime_maps_jpeg_to_jpg() {
+        assert_eq!(extension_for_mime("image/jpeg"), "jpg");
+        assert_eq!(extension_for_mime("image/png"), "png");
+        assert_eq!(extension_for_mime("image/webp"), "webp");
+        assert_eq!(extension_for_mime("image/gif"), "gif");
+        assert_eq!(extension_for_mime("application/octet-stream"), "bin");
+    }
+}

--- a/engine/src/codex_bridge.rs
+++ b/engine/src/codex_bridge.rs
@@ -679,6 +679,7 @@ pub async fn cmd_codex_bridge_start(config: BridgeStartConfig) -> Result<BridgeS
 
 pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
     let pid = std::process::id();
+    crate::codex_attachments::cleanup_session_tmpdir(&config.session_id);
     let initial_state = BridgeStateFile {
         session_id: config.session_id.clone(),
         cwd: config.cwd.display().to_string(),

--- a/engine/src/codex_bridge.rs
+++ b/engine/src/codex_bridge.rs
@@ -1101,8 +1101,8 @@ async fn handle_ipc_turn_start(
 }
 
 pub async fn cmd_codex_bridge_send(config: BridgeSendConfig) -> Result<BridgeSendSummary> {
-    if config.text.trim().is_empty() {
-        bail!("text must not be empty");
+    if config.text.trim().is_empty() && config.attachments.is_empty() {
+        bail!("text must not be empty when no attachments are present");
     }
     let state = load_ready_state(&config.session_id, config.state_root.as_deref())?;
     let thread_id = state

--- a/engine/src/codex_bridge.rs
+++ b/engine/src/codex_bridge.rs
@@ -1031,8 +1031,9 @@ async fn handle_ipc_steer(
         attachments,
     )
     .await?;
+    let had_attachments = !fetched.is_empty();
     let input = crate::codex_attachments::build_user_input_items(text, &fetched);
-    send_request_with_runtime(
+    let result = send_request_with_runtime(
         client,
         "turn/steer",
         json!({
@@ -1043,8 +1044,11 @@ async fn handle_ipc_steer(
         config,
         context,
     )
-    .await
-    .map(|_| ())
+    .await;
+    if result.is_err() && had_attachments {
+        crate::codex_attachments::cleanup_session_tmpdir(&context.state.session_id);
+    }
+    result.map(|_| ())
 }
 
 async fn handle_ipc_turn_start(
@@ -1063,8 +1067,9 @@ async fn handle_ipc_turn_start(
         attachments,
     )
     .await?;
+    let had_attachments = !fetched.is_empty();
     let input = crate::codex_attachments::build_user_input_items(text, &fetched);
-    let response = send_request_with_runtime(
+    let response = match send_request_with_runtime(
         client,
         "turn/start",
         json!({
@@ -1074,7 +1079,16 @@ async fn handle_ipc_turn_start(
         config,
         context,
     )
-    .await?;
+    .await
+    {
+        Ok(value) => value,
+        Err(err) => {
+            if had_attachments {
+                crate::codex_attachments::cleanup_session_tmpdir(&context.state.session_id);
+            }
+            return Err(err);
+        }
+    };
     let turn_id = extract_string(&response, &["turn", "id"])
         .context("missing turn.id in IPC turn/start response")?;
     let turn_status =

--- a/engine/src/codex_bridge.rs
+++ b/engine/src/codex_bridge.rs
@@ -93,6 +93,7 @@ pub struct BridgeSendConfig {
     pub text: String,
     pub state_root: Option<PathBuf>,
     pub allow_direct_ws_fallback: bool,
+    pub attachments: Vec<crate::codex_attachments::AttachmentRef>,
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +107,7 @@ pub struct BridgeSteerConfig {
     pub session_id: String,
     pub text: String,
     pub state_root: Option<PathBuf>,
+    pub attachments: Vec<crate::codex_attachments::AttachmentRef>,
 }
 
 /// Failure modes specific to the steer IPC path. Distinguishes "the turn
@@ -306,6 +308,7 @@ enum IpcCommand {
     TurnStart {
         text: String,
         thread_id: String,
+        attachments: Vec<crate::codex_attachments::AttachmentRef>,
         reply: oneshot::Sender<Result<Value>>,
     },
     /// Mid-turn steer routed through the daemon's persistent app-server
@@ -316,6 +319,7 @@ enum IpcCommand {
         text: String,
         thread_id: String,
         expected_turn_id: String,
+        attachments: Vec<crate::codex_attachments::AttachmentRef>,
         reply: oneshot::Sender<Result<Value>>,
     },
     Stop {
@@ -435,10 +439,13 @@ async fn handle_ipc_connection(
                 .and_then(Value::as_str)
                 .context("IPC steer request missing 'expected_turn_id'")?
                 .to_string();
+            let attachments = crate::codex_attachments::parse_attachments(&request)
+                .context("IPC steer request has invalid attachments")?;
             IpcCommand::Steer {
                 text,
                 thread_id,
                 expected_turn_id,
+                attachments,
                 reply: reply_tx,
             }
         }
@@ -453,9 +460,12 @@ async fn handle_ipc_connection(
                 .and_then(Value::as_str)
                 .context("IPC request missing 'thread_id'")?
                 .to_string();
+            let attachments = crate::codex_attachments::parse_attachments(&request)
+                .context("IPC turn/start request has invalid attachments")?;
             IpcCommand::TurnStart {
                 text,
                 thread_id,
+                attachments,
                 reply: reply_tx,
             }
         }
@@ -929,19 +939,20 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
             }
             Some(cmd) = ipc_rx.recv() => {
                 match cmd {
-                    IpcCommand::TurnStart { text, thread_id, reply } => {
+                    IpcCommand::TurnStart { text, thread_id, attachments, reply } => {
                         let result = handle_ipc_turn_start(
                             &config,
                             &mut client,
                             &mut context,
                             &text,
                             &thread_id,
+                            &attachments,
                         )
                         .await
                         .and_then(|summary| serde_json::to_value(summary).map_err(Into::into));
                         let _ = reply.send(result);
                     }
-                    IpcCommand::Steer { text, thread_id, expected_turn_id, reply } => {
+                    IpcCommand::Steer { text, thread_id, expected_turn_id, attachments, reply } => {
                         let result = handle_ipc_steer(
                             &config,
                             &mut client,
@@ -949,6 +960,7 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
                             &text,
                             &thread_id,
                             &expected_turn_id,
+                            &attachments,
                         )
                         .await
                         .map(|_| json!({}));
@@ -958,6 +970,7 @@ pub async fn cmd_codex_bridge_run(config: BridgeRunConfig) -> Result<()> {
                         terminal_reason,
                         reply,
                     } => {
+                        crate::codex_attachments::cleanup_session_tmpdir(&context.state.session_id);
                         context.state.status = "stopped".to_string();
                         context.state.active_turn_id = None;
                         context.state.last_error = None;
@@ -1008,14 +1021,24 @@ async fn handle_ipc_steer(
     text: &str,
     thread_id: &str,
     expected_turn_id: &str,
+    attachments: &[crate::codex_attachments::AttachmentRef],
 ) -> Result<()> {
+    let fetched = crate::codex_attachments::fetch_all(
+        &context.runtime.http,
+        &config.api_url,
+        &config.api_token,
+        &context.state.session_id,
+        attachments,
+    )
+    .await?;
+    let input = crate::codex_attachments::build_user_input_items(text, &fetched);
     send_request_with_runtime(
         client,
         "turn/steer",
         json!({
             "threadId": thread_id,
             "expectedTurnId": expected_turn_id,
-            "input": [{"type": "text", "text": text}],
+            "input": input,
         }),
         config,
         context,
@@ -1030,13 +1053,23 @@ async fn handle_ipc_turn_start(
     context: &mut BridgeContext,
     text: &str,
     thread_id: &str,
+    attachments: &[crate::codex_attachments::AttachmentRef],
 ) -> Result<BridgeSendSummary> {
+    let fetched = crate::codex_attachments::fetch_all(
+        &context.runtime.http,
+        &config.api_url,
+        &config.api_token,
+        &context.state.session_id,
+        attachments,
+    )
+    .await?;
+    let input = crate::codex_attachments::build_user_input_items(text, &fetched);
     let response = send_request_with_runtime(
         client,
         "turn/start",
         json!({
             "threadId": thread_id,
-            "input": [{"type": "text", "text": text}],
+            "input": input,
         }),
         config,
         context,
@@ -1083,7 +1116,7 @@ pub async fn cmd_codex_bridge_send(config: BridgeSendConfig) -> Result<BridgeSen
     let sock_path = ipc_socket_path(&paths.state_file);
     #[cfg(unix)]
     if sock_path.exists() {
-        match send_via_ipc(&sock_path, &config.text, &thread_id).await {
+        match send_via_ipc(&sock_path, &config.text, &thread_id, &config.attachments).await {
             Ok(summary) => return Ok(summary),
             Err(e) => {
                 // Only fall back on connection failures. If the daemon accepted the
@@ -1121,6 +1154,11 @@ pub async fn cmd_codex_bridge_send(config: BridgeSendConfig) -> Result<BridgeSen
             "IPC socket {} is missing for managed Codex session {}; refusing direct WebSocket fallback. Restart the bridge or pass --allow-direct-ws-fallback for explicit debug/operator use",
             sock_path.display(),
             config.session_id
+        );
+    }
+    if !config.attachments.is_empty() {
+        bail!(
+            "direct WebSocket fallback does not support attachments; restart the bridge so the daemon IPC socket is available"
         );
     }
     eprintln!(
@@ -1167,10 +1205,15 @@ const IPC_STOP_TIMEOUT: Duration = Duration::from_secs(3);
 const CHILD_SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_millis(500);
 
 #[cfg(unix)]
-async fn send_via_ipc(sock_path: &Path, text: &str, thread_id: &str) -> Result<BridgeSendSummary> {
+async fn send_via_ipc(
+    sock_path: &Path,
+    text: &str,
+    thread_id: &str,
+    attachments: &[crate::codex_attachments::AttachmentRef],
+) -> Result<BridgeSendSummary> {
     tokio::time::timeout(
         IPC_SEND_TIMEOUT,
-        send_via_ipc_inner(sock_path, text, thread_id),
+        send_via_ipc_inner(sock_path, text, thread_id, attachments),
     )
     .await
     .map_err(|_| anyhow!("IPC send timed out after {}s", IPC_SEND_TIMEOUT.as_secs()))?
@@ -1181,15 +1224,20 @@ async fn send_via_ipc_inner(
     sock_path: &Path,
     text: &str,
     thread_id: &str,
+    attachments: &[crate::codex_attachments::AttachmentRef],
 ) -> Result<BridgeSendSummary> {
     let mut stream = tokio::net::UnixStream::connect(sock_path)
         .await
         .with_context(|| format!("connecting to IPC socket {}", sock_path.display()))?;
 
-    let mut request = serde_json::to_vec(&json!({
+    let mut payload = json!({
         "text": text,
         "thread_id": thread_id,
-    }))?;
+    });
+    if !attachments.is_empty() {
+        payload["attachments"] = serde_json::to_value(attachments)?;
+    }
+    let mut request = serde_json::to_vec(&payload)?;
     request.push(b'\n');
     stream.write_all(&request).await?;
     stream.shutdown().await?;
@@ -1236,10 +1284,11 @@ async fn send_via_ipc_steer(
     text: &str,
     thread_id: &str,
     expected_turn_id: &str,
+    attachments: &[crate::codex_attachments::AttachmentRef],
 ) -> Result<()> {
     tokio::time::timeout(
         IPC_SEND_TIMEOUT,
-        send_via_ipc_steer_inner(sock_path, text, thread_id, expected_turn_id),
+        send_via_ipc_steer_inner(sock_path, text, thread_id, expected_turn_id, attachments),
     )
     .await
     .map_err(|_| anyhow!("IPC steer timed out after {}s", IPC_SEND_TIMEOUT.as_secs()))?
@@ -1251,17 +1300,22 @@ async fn send_via_ipc_steer_inner(
     text: &str,
     thread_id: &str,
     expected_turn_id: &str,
+    attachments: &[crate::codex_attachments::AttachmentRef],
 ) -> Result<()> {
     let mut stream = tokio::net::UnixStream::connect(sock_path)
         .await
         .with_context(|| format!("connecting to IPC socket {}", sock_path.display()))?;
 
-    let mut request = serde_json::to_vec(&json!({
+    let mut payload = json!({
         "kind": "steer",
         "text": text,
         "thread_id": thread_id,
         "expected_turn_id": expected_turn_id,
-    }))?;
+    });
+    if !attachments.is_empty() {
+        payload["attachments"] = serde_json::to_value(attachments)?;
+    }
+    let mut request = serde_json::to_vec(&payload)?;
     request.push(b'\n');
     stream.write_all(&request).await?;
     stream.shutdown().await?;
@@ -1424,7 +1478,15 @@ pub async fn cmd_codex_bridge_steer(
     let sock_path = ipc_socket_path(&paths.state_file);
     #[cfg(unix)]
     if sock_path.exists() {
-        match send_via_ipc_steer(&sock_path, &config.text, &thread_id, &turn_id).await {
+        match send_via_ipc_steer(
+            &sock_path,
+            &config.text,
+            &thread_id,
+            &turn_id,
+            &config.attachments,
+        )
+        .await
+        {
             Ok(()) => return Ok(()),
             Err(err) => {
                 let msg = format!("{err}");
@@ -1459,7 +1521,14 @@ pub async fn cmd_codex_bridge_steer(
     }
 
     // Fallback: direct WS (used when the daemon socket is missing or the
-    // connect itself failed). Slower — full handshake per call.
+    // connect itself failed). Slower — full handshake per call. Direct WS
+    // cannot fetch attachment blobs (no per-session tmpdir, no token), so
+    // refuse rather than silently dropping the images.
+    if !config.attachments.is_empty() {
+        return Err(BridgeSteerError::Protocol(anyhow!(
+            "direct WebSocket steer fallback does not support attachments; restart the bridge so the daemon IPC socket is available"
+        )));
+    }
     let ws_url = state
         .ws_url
         .clone()
@@ -4498,6 +4567,7 @@ mod tests {
             text: "continue".to_string(),
             state_root: Some(temp.path().to_path_buf()),
             allow_direct_ws_fallback: false,
+            attachments: Vec::new(),
         })
         .await
         .unwrap_err()
@@ -5541,7 +5611,7 @@ mod tests {
             .unwrap();
 
         let summary =
-            handle_ipc_turn_start(&config, &mut client, &mut context, "continue", "thr_test")
+            handle_ipc_turn_start(&config, &mut client, &mut context, "continue", "thr_test", &[])
                 .await
                 .unwrap();
 
@@ -5725,7 +5795,7 @@ mod tests {
             let _ = sock_clone;
         });
 
-        send_via_ipc_steer(&sock, "ipc steer", "thr-1", "turn-1")
+        send_via_ipc_steer(&sock, "ipc steer", "thr-1", "turn-1", &[])
             .await
             .unwrap();
         server.await.unwrap();
@@ -5749,7 +5819,7 @@ mod tests {
                 .unwrap();
         });
 
-        let err = send_via_ipc_steer(&sock, "x", "thr", "turn")
+        let err = send_via_ipc_steer(&sock, "x", "thr", "turn", &[])
             .await
             .unwrap_err();
         let msg = format!("{err}");

--- a/engine/src/control_channel.rs
+++ b/engine/src/control_channel.rs
@@ -589,6 +589,7 @@ async fn execute_command(
                 text,
                 state_root: None,
                 allow_direct_ws_fallback: false,
+                attachments: Vec::new(),
             })
             .await
             .map_err(|err| CommandError::command_failed(err))?;
@@ -628,6 +629,7 @@ async fn execute_command(
                 session_id,
                 text,
                 state_root: None,
+                attachments: Vec::new(),
             })
             .await
             {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -712,6 +712,12 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let command_name = command_name(&cli.command);
 
+    // Drop any leftover image-attach blobs from a prior process before
+    // touching anything else. Cheap, best-effort, no-op when empty.
+    if matches!(cli.command, Commands::Connect { .. }) {
+        crate::codex_attachments::cleanup_orphan_tmpdirs();
+    }
+
     // For Connect (daemon) mode: use rolling file appender.
     // For all other commands: log to stderr as usual.
     let _guard;
@@ -1292,12 +1298,18 @@ mod tests {
 
     #[test]
     fn codex_bridge_send_parses_attachments_json() {
+        let attach_id = uuid::Uuid::new_v4().to_string();
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let blob_url = format!(
+            "/api/agents/sessions/{}/inputs/1/attachments/{}/blob",
+            session_id, attach_id
+        );
         let attachments = serde_json::json!([
             {
-                "id": "att_1",
+                "id": attach_id,
                 "mime_type": "image/png",
                 "sha256": "a".repeat(64),
-                "blob_url": "https://example.com/blob/1",
+                "blob_url": blob_url,
             }
         ])
         .to_string();
@@ -1322,8 +1334,8 @@ mod tests {
             } => {
                 let parsed = parse_attachments_cli_arg(attachments_json.as_deref()).unwrap();
                 assert_eq!(parsed.len(), 1);
-                assert_eq!(parsed[0].id, "att_1");
-                assert_eq!(parsed[0].blob_url, "https://example.com/blob/1");
+                assert_eq!(parsed[0].id, attach_id);
+                assert_eq!(parsed[0].blob_url, blob_url);
             }
             _ => panic!("expected codex-bridge send command"),
         }
@@ -1344,12 +1356,18 @@ mod tests {
 
     #[test]
     fn codex_bridge_steer_accepts_attachments_json() {
+        let attach_id = uuid::Uuid::new_v4().to_string();
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let blob_url = format!(
+            "/api/agents/sessions/{}/inputs/2/attachments/{}/blob",
+            session_id, attach_id
+        );
         let attachments = serde_json::json!([
             {
-                "id": "att_2",
+                "id": attach_id,
                 "mime_type": "image/jpeg",
                 "sha256": "b".repeat(64),
-                "blob_url": "https://example.com/blob/2",
+                "blob_url": blob_url,
             }
         ])
         .to_string();
@@ -1374,7 +1392,7 @@ mod tests {
             } => {
                 let parsed = parse_attachments_cli_arg(attachments_json.as_deref()).unwrap();
                 assert_eq!(parsed.len(), 1);
-                assert_eq!(parsed[0].id, "att_2");
+                assert_eq!(parsed[0].id, attach_id);
             }
             _ => panic!("expected codex-bridge steer command"),
         }

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,6 +1,7 @@
 mod bench;
 mod build_identity;
 mod codex_app_server_canary;
+mod codex_attachments;
 mod codex_bridge;
 mod codex_source;
 mod codex_ws_relay;
@@ -47,6 +48,24 @@ use codex_bridge::{
 use config::ShipperConfig;
 use pipeline::compressor::CompressionAlgo;
 use state::db::open_db;
+
+/// Parse the `--attachments-json` CLI flag into the engine's typed
+/// `AttachmentRef` list. Empty / `None` / `null` / `[]` all collapse to no
+/// attachments so text-only callers don't need to special-case the flag.
+fn parse_attachments_cli_arg(
+    raw: Option<&str>,
+) -> anyhow::Result<Vec<crate::codex_attachments::AttachmentRef>> {
+    let Some(raw) = raw else {
+        return Ok(Vec::new());
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let value: serde_json::Value = serde_json::from_str(trimmed)
+        .map_err(|e| anyhow::anyhow!("--attachments-json is not valid JSON: {e}"))?;
+    crate::codex_attachments::parse_attachments(&serde_json::json!({ "attachments": value }))
+}
 
 fn parse_compression_algo(s: &str) -> anyhow::Result<CompressionAlgo> {
     match s.to_lowercase().as_str() {
@@ -544,6 +563,11 @@ enum CodexBridgeCommands {
         #[arg(long, hide = true)]
         allow_direct_ws_fallback: bool,
 
+        /// JSON array of attachment refs: `[{"id":"...","mime_type":"image/png","sha256":"...","blob_url":"..."}]`.
+        /// Empty / unset means text-only.
+        #[arg(long)]
+        attachments_json: Option<String>,
+
         #[arg(long)]
         json: bool,
     },
@@ -572,6 +596,10 @@ enum CodexBridgeCommands {
 
         #[arg(long)]
         state_root: Option<PathBuf>,
+
+        /// JSON array of attachment refs (same shape as `send --attachments-json`).
+        #[arg(long)]
+        attachments_json: Option<String>,
     },
 
     /// Stop a running managed bridge and its local Codex app-server child
@@ -1097,13 +1125,16 @@ fn main() -> anyhow::Result<()> {
                     text,
                     state_root,
                     allow_direct_ws_fallback,
+                    attachments_json,
                     json,
                 } => {
+                    let attachments = parse_attachments_cli_arg(attachments_json.as_deref())?;
                     let summary = rt.block_on(cmd_codex_bridge_send(BridgeSendConfig {
                         session_id,
                         text,
                         state_root,
                         allow_direct_ws_fallback,
+                        attachments,
                     }))?;
                     if json {
                         println!("{}", serde_json::to_string_pretty(&summary)?);
@@ -1127,11 +1158,14 @@ fn main() -> anyhow::Result<()> {
                     session_id,
                     text,
                     state_root,
+                    attachments_json,
                 } => {
+                    let attachments = parse_attachments_cli_arg(attachments_json.as_deref())?;
                     let res = rt.block_on(cmd_codex_bridge_steer(BridgeSteerConfig {
                         session_id,
                         text,
                         state_root,
+                        attachments,
                     }));
                     match res {
                         Ok(()) => {}
@@ -1253,6 +1287,96 @@ mod tests {
                     },
             } => assert!(allow_direct_ws_fallback),
             _ => panic!("expected codex-bridge send command"),
+        }
+    }
+
+    #[test]
+    fn codex_bridge_send_parses_attachments_json() {
+        let attachments = serde_json::json!([
+            {
+                "id": "att_1",
+                "mime_type": "image/png",
+                "sha256": "a".repeat(64),
+                "blob_url": "https://example.com/blob/1",
+            }
+        ])
+        .to_string();
+        let cli = Cli::try_parse_from([
+            "longhouse-engine",
+            "codex-bridge",
+            "send",
+            "--session-id",
+            "sess-test",
+            "--text",
+            "look at this",
+            "--attachments-json",
+            &attachments,
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::CodexBridge {
+                command:
+                    CodexBridgeCommands::Send {
+                        attachments_json, ..
+                    },
+            } => {
+                let parsed = parse_attachments_cli_arg(attachments_json.as_deref()).unwrap();
+                assert_eq!(parsed.len(), 1);
+                assert_eq!(parsed[0].id, "att_1");
+                assert_eq!(parsed[0].blob_url, "https://example.com/blob/1");
+            }
+            _ => panic!("expected codex-bridge send command"),
+        }
+    }
+
+    #[test]
+    fn parse_attachments_cli_arg_handles_missing_and_empty() {
+        assert!(parse_attachments_cli_arg(None).unwrap().is_empty());
+        assert!(parse_attachments_cli_arg(Some("")).unwrap().is_empty());
+        assert!(parse_attachments_cli_arg(Some("   ")).unwrap().is_empty());
+        assert!(parse_attachments_cli_arg(Some("[]")).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_attachments_cli_arg_rejects_invalid_json() {
+        assert!(parse_attachments_cli_arg(Some("not json")).is_err());
+    }
+
+    #[test]
+    fn codex_bridge_steer_accepts_attachments_json() {
+        let attachments = serde_json::json!([
+            {
+                "id": "att_2",
+                "mime_type": "image/jpeg",
+                "sha256": "b".repeat(64),
+                "blob_url": "https://example.com/blob/2",
+            }
+        ])
+        .to_string();
+        let cli = Cli::try_parse_from([
+            "longhouse-engine",
+            "codex-bridge",
+            "steer",
+            "--session-id",
+            "sess-test",
+            "--text",
+            "fine-tune",
+            "--attachments-json",
+            &attachments,
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::CodexBridge {
+                command:
+                    CodexBridgeCommands::Steer {
+                        attachments_json, ..
+                    },
+            } => {
+                let parsed = parse_attachments_cli_arg(attachments_json.as_deref()).unwrap();
+                assert_eq!(parsed.len(), 1);
+                assert_eq!(parsed[0].id, "att_2");
+            }
+            _ => panic!("expected codex-bridge steer command"),
         }
     }
 

--- a/ios/Sources/LonghouseApp/ChatUITestFixtureView.swift
+++ b/ios/Sources/LonghouseApp/ChatUITestFixtureView.swift
@@ -328,6 +328,10 @@ private actor ChatUITestWorkspaceClient: SessionWorkspaceClient {
         return SessionInputResponse(outcome: .sent, inputId: inputID, clientRequestId: clientRequestId, intent: intent, queued: [])
     }
 
+    func sendInputMultipart(id: String, text: String, attachments: [ComposerAttachment], clientRequestId: String?) async throws -> SessionInputResponse {
+        try await sendInput(id: id, text: text, intent: "auto", clientRequestId: clientRequestId)
+    }
+
     func draftReply(id: String, maxChars: Int) async throws -> DraftReplyResponse {
         DraftReplyResponse(
             draftText: "Drafted fixture reply",
@@ -558,7 +562,8 @@ private actor ChatUITestWorkspaceClient: SessionWorkspaceClient {
                 defaultInputIntent: "auto",
                 composerEnabled: true,
                 composerPlaceholder: "Send a message to the live Codex session...",
-                composerDisabledReason: nil
+                composerDisabledReason: nil,
+                attachImages: false
             ),
             runtimeDisplay: SessionRuntimeDisplay(
                 truthTier: "live",

--- a/ios/Sources/LonghouseApp/SessionView.swift
+++ b/ios/Sources/LonghouseApp/SessionView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PhotosUI
 
 struct SessionWorkspaceStreamSource: Sendable {
     let start: @Sendable () async -> AsyncStream<SessionWorkspaceStream.Event>
@@ -27,6 +28,8 @@ struct SessionView: View {
     @StateObject private var liveActivityManager = SessionLiveActivityManager()
     @State private var composerText: String = ""
     @FocusState private var composerFocused: Bool
+    @StateObject private var attachmentStore = ComposerAttachmentStore()
+    @State private var pickerSelection: [PhotosPickerItem] = []
 
     init(
         sessionId: String,
@@ -42,6 +45,10 @@ struct SessionView: View {
 
     private var composerHasText: Bool {
         !composerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var composerHasContent: Bool {
+        composerHasText || !attachmentStore.isEmpty
     }
 
     var body: some View {
@@ -268,6 +275,10 @@ struct SessionView: View {
                     .foregroundStyle(.orange)
             }
 
+            if detail.attachImagesEnabled {
+                attachmentTray
+            }
+
             HStack(alignment: .bottom, spacing: 8) {
                 // Sparkle: AI draft, only when field is empty
                 Button {
@@ -284,6 +295,22 @@ struct SessionView: View {
                 .frame(width: 32, height: 32)
                 .disabled(composerHasText || viewModel.isSending || viewModel.isDrafting)
                 .accessibilityLabel("Draft reply")
+
+                if detail.attachImagesEnabled {
+                    PhotosPicker(
+                        selection: $pickerSelection,
+                        maxSelectionCount: max(1, attachmentStore.slotsLeft),
+                        matching: .images
+                    ) {
+                        Image(systemName: attachmentStore.isProcessing ? "ellipsis.circle" : "paperclip")
+                            .font(.title3)
+                            .foregroundStyle(attachmentStore.slotsLeft > 0 ? Color.accentColor : Color.secondary.opacity(0.3))
+                    }
+                    .frame(width: 32, height: 32)
+                    .disabled(attachmentStore.slotsLeft <= 0 || attachmentStore.isProcessing || viewModel.isSending)
+                    .accessibilityLabel("Attach images")
+                    .accessibilityIdentifier("session-chat-attach")
+                }
 
                 TextField(detail.composerPlaceholder, text: $composerText, axis: .vertical)
                     .textFieldStyle(.roundedBorder)
@@ -302,10 +329,10 @@ struct SessionView: View {
                     } else {
                         Image(systemName: sendIcon)
                             .font(.title2)
-                            .foregroundStyle(composerHasText ? Color.accentColor : Color.secondary.opacity(0.3))
+                            .foregroundStyle(composerHasContent ? Color.accentColor : Color.secondary.opacity(0.3))
                     }
                 }
-                .disabled(!composerHasText || viewModel.isSending || viewModel.isDrafting)
+                .disabled(!composerHasContent || viewModel.isSending || viewModel.isDrafting || attachmentStore.isProcessing)
                 .accessibilityLabel(sendAccessibilityLabel)
                 .accessibilityIdentifier("session-chat-send")
                 .contextMenu {
@@ -326,6 +353,65 @@ struct SessionView: View {
         }
         .padding(12)
         .background(.bar)
+        .onChange(of: pickerSelection) { _, items in
+            guard !items.isEmpty else { return }
+            Task {
+                var raw: [(filename: String, data: Data)] = []
+                for (idx, item) in items.enumerated() {
+                    if let data = try? await item.loadTransferable(type: Data.self) {
+                        let name = item.itemIdentifier.map { "ios-\($0).jpg" } ?? "ios-\(idx).jpg"
+                        raw.append((filename: name, data: data))
+                    }
+                }
+                await attachmentStore.ingest(rawImages: raw)
+                await MainActor.run { pickerSelection = [] }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var attachmentTray: some View {
+        if !attachmentStore.attachments.isEmpty || attachmentStore.errorMessage != nil {
+            VStack(alignment: .leading, spacing: 6) {
+                if !attachmentStore.attachments.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(attachmentStore.attachments) { item in
+                                ZStack(alignment: .topTrailing) {
+                                    if let thumb = item.thumbnail {
+                                        Image(uiImage: thumb)
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: 56, height: 56)
+                                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                                    } else {
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .fill(Color.secondary.opacity(0.2))
+                                            .frame(width: 56, height: 56)
+                                    }
+                                    Button {
+                                        attachmentStore.remove(item.id)
+                                    } label: {
+                                        Image(systemName: "xmark.circle.fill")
+                                            .font(.system(size: 18))
+                                            .foregroundStyle(.white, .black.opacity(0.7))
+                                            .padding(2)
+                                    }
+                                    .accessibilityLabel("Remove \(item.filename)")
+                                }
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("session-chat-attachment-tray")
+                }
+                if let err = attachmentStore.errorMessage {
+                    Text(err)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .onTapGesture { attachmentStore.errorMessage = nil }
+                }
+            }
+        }
     }
 
     private func unavailableComposerFooter(detail: SessionDetail) -> some View {
@@ -380,16 +466,24 @@ struct SessionView: View {
 
     private func send(intent: String? = nil) async {
         guard !viewModel.isSending else { return }
+        guard !attachmentStore.isProcessing else { return }
         let trimmed = composerText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        let resolvedIntent = intent ?? primaryIntent
+        let pendingAttachments = attachmentStore.snapshot()
+        guard !trimmed.isEmpty || !pendingAttachments.isEmpty else { return }
+        // Multipart route only accepts intent=auto in v1. Force auto when
+        // attachments are present, regardless of the requested intent.
+        let resolvedIntent = pendingAttachments.isEmpty ? (intent ?? primaryIntent) : "auto"
         composerText = ""
         composerFocused = false
+        // Snapshot+clear before send so a slow request doesn't keep the
+        // thumbnails next to a fresh empty draft.
+        attachmentStore.clear()
         let sent = await viewModel.send(
             text: trimmed,
             sessionId: sessionId,
             appState: appState,
             intent: resolvedIntent,
+            attachments: pendingAttachments,
         )
         if sent {
             let token = viewModel.sendCounter
@@ -755,7 +849,13 @@ final class SessionViewModel: ObservableObject {
         isInitialLoading = false
     }
 
-    func send(text: String, sessionId: String, appState: AppState, intent: String = "auto") async -> Bool {
+    func send(
+        text: String,
+        sessionId: String,
+        appState: AppState,
+        intent: String = "auto",
+        attachments: [ComposerAttachment] = []
+    ) async -> Bool {
         let clientRequestId = "ios-\(UUID().uuidString)"
         let localInput = SubmittedInput(
             id: clientRequestId,
@@ -781,12 +881,24 @@ final class SessionViewModel: ObservableObject {
         draftErrorMessage = nil
         defer { isSending = false }
         do {
-            let response = try await api.sendInput(
-                id: sessionId,
-                text: text,
-                intent: intent,
-                clientRequestId: clientRequestId
-            )
+            let response: SessionInputResponse
+            if attachments.isEmpty {
+                response = try await api.sendInput(
+                    id: sessionId,
+                    text: text,
+                    intent: intent,
+                    clientRequestId: clientRequestId
+                )
+            } else {
+                // Server v1 multipart accepts intent=auto only; the UI gates
+                // attachments to managed Codex sessions at the composer level.
+                response = try await api.sendInputMultipart(
+                    id: sessionId,
+                    text: text,
+                    attachments: attachments,
+                    clientRequestId: clientRequestId
+                )
+            }
             sendCounter &+= 1
             lastSendOutcome = response.outcome
             queuedInputCount = response.pendingInputCount

--- a/ios/Sources/LonghouseApp/SessionView.swift
+++ b/ios/Sources/LonghouseApp/SessionView.swift
@@ -30,6 +30,7 @@ struct SessionView: View {
     @FocusState private var composerFocused: Bool
     @StateObject private var attachmentStore = ComposerAttachmentStore()
     @State private var pickerSelection: [PhotosPickerItem] = []
+    @State private var isLoadingPickerItems: Bool = false
 
     init(
         sessionId: String,
@@ -307,7 +308,7 @@ struct SessionView: View {
                             .foregroundStyle(attachmentStore.slotsLeft > 0 ? Color.accentColor : Color.secondary.opacity(0.3))
                     }
                     .frame(width: 32, height: 32)
-                    .disabled(attachmentStore.slotsLeft <= 0 || attachmentStore.isProcessing || viewModel.isSending)
+                    .disabled(attachmentStore.slotsLeft <= 0 || attachmentStore.isProcessing || isLoadingPickerItems || viewModel.isSending)
                     .accessibilityLabel("Attach images")
                     .accessibilityIdentifier("session-chat-attach")
                 }
@@ -332,11 +333,11 @@ struct SessionView: View {
                             .foregroundStyle(composerHasContent ? Color.accentColor : Color.secondary.opacity(0.3))
                     }
                 }
-                .disabled(!composerHasContent || viewModel.isSending || viewModel.isDrafting || attachmentStore.isProcessing)
+                .disabled(!composerHasContent || viewModel.isSending || viewModel.isDrafting || attachmentStore.isProcessing || isLoadingPickerItems)
                 .accessibilityLabel(sendAccessibilityLabel)
                 .accessibilityIdentifier("session-chat-send")
                 .contextMenu {
-                    if showSecondaryQueueAction {
+                    if showSecondaryQueueAction && attachmentStore.isEmpty {
                         Button {
                             Task { await send(intent: "steer") }
                         } label: {
@@ -356,15 +357,32 @@ struct SessionView: View {
         .onChange(of: pickerSelection) { _, items in
             guard !items.isEmpty else { return }
             Task {
+                await MainActor.run { isLoadingPickerItems = true }
                 var raw: [(filename: String, data: Data)] = []
+                var loadFailures = 0
+                for _ in items.indices {
+                    raw.append((filename: "", data: Data()))
+                }
                 for (idx, item) in items.enumerated() {
-                    if let data = try? await item.loadTransferable(type: Data.self) {
-                        let name = item.itemIdentifier.map { "ios-\($0).jpg" } ?? "ios-\(idx).jpg"
-                        raw.append((filename: name, data: data))
+                    do {
+                        if let data = try await item.loadTransferable(type: Data.self) {
+                            raw[idx] = (filename: "image-\(UUID().uuidString).jpg", data: data)
+                        } else {
+                            loadFailures += 1
+                        }
+                    } catch {
+                        loadFailures += 1
                     }
                 }
-                await attachmentStore.ingest(rawImages: raw)
-                await MainActor.run { pickerSelection = [] }
+                let loaded = raw.filter { !$0.data.isEmpty }
+                await attachmentStore.ingest(rawImages: loaded)
+                await MainActor.run {
+                    if loadFailures > 0 && loaded.isEmpty {
+                        attachmentStore.errorMessage = "Could not load selected image."
+                    }
+                    pickerSelection = []
+                    isLoadingPickerItems = false
+                }
             }
         }
     }
@@ -467,6 +485,7 @@ struct SessionView: View {
     private func send(intent: String? = nil) async {
         guard !viewModel.isSending else { return }
         guard !attachmentStore.isProcessing else { return }
+        guard !isLoadingPickerItems else { return }
         let trimmed = composerText.trimmingCharacters(in: .whitespacesAndNewlines)
         let pendingAttachments = attachmentStore.snapshot()
         guard !trimmed.isEmpty || !pendingAttachments.isEmpty else { return }
@@ -496,6 +515,11 @@ struct SessionView: View {
                     }
                 }
             }
+        } else if !pendingAttachments.isEmpty {
+            // Send failed: re-ingest the compressed attachments so the user
+            // can retry without re-picking from Photos.
+            let raw = pendingAttachments.map { (filename: $0.filename, data: $0.data) }
+            await attachmentStore.ingest(rawImages: raw)
         }
     }
 

--- a/ios/Sources/LonghouseApp/SessionView.swift
+++ b/ios/Sources/LonghouseApp/SessionView.swift
@@ -52,6 +52,15 @@ struct SessionView: View {
         composerHasText || !attachmentStore.isEmpty
     }
 
+    private var attachmentInputEnabled: Bool {
+        guard viewModel.detail?.attachImagesEnabled == true else { return false }
+        return primaryIntent == "auto"
+    }
+
+    private var attachmentSendBlocked: Bool {
+        !attachmentStore.isEmpty && primaryIntent != "auto"
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             transcript
@@ -298,17 +307,20 @@ struct SessionView: View {
                 .accessibilityLabel("Draft reply")
 
                 if detail.attachImagesEnabled {
+                    let attachmentSlotsLeft = attachmentStore.slotsLeft
+                    let attachmentIsProcessing = attachmentStore.isProcessing
+                    let canAttachImages = attachmentInputEnabled
                     PhotosPicker(
                         selection: $pickerSelection,
-                        maxSelectionCount: max(1, attachmentStore.slotsLeft),
+                        maxSelectionCount: max(1, attachmentSlotsLeft),
                         matching: .images
                     ) {
-                        Image(systemName: attachmentStore.isProcessing ? "ellipsis.circle" : "paperclip")
+                        Image(systemName: attachmentIsProcessing ? "ellipsis.circle" : "paperclip")
                             .font(.title3)
-                            .foregroundStyle(attachmentStore.slotsLeft > 0 ? Color.accentColor : Color.secondary.opacity(0.3))
+                            .foregroundStyle(canAttachImages && attachmentSlotsLeft > 0 ? Color.accentColor : Color.secondary.opacity(0.3))
                     }
                     .frame(width: 32, height: 32)
-                    .disabled(attachmentStore.slotsLeft <= 0 || attachmentStore.isProcessing || isLoadingPickerItems || viewModel.isSending)
+                    .disabled(!canAttachImages || attachmentSlotsLeft <= 0 || attachmentIsProcessing || isLoadingPickerItems || viewModel.isSending)
                     .accessibilityLabel("Attach images")
                     .accessibilityIdentifier("session-chat-attach")
                 }
@@ -333,7 +345,7 @@ struct SessionView: View {
                             .foregroundStyle(composerHasContent ? Color.accentColor : Color.secondary.opacity(0.3))
                     }
                 }
-                .disabled(!composerHasContent || viewModel.isSending || viewModel.isDrafting || attachmentStore.isProcessing || isLoadingPickerItems)
+                .disabled(!composerHasContent || viewModel.isSending || viewModel.isDrafting || attachmentStore.isProcessing || isLoadingPickerItems || attachmentSendBlocked)
                 .accessibilityLabel(sendAccessibilityLabel)
                 .accessibilityIdentifier("session-chat-send")
                 .contextMenu {
@@ -489,9 +501,11 @@ struct SessionView: View {
         let trimmed = composerText.trimmingCharacters(in: .whitespacesAndNewlines)
         let pendingAttachments = attachmentStore.snapshot()
         guard !trimmed.isEmpty || !pendingAttachments.isEmpty else { return }
-        // Multipart route only accepts intent=auto in v1. Force auto when
-        // attachments are present, regardless of the requested intent.
-        let resolvedIntent = pendingAttachments.isEmpty ? (intent ?? primaryIntent) : "auto"
+        let requestedIntent = intent ?? primaryIntent
+        if !pendingAttachments.isEmpty && requestedIntent != "auto" {
+            attachmentStore.errorMessage = "Images can be sent when the session is ready for a new turn."
+            return
+        }
         composerText = ""
         composerFocused = false
         // Snapshot+clear before send so a slow request doesn't keep the
@@ -501,7 +515,7 @@ struct SessionView: View {
             text: trimmed,
             sessionId: sessionId,
             appState: appState,
-            intent: resolvedIntent,
+            intent: requestedIntent,
             attachments: pendingAttachments,
         )
         if sent {

--- a/ios/Sources/Shared/ComposerAttachment.swift
+++ b/ios/Sources/Shared/ComposerAttachment.swift
@@ -1,0 +1,75 @@
+import Foundation
+import SwiftUI
+
+struct ComposerAttachment: Identifiable, Sendable {
+    let id: UUID
+    let filename: String
+    let data: Data
+    let mimeType: String
+    let thumbnail: UIImage?
+
+    var byteSize: Int { data.count }
+}
+
+enum ComposerAttachmentLimits {
+    static let maxAttachments = 4
+    static let maxBytes = 2 * 1024 * 1024
+}
+
+@MainActor
+final class ComposerAttachmentStore: ObservableObject {
+    @Published private(set) var attachments: [ComposerAttachment] = []
+    @Published private(set) var isProcessing = false
+    @Published var errorMessage: String? = nil
+
+    var isEmpty: Bool { attachments.isEmpty }
+    var slotsLeft: Int { ComposerAttachmentLimits.maxAttachments - attachments.count }
+
+    /// Compress + add new images, capping at the slot limit. Each input may
+    /// already be compressed (PhotosPicker hands us decoded image data) but
+    /// we re-encode through ImageCompression for size + dimension control.
+    func ingest(rawImages: [(filename: String, data: Data)]) async {
+        guard slotsLeft > 0 else {
+            errorMessage = "Max \(ComposerAttachmentLimits.maxAttachments) attachments."
+            return
+        }
+        isProcessing = true
+        defer { isProcessing = false }
+        let toProcess = Array(rawImages.prefix(slotsLeft))
+        for raw in toProcess {
+            do {
+                let compressed = try await Task.detached(priority: .userInitiated) {
+                    try ImageCompression.compress(raw.data)
+                }.value
+                if compressed.data.count > ComposerAttachmentLimits.maxBytes {
+                    let kb = compressed.data.count / 1024
+                    errorMessage = "\(raw.filename) is still \(kb) KB after compression (max 2 MB)."
+                    continue
+                }
+                let thumb = UIImage(data: compressed.data)
+                attachments.append(
+                    ComposerAttachment(
+                        id: UUID(),
+                        filename: raw.filename,
+                        data: compressed.data,
+                        mimeType: compressed.mimeType,
+                        thumbnail: thumb,
+                    )
+                )
+            } catch {
+                errorMessage = "Could not process \(raw.filename): \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func remove(_ id: UUID) {
+        attachments.removeAll { $0.id == id }
+    }
+
+    func clear() {
+        attachments.removeAll()
+        errorMessage = nil
+    }
+
+    func snapshot() -> [ComposerAttachment] { attachments }
+}

--- a/ios/Sources/Shared/ComposerAttachment.swift
+++ b/ios/Sources/Shared/ComposerAttachment.swift
@@ -29,18 +29,23 @@ final class ComposerAttachmentStore: ObservableObject {
     /// already be compressed (PhotosPicker hands us decoded image data) but
     /// we re-encode through ImageCompression for size + dimension control.
     func ingest(rawImages: [(filename: String, data: Data)]) async {
+        guard !isProcessing else {
+            errorMessage = "Still processing previous selection — try again in a moment."
+            return
+        }
         guard slotsLeft > 0 else {
             errorMessage = "Max \(ComposerAttachmentLimits.maxAttachments) attachments."
             return
         }
         isProcessing = true
         defer { isProcessing = false }
-        let toProcess = Array(rawImages.prefix(slotsLeft))
-        for raw in toProcess {
+        for raw in rawImages {
+            guard attachments.count < ComposerAttachmentLimits.maxAttachments else { break }
             do {
                 let compressed = try await Task.detached(priority: .userInitiated) {
                     try ImageCompression.compress(raw.data)
                 }.value
+                guard attachments.count < ComposerAttachmentLimits.maxAttachments else { break }
                 if compressed.data.count > ComposerAttachmentLimits.maxBytes {
                     let kb = compressed.data.count / 1024
                     errorMessage = "\(raw.filename) is still \(kb) KB after compression (max 2 MB)."

--- a/ios/Sources/Shared/Generated/SessionAPI.generated.swift
+++ b/ios/Sources/Shared/Generated/SessionAPI.generated.swift
@@ -29,6 +29,7 @@ struct APISessionCapabilitiesResponse: Codable, Hashable, Sendable {
     let canTerminate: Bool?
     let canTailOutput: Bool?
     let canResume: Bool?
+    let attachImages: Bool?
 }
 
 struct APISessionControlResponse: Codable, Hashable, Sendable {

--- a/ios/Sources/Shared/ImageCompression.swift
+++ b/ios/Sources/Shared/ImageCompression.swift
@@ -1,8 +1,6 @@
 import Foundation
 import UIKit
 import ImageIO
-import MobileCoreServices
-import UniformTypeIdentifiers
 
 /// Compressed image payload destined for the multipart upload.
 struct CompressedImage: Sendable {
@@ -36,36 +34,27 @@ enum ImageCompression {
     /// adding a webp encode for iOS is not worth the dependency here.
     static func compress(_ data: Data) throws -> CompressedImage {
         guard !data.isEmpty else { throw ImageCompressionError.empty }
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-              let cg = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
             throw ImageCompressionError.decodeFailed
         }
-        let original = UIImage(cgImage: cg)
-        let scaled = downscale(original)
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: Int(maxLongEdge),
+        ]
+        guard let cg = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            throw ImageCompressionError.decodeFailed
+        }
+        let scaled = UIImage(cgImage: cg)
         guard let jpeg = scaled.jpegData(compressionQuality: jpegQuality) else {
             throw ImageCompressionError.encodeFailed
         }
         return CompressedImage(
             data: jpeg,
             mimeType: "image/jpeg",
-            width: Int(scaled.size.width * scaled.scale),
-            height: Int(scaled.size.height * scaled.scale),
+            width: cg.width,
+            height: cg.height,
         )
-    }
-
-    private static func downscale(_ image: UIImage) -> UIImage {
-        let pixelWidth = image.size.width * image.scale
-        let pixelHeight = image.size.height * image.scale
-        let longest = max(pixelWidth, pixelHeight)
-        guard longest > maxLongEdge else { return image }
-        let scale = maxLongEdge / longest
-        let target = CGSize(width: pixelWidth * scale, height: pixelHeight * scale)
-        let format = UIGraphicsImageRendererFormat()
-        format.scale = 1
-        format.opaque = false
-        let renderer = UIGraphicsImageRenderer(size: target, format: format)
-        return renderer.image { _ in
-            image.draw(in: CGRect(origin: .zero, size: target))
-        }
     }
 }

--- a/ios/Sources/Shared/ImageCompression.swift
+++ b/ios/Sources/Shared/ImageCompression.swift
@@ -1,0 +1,71 @@
+import Foundation
+import UIKit
+import ImageIO
+import MobileCoreServices
+import UniformTypeIdentifiers
+
+/// Compressed image payload destined for the multipart upload.
+struct CompressedImage: Sendable {
+    let data: Data
+    let mimeType: String
+    let width: Int
+    let height: Int
+}
+
+enum ImageCompressionError: Error, LocalizedError {
+    case decodeFailed
+    case encodeFailed
+    case empty
+
+    var errorDescription: String? {
+        switch self {
+        case .decodeFailed: return "Could not decode image."
+        case .encodeFailed: return "Could not encode image."
+        case .empty: return "Empty image."
+        }
+    }
+}
+
+enum ImageCompression {
+    static let maxLongEdge: CGFloat = 2048
+    static let jpegQuality: CGFloat = 0.85
+
+    /// Decode → downscale (longest edge ≤ 2048) → JPEG @ 0.85.
+    /// JPEG is the broadest-compatible target across the server's allow-list
+    /// (png/jpeg/webp/gif). HEIC roundtrips into Codex are unproven and
+    /// adding a webp encode for iOS is not worth the dependency here.
+    static func compress(_ data: Data) throws -> CompressedImage {
+        guard !data.isEmpty else { throw ImageCompressionError.empty }
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let cg = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw ImageCompressionError.decodeFailed
+        }
+        let original = UIImage(cgImage: cg)
+        let scaled = downscale(original)
+        guard let jpeg = scaled.jpegData(compressionQuality: jpegQuality) else {
+            throw ImageCompressionError.encodeFailed
+        }
+        return CompressedImage(
+            data: jpeg,
+            mimeType: "image/jpeg",
+            width: Int(scaled.size.width * scaled.scale),
+            height: Int(scaled.size.height * scaled.scale),
+        )
+    }
+
+    private static func downscale(_ image: UIImage) -> UIImage {
+        let pixelWidth = image.size.width * image.scale
+        let pixelHeight = image.size.height * image.scale
+        let longest = max(pixelWidth, pixelHeight)
+        guard longest > maxLongEdge else { return image }
+        let scale = maxLongEdge / longest
+        let target = CGSize(width: pixelWidth * scale, height: pixelHeight * scale)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: target, format: format)
+        return renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: target))
+        }
+    }
+}

--- a/ios/Sources/Shared/LonghouseAPI.swift
+++ b/ios/Sources/Shared/LonghouseAPI.swift
@@ -319,15 +319,26 @@ struct LonghouseAPI: Sendable {
         request.httpMethod = "POST"
         request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
-        request.httpBody = Self.buildMultipartBody(
+        request.addValue("Longhouse-iOS", forHTTPHeaderField: "User-Agent")
+        let body = Self.buildMultipartBody(
             boundary: boundary,
             text: text,
             intent: "auto",
             clientRequestId: clientRequestId,
             attachments: attachments,
         )
+        request.httpBody = body
+        let totalBytes = body.count
+        let attachmentBytes = attachments.reduce(0) { $0 + $1.byteSize }
+        let started = Date()
 
         let (data, httpResponse) = try await data(for: request)
+        let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
+        print(
+            "[image-attach] ios upload count=\(attachments.count) " +
+            "attachment_bytes=\(attachmentBytes) total_bytes=\(totalBytes) " +
+            "status=\(httpResponse.statusCode) elapsed_ms=\(elapsedMs)"
+        )
         guard (200..<300).contains(httpResponse.statusCode) else {
             if let structured = Self.parseStructuredError(statusCode: httpResponse.statusCode, data: data) {
                 throw structured

--- a/ios/Sources/Shared/LonghouseAPI.swift
+++ b/ios/Sources/Shared/LonghouseAPI.swift
@@ -103,6 +103,7 @@ protocol SessionWorkspaceClient: Sendable {
         snapshotEventId: Int?
     ) async throws -> SessionMobileTailResponse
     func sendInput(id: String, text: String, intent: String, clientRequestId: String?) async throws -> SessionInputResponse
+    func sendInputMultipart(id: String, text: String, attachments: [ComposerAttachment], clientRequestId: String?) async throws -> SessionInputResponse
     func draftReply(id: String, maxChars: Int) async throws -> DraftReplyResponse
     func setSessionLoopMode(id: String, loopMode: SessionLoopMode) async throws -> LoopModeResponse
     func postRenderBeacon(_ payload: RenderBeaconReporter.Payload) async
@@ -303,6 +304,72 @@ struct LonghouseAPI: Sendable {
             throw LonghouseAPIError.from(statusCode: httpResponse.statusCode)
         }
         return try JSONDecoder.snakeCase.decode(APISessionInputResponse.self, from: data).sessionInputResponse
+    }
+
+    /// Multipart POST for inputs that include image attachments. Server route
+    /// only accepts `intent=auto` in v1 (steer/queue must use the JSON endpoint).
+    func sendInputMultipart(
+        id: String,
+        text: String,
+        attachments: [ComposerAttachment],
+        clientRequestId: String? = nil
+    ) async throws -> SessionInputResponse {
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: baseURL.appendingPathComponent("/api/sessions/\(id)/inputs-multipart"))
+        request.httpMethod = "POST"
+        request.addValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = Self.buildMultipartBody(
+            boundary: boundary,
+            text: text,
+            intent: "auto",
+            clientRequestId: clientRequestId,
+            attachments: attachments,
+        )
+
+        let (data, httpResponse) = try await data(for: request)
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            if let structured = Self.parseStructuredError(statusCode: httpResponse.statusCode, data: data) {
+                throw structured
+            }
+            throw LonghouseAPIError.from(statusCode: httpResponse.statusCode)
+        }
+        return try JSONDecoder.snakeCase.decode(APISessionInputResponse.self, from: data).sessionInputResponse
+    }
+
+    static func buildMultipartBody(
+        boundary: String,
+        text: String,
+        intent: String,
+        clientRequestId: String?,
+        attachments: [ComposerAttachment]
+    ) -> Data {
+        var body = Data()
+        let crlf = "\r\n"
+        let dashes = "--"
+
+        func appendField(name: String, value: String) {
+            body.append("\(dashes)\(boundary)\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"\(name)\"\(crlf)\(crlf)".data(using: .utf8)!)
+            body.append(value.data(using: .utf8) ?? Data())
+            body.append(crlf.data(using: .utf8)!)
+        }
+
+        appendField(name: "text", value: text)
+        appendField(name: "intent", value: intent)
+        if let clientRequestId, !clientRequestId.isEmpty {
+            appendField(name: "client_request_id", value: clientRequestId)
+        }
+
+        for attachment in attachments {
+            body.append("\(dashes)\(boundary)\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"images\"; filename=\"\(attachment.filename)\"\(crlf)".data(using: .utf8)!)
+            body.append("Content-Type: \(attachment.mimeType)\(crlf)\(crlf)".data(using: .utf8)!)
+            body.append(attachment.data)
+            body.append(crlf.data(using: .utf8)!)
+        }
+        body.append("\(dashes)\(boundary)\(dashes)\(crlf)".data(using: .utf8)!)
+        return body
     }
 
     /// Extract `{"detail": {"error_code": ..., "message": ...}}` from an

--- a/ios/Sources/Shared/LonghouseAPI.swift
+++ b/ios/Sources/Shared/LonghouseAPI.swift
@@ -332,7 +332,18 @@ struct LonghouseAPI: Sendable {
         let attachmentBytes = attachments.reduce(0) { $0 + $1.byteSize }
         let started = Date()
 
-        let (data, httpResponse) = try await data(for: request)
+        let data: Data
+        let httpResponse: HTTPURLResponse
+        do {
+            (data, httpResponse) = try await self.data(for: request)
+        } catch {
+            let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
+            print(
+                "[image-attach] ios upload transport_failed count=\(attachments.count) " +
+                "attachment_bytes=\(attachmentBytes) total_bytes=\(totalBytes) elapsed_ms=\(elapsedMs)"
+            )
+            throw error
+        }
         let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
         print(
             "[image-attach] ios upload count=\(attachments.count) " +

--- a/ios/Sources/Shared/LonghouseAPI.swift
+++ b/ios/Sources/Shared/LonghouseAPI.swift
@@ -362,14 +362,22 @@ struct LonghouseAPI: Sendable {
         }
 
         for attachment in attachments {
+            let safeFilename = sanitizeMultipartFilename(attachment.filename)
             body.append("\(dashes)\(boundary)\(crlf)".data(using: .utf8)!)
-            body.append("Content-Disposition: form-data; name=\"images\"; filename=\"\(attachment.filename)\"\(crlf)".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"attachments\"; filename=\"\(safeFilename)\"\(crlf)".data(using: .utf8)!)
             body.append("Content-Type: \(attachment.mimeType)\(crlf)\(crlf)".data(using: .utf8)!)
             body.append(attachment.data)
             body.append(crlf.data(using: .utf8)!)
         }
         body.append("\(dashes)\(boundary)\(dashes)\(crlf)".data(using: .utf8)!)
         return body
+    }
+
+    private static func sanitizeMultipartFilename(_ name: String) -> String {
+        let stripped = name.replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: "\r", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+        return stripped.isEmpty ? "image.jpg" : stripped
     }
 
     /// Extract `{"detail": {"error_code": ..., "message": ...}}` from an

--- a/ios/Sources/Shared/SessionAPIAdapters.swift
+++ b/ios/Sources/Shared/SessionAPIAdapters.swift
@@ -59,7 +59,8 @@ extension APISessionCapabilitiesResponse {
             defaultInputIntent: defaultInputIntent,
             composerEnabled: composerEnabled,
             composerPlaceholder: composerPlaceholder,
-            composerDisabledReason: composerDisabledReason
+            composerDisabledReason: composerDisabledReason,
+            attachImages: attachImages
         )
     }
 }

--- a/ios/Sources/Shared/SessionModels.swift
+++ b/ios/Sources/Shared/SessionModels.swift
@@ -597,6 +597,7 @@ struct SessionCapabilities: Codable, Sendable {
     let composerEnabled: Bool?
     let composerPlaceholder: String?
     let composerDisabledReason: String?
+    let attachImages: Bool?
 }
 
 struct TimelineBadgePresentation: Codable, Hashable, Sendable {
@@ -755,6 +756,12 @@ struct SessionDetail: Codable, Identifiable, Sendable {
 
     var canSendLive: Bool {
         capabilities.composerEnabled ?? (capabilities.liveControlAvailable || capabilities.replyToLiveSessionAvailable)
+    }
+
+    /// Codex managed sessions advertise `attach_images=true` once both the
+    /// backend and the engine on this device support the attach pipeline.
+    var attachImagesEnabled: Bool {
+        canSendLive && (capabilities.attachImages ?? false)
     }
 
     var canQueueNextInput: Bool {

--- a/ios/Tests/LonghouseIOSTests/ImageCompressionTests.swift
+++ b/ios/Tests/LonghouseIOSTests/ImageCompressionTests.swift
@@ -74,7 +74,7 @@ struct MultipartBodyTests {
         #expect(s.contains("name=\"intent\""))
         #expect(s.contains("name=\"client_request_id\""))
         #expect(s.contains("ios-abc"))
-        #expect(s.contains("name=\"images\"; filename=\"shot.jpg\""))
+        #expect(s.contains("name=\"attachments\"; filename=\"shot.jpg\""))
         #expect(s.contains("Content-Type: image/jpeg"))
         #expect(s.contains("--Boundary-FIXED--"))
     }

--- a/ios/Tests/LonghouseIOSTests/ImageCompressionTests.swift
+++ b/ios/Tests/LonghouseIOSTests/ImageCompressionTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+import UIKit
+@testable import Longhouse
+
+struct ImageCompressionTests {
+    @Test
+    func emptyDataIsRejected() {
+        #expect(throws: ImageCompressionError.self) {
+            _ = try ImageCompression.compress(Data())
+        }
+    }
+
+    @Test
+    func nonImageDataIsRejected() {
+        let bytes = "not an image".data(using: .utf8)!
+        #expect(throws: ImageCompressionError.self) {
+            _ = try ImageCompression.compress(bytes)
+        }
+    }
+
+    @Test
+    func smallImagePassesThrough() throws {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 100, height: 80), format: format)
+        let original = renderer.image { ctx in
+            UIColor.red.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 100, height: 80))
+        }
+        let png = try #require(original.pngData())
+        let out = try ImageCompression.compress(png)
+        #expect(out.mimeType == "image/jpeg")
+        #expect(out.width == 100)
+        #expect(out.height == 80)
+    }
+
+    @Test
+    func longestEdgeIsScaledTo2048() throws {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 4096, height: 3072), format: format)
+        let original = renderer.image { ctx in
+            UIColor.blue.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 4096, height: 3072))
+        }
+        let png = try #require(original.pngData())
+        let out = try ImageCompression.compress(png)
+        #expect(out.width == 2048)
+        #expect(out.height == 1536)
+    }
+}
+
+struct MultipartBodyTests {
+    @Test
+    func bodyContainsTextAndAttachmentParts() throws {
+        let attachment = ComposerAttachment(
+            id: UUID(),
+            filename: "shot.jpg",
+            data: Data([0xFF, 0xD8, 0xFF, 0xD9]),
+            mimeType: "image/jpeg",
+            thumbnail: nil,
+        )
+        let body = LonghouseAPI.buildMultipartBody(
+            boundary: "Boundary-FIXED",
+            text: "describe this",
+            intent: "auto",
+            clientRequestId: "ios-abc",
+            attachments: [attachment],
+        )
+        let s = try #require(String(data: body, encoding: .isoLatin1))
+        #expect(s.contains("Content-Disposition: form-data; name=\"text\""))
+        #expect(s.contains("describe this"))
+        #expect(s.contains("name=\"intent\""))
+        #expect(s.contains("name=\"client_request_id\""))
+        #expect(s.contains("ios-abc"))
+        #expect(s.contains("name=\"images\"; filename=\"shot.jpg\""))
+        #expect(s.contains("Content-Type: image/jpeg"))
+        #expect(s.contains("--Boundary-FIXED--"))
+    }
+
+    @Test
+    func bodyOmitsClientRequestIdWhenNil() throws {
+        let body = LonghouseAPI.buildMultipartBody(
+            boundary: "B",
+            text: "hi",
+            intent: "auto",
+            clientRequestId: nil,
+            attachments: [],
+        )
+        let s = try #require(String(data: body, encoding: .utf8))
+        #expect(!s.contains("client_request_id"))
+    }
+}

--- a/ios/Tests/LonghouseIOSTests/SessionViewModelTests.swift
+++ b/ios/Tests/LonghouseIOSTests/SessionViewModelTests.swift
@@ -715,6 +715,10 @@ private actor FakeSessionWorkspaceClient: SessionWorkspaceClient {
         return sendResponse
     }
 
+    func sendInputMultipart(id: String, text: String, attachments: [ComposerAttachment], clientRequestId: String?) async throws -> SessionInputResponse {
+        try await sendInput(id: id, text: text, intent: "auto", clientRequestId: clientRequestId)
+    }
+
     func draftReply(id: String, maxChars: Int) async throws -> DraftReplyResponse {
         DraftReplyResponse(draftText: "Draft", model: "test", generatedAt: "2026-05-02T20:00:00Z", basedOnEventIds: [])
     }

--- a/server/tests_lite/test_managed_local_session_chat.py
+++ b/server/tests_lite/test_managed_local_session_chat.py
@@ -250,6 +250,7 @@ def test_managed_local_claude_dispatch_returns_json_ack(monkeypatch, tmp_path):
             timeout_secs=15,
             verify_turn_started=False,
             verification_timeout_secs=None,
+            attachments=None,
         ):
             calls.append({
                 "owner_id": owner_id,
@@ -322,6 +323,7 @@ def test_managed_local_codex_dispatch_returns_json_ack(monkeypatch, tmp_path):
             timeout_secs=15,
             verify_turn_started=False,
             verification_timeout_secs=None,
+            attachments=None,
         ):
             return SimpleNamespace(ok=True, exit_code=0, error=None, verified_turn_started=True)
 
@@ -456,6 +458,7 @@ def test_managed_local_dispatch_send_failure_returns_502(monkeypatch, tmp_path):
             timeout_secs=15,
             verify_turn_started=False,
             verification_timeout_secs=None,
+            attachments=None,
         ):
             return SimpleNamespace(ok=False, exit_code=None, error="Runner send failed", verified_turn_started=False)
 
@@ -505,6 +508,7 @@ def test_managed_local_dispatch_send_failure_releases_lock_for_retry(monkeypatch
             timeout_secs=15,
             verify_turn_started=False,
             verification_timeout_secs=None,
+            attachments=None,
         ):
             nonlocal send_calls
             send_calls += 1
@@ -557,6 +561,7 @@ def test_managed_local_dispatch_requires_verified_turn_start(monkeypatch, tmp_pa
             timeout_secs=15,
             verify_turn_started=False,
             verification_timeout_secs=None,
+            attachments=None,
         ):
             return SimpleNamespace(ok=True, exit_code=0, error=None, verified_turn_started=False)
 
@@ -606,6 +611,7 @@ def test_managed_local_dispatch_keeps_lock_until_terminal(monkeypatch, tmp_path)
             timeout_secs=15,
             verify_turn_started=False,
             verification_timeout_secs=None,
+            attachments=None,
         ):
             return SimpleNamespace(ok=True, exit_code=0, error=None, verified_turn_started=True)
 
@@ -649,6 +655,7 @@ def test_managed_local_dispatch_updates_lock_endpoint_until_terminal(monkeypatch
             timeout_secs=15,
             verify_turn_started=False,
             verification_timeout_secs=None,
+            attachments=None,
         ):
             return SimpleNamespace(ok=True, exit_code=0, error=None, verified_turn_started=True)
 
@@ -861,6 +868,7 @@ def test_managed_local_dispatch_send_crash_does_not_persist_orphan_canonical_tur
             timeout_secs=15,
             verify_turn_started=False,
             verification_timeout_secs=None,
+            attachments=None,
         ):
             raise RuntimeError("dispatch crashed")
 

--- a/server/tests_lite/test_managed_local_transport.py
+++ b/server/tests_lite/test_managed_local_transport.py
@@ -92,6 +92,53 @@ def test_build_managed_local_send_text_command_uses_engine_bridge_for_codex_app_
     assert '"$engine" codex-bridge send --session-id session-123 --text continue' in inner
 
 
+def test_build_managed_local_send_text_command_appends_attachments_json_for_codex():
+    session = SimpleNamespace(
+        id="session-123",
+        managed_transport=ManagedSessionTransport.CODEX_APP_SERVER.value,
+        provider="codex",
+    )
+    refs = [
+        {
+            "id": "att_1",
+            "mime_type": "image/png",
+            "sha256": "a" * 64,
+            "blob_url": "/api/agents/sessions/session-123/inputs/1/attachments/att_1/blob",
+        }
+    ]
+    command = build_managed_local_send_text_command(
+        session=session,
+        text="hello",
+        attachments=refs,
+    )
+    inner = _wrapped_inner(command)
+    assert "--attachments-json" in inner
+    # Either the JSON is single-quote-shell-quoted; assert it contains the id and sha.
+    assert "att_1" in inner
+    assert "a" * 64 in inner
+
+
+def test_build_managed_local_send_text_command_rejects_attachments_for_claude_channel():
+    session = SimpleNamespace(
+        id="session-123",
+        managed_transport=ManagedSessionTransport.CLAUDE_CHANNEL_BRIDGE.value,
+        provider="claude",
+    )
+    with pytest.raises(ManagedLocalTransportError):
+        build_managed_local_send_text_command(
+            session=session,
+            text="hello",
+            attachments=[
+                {
+                    "id": "x",
+                    "mime_type": "image/png",
+                    "sha256": "a" * 64,
+                    "blob_url": "/x",
+                }
+            ],
+        )
+
+
 def test_build_managed_local_send_text_command_uses_local_bridge_for_claude_channel_transport():
     session = SimpleNamespace(
         id="session-123",

--- a/server/tests_lite/test_session_chat.py
+++ b/server/tests_lite/test_session_chat.py
@@ -405,6 +405,7 @@ def test_agents_send_live_route_ignores_device_mismatch_and_dispatches(monkeypat
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         calls.append(
             {

--- a/server/tests_lite/test_session_inputs_api.py
+++ b/server/tests_lite/test_session_inputs_api.py
@@ -175,6 +175,7 @@ def _stub_dispatch(monkeypatch, *, emit_verified_user_event: bool = False):
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         calls.append({"session_id": str(session.id), "text": text, "commis_id": commis_id})
         verified_user_event_id = None

--- a/server/tests_lite/test_session_inputs_attachments_api.py
+++ b/server/tests_lite/test_session_inputs_attachments_api.py
@@ -252,8 +252,14 @@ def _stub_dispatch(monkeypatch):
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
-        calls.append({"session_id": str(session.id), "text": text, "commis_id": commis_id})
+        calls.append({
+            "session_id": str(session.id),
+            "text": text,
+            "commis_id": commis_id,
+            "attachments": list(attachments or []),
+        })
         return SimpleNamespace(
             ok=True,
             exit_code=0,
@@ -297,6 +303,13 @@ def test_multipart_upload_succeeds_on_codex(monkeypatch, tmp_path):
         assert body["intent"] == "auto"
         assert len(calls) == 1
         assert calls[0]["text"] == "look at this"
+        forwarded = calls[0]["attachments"]
+        assert len(forwarded) == 1
+        ref = forwarded[0]
+        assert ref["mime_type"] == "image/png"
+        assert len(ref["sha256"]) == 64
+        assert ref["blob_url"].startswith(f"/api/agents/sessions/{session_id}/inputs/")
+        assert ref["blob_url"].endswith("/blob")
 
         with session_local() as db:
             row = db.query(SessionInput).filter(SessionInput.session_id == session_id).one()
@@ -311,6 +324,8 @@ def test_multipart_upload_succeeds_on_codex(monkeypatch, tmp_path):
             assert attach.mime_type == "image/png"
             assert attach.byte_size == len(_PNG_BYTES)
             assert len(attach.sha256) == 64
+            assert ref["id"] == str(attach.id)
+            assert ref["sha256"] == attach.sha256
     finally:
         asyncio.run(session_lock_manager.release(str(session_id)))
         api_app_ref.dependency_overrides = {}

--- a/server/tests_lite/test_session_inputs_attachments_api.py
+++ b/server/tests_lite/test_session_inputs_attachments_api.py
@@ -1,0 +1,552 @@
+"""Tests for the multipart input + attachment blob fetch endpoints.
+
+Mirrors the structure of test_session_inputs_api.py for fixtures, but
+exercises POST /sessions/{id}/inputs-multipart and the machine-token
+GET /agents/sessions/.../attachments/{aid}/blob path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("TESTING", "1")
+os.environ.setdefault("FERNET_SECRET", Fernet.generate_key().decode())
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret-1234")
+os.environ.setdefault("INTERNAL_API_SECRET", "test-internal-secret-1234")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "test-google-client-id")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test-google-client-secret")
+
+from zerg.database import get_db
+from zerg.database import initialize_database
+from zerg.database import make_engine
+from zerg.database import make_sessionmaker
+from zerg.dependencies.agents_auth import require_single_tenant
+from zerg.dependencies.agents_auth import verify_agents_token
+from zerg.dependencies.browser_route_auth import get_current_browser_route_user
+from zerg.models.agents import AgentEvent
+from zerg.models.agents import AgentSession
+from zerg.models.agents import SessionConnection
+from zerg.models.agents import SessionInput
+from zerg.models.agents import SessionInputAttachment
+from zerg.models.agents import SessionRun
+from zerg.models.agents import SessionRuntimeState
+from zerg.models.agents import SessionThread
+from zerg.models.enums import UserRole
+from zerg.models.models import Runner
+from zerg.models.user import User
+from zerg.services.agents_store import AgentsStore
+from zerg.services.agents_store import EventIngest
+from zerg.services.agents_store import SessionIngest
+from zerg.services.runner_connection_manager import get_runner_connection_manager
+from zerg.services.session_continuity import session_lock_manager
+from zerg.services.session_input_attachments import cleanup_stale_blobs
+from zerg.services.session_inputs import INPUT_STATUS_DELIVERED
+from zerg.services.session_runtime import phase_freshness_ms
+from zerg.services.session_runtime import runtime_key_for_session
+from tests_lite._kernel_test_helpers import seed_managed_kernel_rows
+
+
+# A 1x1 PNG (~70 bytes) — enough to hash, well under the 2MB cap.
+_PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00"
+    b"\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9c"
+    b"c\xfc\xcf\xc0P\x0f\x00\x05\x01\x01\x02\xb4\x9d\xb1\xa6\x00\x00\x00"
+    b"\x00IEND\xaeB`\x82"
+)
+
+
+def _make_db(tmp_path):
+    db_path = tmp_path / "test_session_inputs_attachments.db"
+    engine = make_engine(f"sqlite:///{db_path}")
+    initialize_database(engine)
+    return make_sessionmaker(engine)
+
+
+def _make_client(session_local, current_user):
+    from zerg.main import api_app
+    from zerg.main import app
+
+    def override_get_db():
+        db = session_local()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def override_current_user():
+        return current_user
+
+    api_app.dependency_overrides[get_db] = override_get_db
+    api_app.dependency_overrides[get_current_browser_route_user] = override_current_user
+    return TestClient(app, backend="asyncio"), api_app
+
+
+def _seed_live_runtime_state(db, session, *, phase: str = "running") -> None:
+    now = datetime.now(timezone.utc)
+    freshness_ms = phase_freshness_ms(phase) or int(timedelta(minutes=5).total_seconds() * 1000)
+    key = runtime_key_for_session(str(session.provider or "codex"), str(session.id))
+    state = db.query(SessionRuntimeState).filter(SessionRuntimeState.runtime_key == key).first()
+    if state is None:
+        state = SessionRuntimeState(
+            runtime_key=key,
+            session_id=session.id,
+            provider=str(session.provider or "codex"),
+            device_id=session.device_id,
+        )
+        db.add(state)
+    state.phase = phase
+    state.phase_source = "semantic"
+    state.phase_started_at = now
+    state.last_runtime_signal_at = now
+    state.last_progress_at = now
+    state.last_live_at = now
+    state.timeline_anchor_at = now
+    state.freshness_expires_at = now + timedelta(milliseconds=freshness_ms)
+    state.terminal_state = None
+    state.terminal_at = None
+    state.runtime_version = int(getattr(state, "runtime_version", 0) or 0) + 1
+    db.commit()
+
+
+def _seed_codex_session(session_local):
+    """Seed a managed-local codex session that satisfies the attach_images gate."""
+    session_id = uuid4()
+    provider_session_id = f"codex-attach-{uuid4().hex[:8]}"
+    with session_local() as db:
+        user = User(email=f"attach-{uuid4().hex[:6]}@test.local", role=UserRole.USER.value)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+        store = AgentsStore(db)
+        started_at = datetime.now(timezone.utc)
+        store.ingest_session(
+            SessionIngest(
+                id=session_id,
+                provider="codex",
+                environment="Cinder",
+                project="codex-attach",
+                device_id="cinder",
+                cwd="/tmp",
+                git_repo=None,
+                git_branch=None,
+                provider_session_id=provider_session_id,
+                started_at=started_at,
+                ended_at=started_at,
+                events=[
+                    EventIngest(
+                        role="user",
+                        content_text="seed",
+                        timestamp=started_at,
+                        source_path="/tmp/session.jsonl",
+                        source_offset=0,
+                    )
+                ],
+            )
+        )
+        session = store.get_session(session_id)
+        assert session is not None
+        session.execution_home = "managed_local"
+        session.managed_transport = "codex_app_server"
+        session.source_runner_id = 1
+        session.source_runner_name = "cinder"
+        session.managed_session_name = "lh-attach"
+        seed_managed_kernel_rows(db, session, control_plane="codex_bridge")
+        runner = Runner(
+            id=1,
+            owner_id=user.id,
+            name="cinder",
+            status="online",
+            auth_secret_hash="test",
+        )
+        db.merge(runner)
+        db.commit()
+        get_runner_connection_manager().register(user.id, 1, SimpleNamespace())
+        _seed_live_runtime_state(db, session)
+        user_id = user.id
+
+    return session_id, user_id
+
+
+def _seed_claude_session(session_local):
+    """Seed a Claude channel session — attach_images gate should reject."""
+    session_id = uuid4()
+    provider_session_id = f"claude-noattach-{uuid4().hex[:8]}"
+    with session_local() as db:
+        user = User(email=f"noattach-{uuid4().hex[:6]}@test.local", role=UserRole.USER.value)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+        store = AgentsStore(db)
+        started_at = datetime.now(timezone.utc)
+        store.ingest_session(
+            SessionIngest(
+                id=session_id,
+                provider="claude",
+                environment="Cinder",
+                project="claude-attach",
+                device_id="cinder",
+                cwd="/tmp",
+                git_repo=None,
+                git_branch=None,
+                provider_session_id=provider_session_id,
+                started_at=started_at,
+                ended_at=started_at,
+                events=[
+                    EventIngest(
+                        role="user",
+                        content_text="seed",
+                        timestamp=started_at,
+                        source_path="/tmp/session.jsonl",
+                        source_offset=0,
+                    )
+                ],
+            )
+        )
+        session = store.get_session(session_id)
+        assert session is not None
+        session.execution_home = "managed_local"
+        session.managed_transport = "claude_channel_bridge"
+        session.source_runner_id = 1
+        session.source_runner_name = "cinder"
+        session.managed_session_name = "lh-noattach"
+        seed_managed_kernel_rows(db, session, control_plane="claude_channel_bridge")
+        runner = Runner(
+            id=1,
+            owner_id=user.id,
+            name="cinder",
+            status="online",
+            auth_secret_hash="test",
+        )
+        db.merge(runner)
+        db.commit()
+        get_runner_connection_manager().register(user.id, 1, SimpleNamespace())
+        _seed_live_runtime_state(db, session, phase="idle")
+        user_id = user.id
+
+    return session_id, user_id
+
+
+def _stub_dispatch(monkeypatch):
+    calls: list[dict] = []
+
+    async def fake_send_text(
+        *,
+        db,
+        owner_id,
+        session,
+        text,
+        commis_id=None,
+        timeout_secs=15,
+        verify_turn_started=False,
+        verification_timeout_secs=None,
+    ):
+        calls.append({"session_id": str(session.id), "text": text, "commis_id": commis_id})
+        return SimpleNamespace(
+            ok=True,
+            exit_code=0,
+            error=None,
+            verified_turn_started=True,
+            verified_user_event_id=None,
+        )
+
+    monkeypatch.setattr("zerg.services.live_session_dispatch.send_text_to_live_session", fake_send_text)
+    monkeypatch.setattr("zerg.services.session_chat_impl._schedule_managed_local_lock_release", lambda **_: None)
+    monkeypatch.setattr(
+        "zerg.services.session_chat_impl._schedule_managed_local_active_phase_observation",
+        lambda **_: None,
+    )
+    return calls
+
+
+def _set_blob_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("LONGHOUSE_ATTACHMENT_BLOB_ROOT", str(tmp_path / "blobs"))
+
+
+def test_multipart_upload_succeeds_on_codex(monkeypatch, tmp_path):
+    _set_blob_root(monkeypatch, tmp_path)
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_codex_session(session_local)
+    calls = _stub_dispatch(monkeypatch)
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    try:
+        resp = client.post(
+            f"/api/sessions/{session_id}/inputs-multipart",
+            data={"text": "look at this", "intent": "auto"},
+            files=[("attachments", ("a.png", io.BytesIO(_PNG_BYTES), "image/png"))],
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["outcome"] == "sent"
+        assert body["intent"] == "auto"
+        assert len(calls) == 1
+        assert calls[0]["text"] == "look at this"
+
+        with session_local() as db:
+            row = db.query(SessionInput).filter(SessionInput.session_id == session_id).one()
+            assert row.status == INPUT_STATUS_DELIVERED
+            attachments = (
+                db.query(SessionInputAttachment)
+                .filter(SessionInputAttachment.session_input_id == row.id)
+                .all()
+            )
+            assert len(attachments) == 1
+            attach = attachments[0]
+            assert attach.mime_type == "image/png"
+            assert attach.byte_size == len(_PNG_BYTES)
+            assert len(attach.sha256) == 64
+    finally:
+        asyncio.run(session_lock_manager.release(str(session_id)))
+        api_app_ref.dependency_overrides = {}
+
+
+def test_multipart_rejects_non_codex_transport(monkeypatch, tmp_path):
+    _set_blob_root(monkeypatch, tmp_path)
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_claude_session(session_local)
+    _stub_dispatch(monkeypatch)
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    try:
+        resp = client.post(
+            f"/api/sessions/{session_id}/inputs-multipart",
+            data={"text": "blocked", "intent": "auto"},
+            files=[("attachments", ("a.png", io.BytesIO(_PNG_BYTES), "image/png"))],
+        )
+        assert resp.status_code == 409, resp.text
+        assert "codex" in resp.json()["detail"].lower()
+
+        with session_local() as db:
+            assert db.query(SessionInput).count() == 0
+            assert db.query(SessionInputAttachment).count() == 0
+    finally:
+        api_app_ref.dependency_overrides = {}
+
+
+def test_multipart_rejects_queue_intent(monkeypatch, tmp_path):
+    _set_blob_root(monkeypatch, tmp_path)
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_codex_session(session_local)
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    try:
+        resp = client.post(
+            f"/api/sessions/{session_id}/inputs-multipart",
+            data={"text": "queue?", "intent": "queue"},
+            files=[("attachments", ("a.png", io.BytesIO(_PNG_BYTES), "image/png"))],
+        )
+        assert resp.status_code == 400, resp.text
+        assert "intent" in resp.json()["detail"].lower()
+    finally:
+        api_app_ref.dependency_overrides = {}
+
+
+def test_multipart_rejects_unsupported_mime(monkeypatch, tmp_path):
+    _set_blob_root(monkeypatch, tmp_path)
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_codex_session(session_local)
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    try:
+        resp = client.post(
+            f"/api/sessions/{session_id}/inputs-multipart",
+            data={"text": "bad type", "intent": "auto"},
+            files=[("attachments", ("a.txt", io.BytesIO(b"hi"), "text/plain"))],
+        )
+        assert resp.status_code == 400, resp.text
+        assert "unsupported" in resp.json()["detail"].lower()
+    finally:
+        api_app_ref.dependency_overrides = {}
+
+
+def test_multipart_rejects_oversize(monkeypatch, tmp_path):
+    _set_blob_root(monkeypatch, tmp_path)
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_codex_session(session_local)
+    _stub_dispatch(monkeypatch)
+
+    big = b"\x00" * (3 * 1024 * 1024)  # 3 MB > 2 MB cap
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    try:
+        resp = client.post(
+            f"/api/sessions/{session_id}/inputs-multipart",
+            data={"text": "huge", "intent": "auto"},
+            files=[("attachments", ("big.png", io.BytesIO(big), "image/png"))],
+        )
+        assert resp.status_code == 400, resp.text
+        assert "MB" in resp.json()["detail"] or "exceed" in resp.json()["detail"].lower()
+    finally:
+        asyncio.run(session_lock_manager.release(str(session_id)))
+        api_app_ref.dependency_overrides = {}
+
+
+def test_machine_blob_fetch_streams_bytes(monkeypatch, tmp_path):
+    _set_blob_root(monkeypatch, tmp_path)
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_codex_session(session_local)
+    _stub_dispatch(monkeypatch)
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+
+    def override_verify():
+        return SimpleNamespace(device_id="cinder", id="token-1", owner_id=user_id)
+
+    def override_single():
+        return None
+
+    api_app_ref.dependency_overrides[verify_agents_token] = override_verify
+    api_app_ref.dependency_overrides[require_single_tenant] = override_single
+
+    try:
+        upload = client.post(
+            f"/api/sessions/{session_id}/inputs-multipart",
+            data={"text": "look", "intent": "auto"},
+            files=[("attachments", ("a.png", io.BytesIO(_PNG_BYTES), "image/png"))],
+        )
+        assert upload.status_code == 200, upload.text
+        input_id = upload.json()["input_id"]
+
+        with session_local() as db:
+            attach = (
+                db.query(SessionInputAttachment)
+                .filter(SessionInputAttachment.session_input_id == input_id)
+                .one()
+            )
+            attach_id = attach.id
+            sha = attach.sha256
+
+        resp = client.get(
+            f"/api/agents/sessions/{session_id}/inputs/{input_id}/attachments/{attach_id}/blob",
+            headers={"X-Agents-Token": "dev"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.content == _PNG_BYTES
+        assert resp.headers["X-Attachment-Sha256"] == sha
+        assert resp.headers["X-Attachment-Bytes"] == str(len(_PNG_BYTES))
+    finally:
+        asyncio.run(session_lock_manager.release(str(session_id)))
+        api_app_ref.dependency_overrides = {}
+
+
+def test_machine_blob_fetch_404_on_session_mismatch(monkeypatch, tmp_path):
+    _set_blob_root(monkeypatch, tmp_path)
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_codex_session(session_local)
+    _stub_dispatch(monkeypatch)
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    api_app_ref.dependency_overrides[verify_agents_token] = lambda: SimpleNamespace(
+        device_id="cinder", id="token-1", owner_id=user_id
+    )
+    api_app_ref.dependency_overrides[require_single_tenant] = lambda: None
+
+    try:
+        upload = client.post(
+            f"/api/sessions/{session_id}/inputs-multipart",
+            data={"text": "look", "intent": "auto"},
+            files=[("attachments", ("a.png", io.BytesIO(_PNG_BYTES), "image/png"))],
+        )
+        assert upload.status_code == 200
+        input_id = upload.json()["input_id"]
+
+        with session_local() as db:
+            attach = (
+                db.query(SessionInputAttachment)
+                .filter(SessionInputAttachment.session_input_id == input_id)
+                .one()
+            )
+            attach_id = attach.id
+
+        bogus_session = uuid4()
+        resp = client.get(
+            f"/api/agents/sessions/{bogus_session}/inputs/{input_id}/attachments/{attach_id}/blob",
+            headers={"X-Agents-Token": "dev"},
+        )
+        assert resp.status_code == 404, resp.text
+    finally:
+        asyncio.run(session_lock_manager.release(str(session_id)))
+        api_app_ref.dependency_overrides = {}
+
+
+def test_cleanup_stale_blobs_removes_terminal_aged_rows(monkeypatch, tmp_path):
+    _set_blob_root(monkeypatch, tmp_path)
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_codex_session(session_local)
+    _stub_dispatch(monkeypatch)
+
+    client, api_app_ref = _make_client(
+        session_local,
+        SimpleNamespace(id=user_id, email="x@y", role=UserRole.USER.value),
+    )
+    try:
+        upload = client.post(
+            f"/api/sessions/{session_id}/inputs-multipart",
+            data={"text": "look", "intent": "auto"},
+            files=[("attachments", ("a.png", io.BytesIO(_PNG_BYTES), "image/png"))],
+        )
+        assert upload.status_code == 200, upload.text
+        input_id = upload.json()["input_id"]
+
+        with session_local() as db:
+            row = db.query(SessionInput).filter(SessionInput.id == input_id).one()
+            assert row.status == INPUT_STATUS_DELIVERED
+            attach = (
+                db.query(SessionInputAttachment)
+                .filter(SessionInputAttachment.session_input_id == input_id)
+                .one()
+            )
+            blob_path = tmp_path / "blobs" / attach.blob_path
+            assert blob_path.exists()
+
+            # Age the row beyond retention.
+            attach.created_at = datetime.now(timezone.utc) - timedelta(days=2)
+            db.add(attach)
+            db.commit()
+
+            removed = cleanup_stale_blobs(db)
+            assert removed == 1
+            assert not blob_path.exists()
+            assert (
+                db.query(SessionInputAttachment)
+                .filter(SessionInputAttachment.session_input_id == input_id)
+                .count()
+                == 0
+            )
+    finally:
+        asyncio.run(session_lock_manager.release(str(session_id)))
+        api_app_ref.dependency_overrides = {}

--- a/server/tests_lite/test_session_inputs_attachments_api.py
+++ b/server/tests_lite/test_session_inputs_attachments_api.py
@@ -27,6 +27,7 @@ os.environ.setdefault("INTERNAL_API_SECRET", "test-internal-secret-1234")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "test-google-client-id")
 os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test-google-client-secret")
 
+from tests_lite._kernel_test_helpers import seed_managed_kernel_rows
 from zerg.database import get_db
 from zerg.database import initialize_database
 from zerg.database import make_engine
@@ -34,14 +35,9 @@ from zerg.database import make_sessionmaker
 from zerg.dependencies.agents_auth import require_single_tenant
 from zerg.dependencies.agents_auth import verify_agents_token
 from zerg.dependencies.browser_route_auth import get_current_browser_route_user
-from zerg.models.agents import AgentEvent
-from zerg.models.agents import AgentSession
-from zerg.models.agents import SessionConnection
 from zerg.models.agents import SessionInput
 from zerg.models.agents import SessionInputAttachment
-from zerg.models.agents import SessionRun
 from zerg.models.agents import SessionRuntimeState
-from zerg.models.agents import SessionThread
 from zerg.models.enums import UserRole
 from zerg.models.models import Runner
 from zerg.models.user import User
@@ -51,11 +47,13 @@ from zerg.services.agents_store import SessionIngest
 from zerg.services.runner_connection_manager import get_runner_connection_manager
 from zerg.services.session_continuity import session_lock_manager
 from zerg.services.session_input_attachments import cleanup_stale_blobs
+from zerg.services.session_input_attachments import store_attachment_blob
 from zerg.services.session_inputs import INPUT_STATUS_DELIVERED
+from zerg.services.session_inputs import INPUT_STATUS_FAILED
+from zerg.services.session_inputs import create_session_input
+from zerg.services.session_inputs import requeue_stuck_delivering
 from zerg.services.session_runtime import phase_freshness_ms
 from zerg.services.session_runtime import runtime_key_for_session
-from tests_lite._kernel_test_helpers import seed_managed_kernel_rows
-
 
 # A 1x1 PNG (~70 bytes) — enough to hash, well under the 2MB cap.
 _PNG_BYTES = (
@@ -565,3 +563,39 @@ def test_cleanup_stale_blobs_removes_terminal_aged_rows(monkeypatch, tmp_path):
     finally:
         asyncio.run(session_lock_manager.release(str(session_id)))
         api_app_ref.dependency_overrides = {}
+
+
+def test_startup_reconciliation_fails_stuck_attachment_rows(monkeypatch, tmp_path):
+    _set_blob_root(monkeypatch, tmp_path)
+    session_local = _make_db(tmp_path)
+    session_id, user_id = _seed_codex_session(session_local)
+
+    with session_local() as db:
+        row = create_session_input(
+            db,
+            session_id=session_id,
+            text="look at this",
+            owner_id=user_id,
+            intent="auto",
+            status="delivering",
+            client_request_id="crash-attachment",
+            delivery_request_id="crash-attachment-delivery",
+        )
+        store_attachment_blob(
+            db,
+            session_input=row,
+            mime_type="image/png",
+            data=_PNG_BYTES,
+            original_filename="a.png",
+            original_byte_size=len(_PNG_BYTES),
+        )
+        row.updated_at = datetime.now(timezone.utc) - timedelta(seconds=300)
+        db.commit()
+
+        requeued = requeue_stuck_delivering(db)
+
+        assert requeued == 0
+        db.expire_all()
+        refreshed = db.query(SessionInput).filter(SessionInput.id == row.id).one()
+        assert refreshed.status == INPUT_STATUS_FAILED
+        assert refreshed.last_error == "attachment delivery interrupted by restart"

--- a/server/tests_lite/test_session_inputs_stress.py
+++ b/server/tests_lite/test_session_inputs_stress.py
@@ -183,6 +183,7 @@ def _install_dispatch_stubs(monkeypatch, *, send_latency_secs: float = 0.0):
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         if send_latency_secs > 0:
             await asyncio.sleep(send_latency_secs)

--- a/server/tests_lite/test_session_messages.py
+++ b/server/tests_lite/test_session_messages.py
@@ -198,6 +198,7 @@ def test_create_message_delivers_immediately_for_safe_managed_local(monkeypatch,
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         send_calls.append(
             {
@@ -308,6 +309,7 @@ def test_create_message_uses_runtime_state_when_presence_missing(monkeypatch, tm
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         send_calls.append(
             {
@@ -379,6 +381,7 @@ def test_create_message_delivers_to_engine_controlled_codex_without_runner(monke
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         send_calls.append(
             {
@@ -446,6 +449,7 @@ def test_presence_safe_transition_delivers_oldest_queued_message(monkeypatch, tm
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         send_calls.append(text)
         return SimpleNamespace(ok=True, error=None)
@@ -510,6 +514,7 @@ def test_runtime_safe_transition_delivers_queued_message_without_presence(monkey
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         send_calls.append(text)
         return SimpleNamespace(ok=True, error=None)
@@ -598,6 +603,7 @@ def test_presence_safe_transition_drains_multiple_queued_messages(monkeypatch, t
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         send_calls.append(text)
         return SimpleNamespace(ok=True, error=None)
@@ -668,6 +674,7 @@ def test_presence_safe_transition_stops_drain_when_session_leaves_safe_boundary(
         timeout_secs=15,
         verify_turn_started=False,
         verification_timeout_secs=None,
+        attachments=None,
     ):
         send_calls.append(text)
         _upsert_runtime_state(db, session, "running")

--- a/server/zerg/lifespan.py
+++ b/server/zerg/lifespan.py
@@ -332,6 +332,32 @@ async def lifespan(app: FastAPI):
                 failed.append(f"remote_launch_reaper ({e})")
                 logger.exception("Failed to start remote_launch_reaper")
 
+            # Image attachment blob reaper: drops blobs whose parent session_input
+            # is in a terminal state and older than the retention window.
+            try:
+                from zerg.database import get_session_factory as _get_sf_attach
+                from zerg.services.session_input_attachments import cleanup_stale_blobs
+
+                async def _attachment_cleanup_loop() -> None:
+                    while True:
+                        try:
+                            await asyncio.sleep(3600)
+                            db = _get_sf_attach()()
+                            try:
+                                cleanup_stale_blobs(db)
+                            finally:
+                                db.close()
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:  # noqa: BLE001
+                            logger.exception("attachment cleanup tick failed")
+
+                asyncio.create_task(_attachment_cleanup_loop())
+                started.append("attachment_cleanup")
+            except Exception as e:  # noqa: BLE001
+                failed.append(f"attachment_cleanup ({e})")
+                logger.exception("Failed to start attachment_cleanup")
+
             # Live session summary/title enrichment. This scans session revision
             # lag directly; it is intentionally separate from the legacy ingest
             # task workers.

--- a/server/zerg/main.py
+++ b/server/zerg/main.py
@@ -145,6 +145,8 @@ from zerg.routers.runs import router as runs_router
 from zerg.routers.runtime import router as runtime_router
 from zerg.routers.session_chat import agents_router as agents_session_chat_router
 from zerg.routers.session_chat import router as session_chat_router
+from zerg.routers.session_inputs_attachments import agents_router as agents_session_inputs_attachments_router
+from zerg.routers.session_inputs_attachments import router as session_inputs_attachments_router
 from zerg.routers.skills import router as skills_router
 from zerg.routers.stream import router as stream_router
 from zerg.routers.system import router as system_router
@@ -283,6 +285,8 @@ api_app.include_router(reliability_router)
 api_app.include_router(skills_router)
 api_app.include_router(session_chat_router)
 api_app.include_router(agents_session_chat_router)
+api_app.include_router(session_inputs_attachments_router)
+api_app.include_router(agents_session_inputs_attachments_router)
 api_app.include_router(timeline_stream_router)
 api_app.include_router(timeline_router)
 api_app.include_router(timeline_canary_stream_router)

--- a/server/zerg/metrics.py
+++ b/server/zerg/metrics.py
@@ -278,6 +278,24 @@ try:
         labelnames=("invariant",),
     )
 
+    session_input_attachments_total = Counter(
+        "session_input_attachments_total",
+        "Image-attach multipart submissions by client and outcome",
+        labelnames=("client", "outcome"),
+    )
+
+    session_input_attachment_bytes = Histogram(
+        "session_input_attachment_bytes",
+        "Bytes per stored attachment after server validation",
+        buckets=(64_000, 128_000, 256_000, 512_000, 1_024_000, 2_097_152),
+    )
+
+    session_input_attachment_blob_fetches_total = Counter(
+        "session_input_attachment_blob_fetches_total",
+        "Engine blob fetches against /api/agents/.../attachments/.../blob by outcome",
+        labelnames=("outcome",),
+    )
+
 except ModuleNotFoundError:  # pragma: no cover – metrics disabled when lib absent
 
     class _NoopCounter:  # noqa: D401 – tiny helper
@@ -303,6 +321,8 @@ except ModuleNotFoundError:  # pragma: no cover – metrics disabled when lib ab
     managed_session_heartbeat_lease_rows_total = _NoopCounter()  # type: ignore[assignment]
     managed_codex_runtime_observations_total = _NoopCounter()  # type: ignore[assignment]
     managed_codex_bridge_freshness_total = _NoopCounter()  # type: ignore[assignment]
+    session_input_attachments_total = _NoopCounter()  # type: ignore[assignment]
+    session_input_attachment_blob_fetches_total = _NoopCounter()  # type: ignore[assignment]
 
     # Provide *noop* Gauge so code can call ``set`` without importing
     # the optional dependency in minimal CI images.
@@ -349,6 +369,7 @@ except ModuleNotFoundError:  # pragma: no cover – metrics disabled when lib ab
     agents_ingest_payload_bytes = _NoopHistogram()  # type: ignore[assignment]
     agents_heartbeat_write_seconds = _NoopHistogram()  # type: ignore[assignment]
     agents_heartbeat_payload_bytes = _NoopHistogram()  # type: ignore[assignment]
+    session_input_attachment_bytes = _NoopHistogram()  # type: ignore[assignment]
     event_age_at_ingest_seconds = _NoopHistogram()  # type: ignore[assignment]
     event_end_to_end_latency_seconds = _NoopHistogram()  # type: ignore[assignment]
     event_render_beacons_total = _NoopCounter()  # type: ignore[assignment]

--- a/server/zerg/models/agents.py
+++ b/server/zerg/models/agents.py
@@ -789,6 +789,34 @@ class SessionInput(AgentsBase):
     )
 
 
+class SessionInputAttachment(AgentsBase):
+    """Image attachment associated with a SessionInput row.
+
+    The blob lives on disk under ``data/attachments/<session_id>/<id>.bin``;
+    this row records the metadata needed to render thumbnails, verify the
+    bytes the engine fetched, and clean up after delivery.
+    """
+
+    __tablename__ = "session_input_attachments"
+
+    id = Column(GUID(), primary_key=True, default=uuid4)
+    _input_fk = "session_inputs.id" if AGENTS_SCHEMA is None else f"{AGENTS_SCHEMA}.session_inputs.id"
+    session_input_id = Column(
+        Integer,
+        ForeignKey(_input_fk, ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    session_id = Column(GUID(), nullable=False, index=True)
+    mime_type = Column(String(64), nullable=False)
+    byte_size = Column(Integer, nullable=False)
+    sha256 = Column(String(64), nullable=False)
+    blob_path = Column(Text, nullable=False)
+    original_filename = Column(String(255), nullable=True)
+    original_byte_size = Column(Integer, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)
+
+
 # ---------------------------------------------------------------------------
 # Session identity kernel — see docs/specs/session-identity-kernel.md
 #

--- a/server/zerg/routers/session_inputs_attachments.py
+++ b/server/zerg/routers/session_inputs_attachments.py
@@ -126,21 +126,39 @@ async def create_session_input_with_attachments(
 ) -> SessionInputResponse:
     """Send a user input with one or more image attachments.
 
-    v1 only supports auto + steer (live dispatch). Queue-with-attachments
-    is rejected — the queued-input drain path doesn't yet load attachments,
-    and silently downgrading would be a no-silent-fallback violation.
+    v1 only supports the ``auto`` intent. ``steer`` would need the live
+    steer chain to accept attachments and would race the dispatch lock
+    that this route already acquires for the regular send path.
+    Queue-with-attachments is also rejected because the queued-input
+    drain path doesn't load attachments yet.
     """
     if not attachments:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="multipart input requires at least one attachment",
         )
-    if intent not in (INPUT_INTENT_AUTO, INPUT_INTENT_STEER):
+    if intent != INPUT_INTENT_AUTO:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"intent {intent!r} not supported with attachments",
         )
     _validate_attachments(attachments)
+
+    # Read every upload + check size before we touch the DB. If a later
+    # attachment is too large, we don't want a half-stored input in
+    # ``delivering`` state with earlier blobs orphaned on disk.
+    upload_payloads: list[tuple[UploadFile, bytes]] = []
+    for upload in attachments:
+        data = await upload.read()
+        if len(data) > MAX_ATTACHMENT_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"attachment {upload.filename!r} exceeds "
+                    f"{MAX_ATTACHMENT_BYTES // 1024 // 1024}MB"
+                ),
+            )
+        upload_payloads.append((upload, data))
 
     source_session = _load_session_for_continuation(db, session_id)
     _assert_live_session_send_available(db, source_session, owner_id=current_user.id)
@@ -182,16 +200,7 @@ async def create_session_input_with_attachments(
             client_request_id=request_id,
             delivery_request_id=delivery_request_id,
         )
-        for upload in attachments:
-            data = await upload.read()
-            if len(data) > MAX_ATTACHMENT_BYTES:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=(
-                        f"attachment {upload.filename!r} exceeds "
-                        f"{MAX_ATTACHMENT_BYTES // 1024 // 1024}MB"
-                    ),
-                )
+        for upload, data in upload_payloads:
             stored = store_attachment_blob(
                 db,
                 session_input=row,
@@ -209,6 +218,8 @@ async def create_session_input_with_attachments(
             )
     except HTTPException:
         await session_lock_manager.release(lock_scope_id, delivery_request_id)
+        if "row" in locals():
+            mark_failed(db, int(row.id), error="attachment store rejected")
         raise
     except Exception as exc:
         await session_lock_manager.release(lock_scope_id, delivery_request_id)

--- a/server/zerg/routers/session_inputs_attachments.py
+++ b/server/zerg/routers/session_inputs_attachments.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import File
 from fastapi import Form
+from fastapi import Header
 from fastapi import HTTPException
 from fastapi import UploadFile
 from fastapi import status
@@ -32,6 +33,9 @@ from zerg.database import get_db
 from zerg.dependencies.agents_auth import require_single_tenant
 from zerg.dependencies.agents_auth import verify_agents_token
 from zerg.dependencies.browser_route_auth import get_current_browser_route_user
+from zerg.metrics import session_input_attachment_blob_fetches_total
+from zerg.metrics import session_input_attachment_bytes
+from zerg.metrics import session_input_attachments_total
 from zerg.models.device_token import DeviceToken
 from zerg.models.user import User
 from zerg.routers.session_chat import QueuedInputSummary
@@ -114,6 +118,17 @@ def _queued_summary_from_row(row) -> QueuedInputSummary:
     )
 
 
+def _client_label_from_user_agent(user_agent: str | None) -> str:
+    if not user_agent:
+        return "unknown"
+    lowered = user_agent.lower()
+    if "longhouse-ios" in lowered or "cfnetwork" in lowered:
+        return "ios"
+    if "mozilla" in lowered or "chrome" in lowered or "safari" in lowered:
+        return "web"
+    return "other"
+
+
 @router.post("/{session_id}/inputs-multipart", response_model=SessionInputResponse)
 async def create_session_input_with_attachments(
     session_id: str,
@@ -121,6 +136,7 @@ async def create_session_input_with_attachments(
     intent: str = Form(INPUT_INTENT_AUTO),
     client_request_id: str | None = Form(None, max_length=64),
     attachments: List[UploadFile] = File(...),
+    user_agent: str | None = Header(default=None),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_browser_route_user),
 ) -> SessionInputResponse:
@@ -132,17 +148,28 @@ async def create_session_input_with_attachments(
     Queue-with-attachments is also rejected because the queued-input
     drain path doesn't load attachments yet.
     """
+    client_label = _client_label_from_user_agent(user_agent)
+
+    def _record_outcome(outcome: str) -> None:
+        session_input_attachments_total.labels(client=client_label, outcome=outcome).inc()
+
     if not attachments:
+        _record_outcome("rejected_empty")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="multipart input requires at least one attachment",
         )
     if intent != INPUT_INTENT_AUTO:
+        _record_outcome("rejected_intent")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"intent {intent!r} not supported with attachments",
         )
-    _validate_attachments(attachments)
+    try:
+        _validate_attachments(attachments)
+    except HTTPException:
+        _record_outcome("rejected_validation")
+        raise
 
     # Read every upload + check size before we touch the DB. If a later
     # attachment is too large, we don't want a half-stored input in
@@ -151,6 +178,7 @@ async def create_session_input_with_attachments(
     for upload in attachments:
         data = await upload.read()
         if len(data) > MAX_ATTACHMENT_BYTES:
+            _record_outcome("rejected_oversize")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
@@ -166,6 +194,7 @@ async def create_session_input_with_attachments(
     capabilities = current_session_capabilities(db, source_session, owner_id=current_user.id)
     transport = (capabilities.managed_transport.value if capabilities.managed_transport else "")
     if transport != "codex_app_server":
+        _record_outcome("rejected_capability")
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="image attach is only supported on codex sessions",
@@ -183,6 +212,7 @@ async def create_session_input_with_attachments(
         ttl_seconds=300,
     )
     if not lock:
+        _record_outcome("rejected_lock")
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="another dispatch is in flight for this session; try again",
@@ -220,12 +250,14 @@ async def create_session_input_with_attachments(
         await session_lock_manager.release(lock_scope_id, delivery_request_id)
         if "row" in locals():
             mark_failed(db, int(row.id), error="attachment store rejected")
+        _record_outcome("store_rejected")
         raise
     except Exception as exc:
         await session_lock_manager.release(lock_scope_id, delivery_request_id)
         if "row" in locals():
             mark_failed(db, int(row.id), error=f"attachment store failed: {exc}")
         logger.exception("attachment upload failed for session %s", source_session.id)
+        _record_outcome("store_failed")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="failed to store attachments",
@@ -245,11 +277,13 @@ async def create_session_input_with_attachments(
     except HTTPException:
         await session_lock_manager.release(lock_scope_id, delivery_request_id)
         mark_failed(db, int(row.id), error="dispatch rejected")
+        _record_outcome("dispatch_rejected")
         raise
     except Exception as exc:
         await session_lock_manager.release(lock_scope_id, delivery_request_id)
         mark_failed(db, int(row.id), error=str(exc)[:200])
         logger.exception("attachment dispatch failed for session %s", source_session.id)
+        _record_outcome("dispatch_failed")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"dispatch failed: {exc}",
@@ -258,6 +292,7 @@ async def create_session_input_with_attachments(
     dispatch_status = int(getattr(dispatch_response, "status_code", 200) or 200)
     if dispatch_status >= 400:
         mark_failed(db, int(row.id), error=f"dispatch returned {dispatch_status}")
+        _record_outcome("dispatch_error")
         raise HTTPException(
             status_code=dispatch_status,
             detail=f"managed local dispatch returned {dispatch_status}",
@@ -266,10 +301,14 @@ async def create_session_input_with_attachments(
     mark_delivered(db, int(row.id))
 
     attachments_list = list_attachments_for_input(db, int(row.id))
+    for stored in attachments_list:
+        session_input_attachment_bytes.observe(int(stored.byte_size))
+    _record_outcome("delivered")
     logger.info(
-        "session_input_attachments_uploaded session=%s input=%d count=%d total_bytes=%d",
+        "session_input_attachments_uploaded session=%s input=%d client=%s count=%d total_bytes=%d",
         source_session.id,
         int(row.id),
+        client_label,
         len(attachments_list),
         sum(a.byte_size for a in attachments_list),
     )
@@ -305,6 +344,7 @@ async def fetch_attachment_blob(
         attach_uuid = uuid.UUID(attachment_id)
         session_uuid = uuid.UUID(session_id)
     except ValueError as exc:
+        session_input_attachment_blob_fetches_total.labels(outcome="bad_uuid").inc()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found") from exc
 
     if device_token is None:
@@ -314,12 +354,16 @@ async def fetch_attachment_blob(
 
     row = get_attachment(db, attach_uuid)
     if row is None or row.session_id != session_uuid or int(row.session_input_id) != input_id:
+        session_input_attachment_blob_fetches_total.labels(outcome="not_found").inc()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
 
     blob_path: Path = absolute_blob_path(row)
     if not blob_path.exists():
         logger.warning("attachment row %s exists but blob is missing at %s", row.id, blob_path)
+        session_input_attachment_blob_fetches_total.labels(outcome="blob_missing").inc()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+
+    session_input_attachment_blob_fetches_total.labels(outcome="served").inc()
 
     def _iter_blob():
         with blob_path.open("rb") as fh:

--- a/server/zerg/routers/session_inputs_attachments.py
+++ b/server/zerg/routers/session_inputs_attachments.py
@@ -1,0 +1,292 @@
+"""Multipart input + attachment blob fetch endpoints.
+
+The browser/iOS composer hits ``POST /api/sessions/{id}/inputs-multipart``
+when the user attaches one or more images. This is parallel to the JSON
+``POST /sessions/{id}/input`` path so the no-attachment flow stays
+untouched and zero-overhead.
+
+The Machine Agent fetches the blob bytes through
+``GET /api/agents/sessions/{sid}/inputs/{iid}/attachments/{aid}/blob``
+using the standard ``X-Agents-Token`` header and a per-session 404 boundary
+so a leaked attachment id can never read across sessions.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from pathlib import Path
+from typing import List
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import File
+from fastapi import Form
+from fastapi import HTTPException
+from fastapi import UploadFile
+from fastapi import status
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from zerg.database import get_db
+from zerg.dependencies.agents_auth import require_single_tenant
+from zerg.dependencies.agents_auth import verify_agents_token
+from zerg.dependencies.browser_route_auth import get_current_browser_route_user
+from zerg.models.device_token import DeviceToken
+from zerg.models.user import User
+from zerg.routers.session_chat import QueuedInputSummary
+from zerg.routers.session_chat import SessionInputResponse
+from zerg.services.session_chat_impl import _assert_live_session_send_available
+from zerg.services.session_chat_impl import _build_managed_local_chat_response
+from zerg.services.session_chat_impl import _load_session_for_continuation
+from zerg.services.session_continuity import session_lock_manager
+from zerg.services.session_current_control import current_session_capabilities
+from zerg.services.session_input_attachments import ALLOWED_MIME_TYPES
+from zerg.services.session_input_attachments import MAX_ATTACHMENT_BYTES
+from zerg.services.session_input_attachments import MAX_ATTACHMENTS_PER_INPUT
+from zerg.services.session_input_attachments import absolute_blob_path
+from zerg.services.session_input_attachments import get_attachment
+from zerg.services.session_input_attachments import list_attachments_for_input
+from zerg.services.session_input_attachments import store_attachment_blob
+from zerg.services.session_inputs import INPUT_INTENT_AUTO
+from zerg.services.session_inputs import INPUT_INTENT_STEER
+from zerg.services.session_inputs import INPUT_STATUS_DELIVERED
+from zerg.services.session_inputs import INPUT_STATUS_DELIVERING
+from zerg.services.session_inputs import INPUT_STATUS_FAILED
+from zerg.services.session_inputs import create_session_input
+from zerg.services.session_inputs import mark_delivered
+from zerg.services.session_inputs import mark_failed
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(prefix="/sessions", tags=["session-chat"])
+agents_router = APIRouter(prefix="/agents/sessions", tags=["agents"])
+
+
+def _validate_attachments(files: List[UploadFile]) -> None:
+    if len(files) > MAX_ATTACHMENTS_PER_INPUT:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"too many attachments (max {MAX_ATTACHMENTS_PER_INPUT})",
+        )
+    for upload in files:
+        if upload.content_type not in ALLOWED_MIME_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"unsupported attachment type: {upload.content_type}",
+            )
+
+
+def _queued_summary_from_row(row) -> QueuedInputSummary:
+    return QueuedInputSummary(
+        id=int(row.id),
+        text=row.body,
+        intent=row.intent,
+        status=row.status,
+        last_error=row.last_error,
+        created_at=row.created_at,
+    )
+
+
+@router.post("/{session_id}/inputs-multipart", response_model=SessionInputResponse)
+async def create_session_input_with_attachments(
+    session_id: str,
+    text: str = Form("", max_length=10000),
+    intent: str = Form(INPUT_INTENT_AUTO),
+    client_request_id: str | None = Form(None, max_length=64),
+    attachments: List[UploadFile] = File(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_browser_route_user),
+) -> SessionInputResponse:
+    """Send a user input with one or more image attachments.
+
+    v1 only supports auto + steer (live dispatch). Queue-with-attachments
+    is rejected — the queued-input drain path doesn't yet load attachments,
+    and silently downgrading would be a no-silent-fallback violation.
+    """
+    if not attachments:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="multipart input requires at least one attachment",
+        )
+    if intent not in (INPUT_INTENT_AUTO, INPUT_INTENT_STEER):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"intent {intent!r} not supported with attachments",
+        )
+    _validate_attachments(attachments)
+
+    source_session = _load_session_for_continuation(db, session_id)
+    _assert_live_session_send_available(db, source_session, owner_id=current_user.id)
+
+    capabilities = current_session_capabilities(db, source_session, owner_id=current_user.id)
+    transport = (capabilities.managed_transport.value if capabilities.managed_transport else "")
+    if transport != "codex_app_server":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="image attach is only supported on codex sessions",
+        )
+
+    request_id = (client_request_id or "").strip() or uuid.uuid4().hex
+    delivery_request_id = uuid.uuid4().hex
+    lock_scope_id = str(source_session.thread_root_session_id or source_session.id)
+
+    # We acquire the dispatch lock before persisting anything so a second
+    # request for the same session can't race the blob writes.
+    lock = await session_lock_manager.acquire(
+        session_id=lock_scope_id,
+        holder=delivery_request_id,
+        ttl_seconds=300,
+    )
+    if not lock:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="another dispatch is in flight for this session; try again",
+        )
+
+    try:
+        row = create_session_input(
+            db,
+            session_id=source_session.id,
+            text=text,
+            owner_id=current_user.id,
+            intent=intent,
+            status=INPUT_STATUS_DELIVERING,
+            client_request_id=request_id,
+            delivery_request_id=delivery_request_id,
+        )
+        for upload in attachments:
+            data = await upload.read()
+            if len(data) > MAX_ATTACHMENT_BYTES:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"attachment {upload.filename!r} exceeds "
+                        f"{MAX_ATTACHMENT_BYTES // 1024 // 1024}MB"
+                    ),
+                )
+            store_attachment_blob(
+                db,
+                session_input=row,
+                mime_type=upload.content_type,
+                data=data,
+                original_filename=upload.filename,
+                original_byte_size=len(data),
+            )
+    except HTTPException:
+        await session_lock_manager.release(lock_scope_id, delivery_request_id)
+        raise
+    except Exception as exc:
+        await session_lock_manager.release(lock_scope_id, delivery_request_id)
+        if "row" in locals():
+            mark_failed(db, int(row.id), error=f"attachment store failed: {exc}")
+        logger.exception("attachment upload failed for session %s", source_session.id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="failed to store attachments",
+        ) from exc
+
+    try:
+        dispatch_response = await _build_managed_local_chat_response(
+            source_session=source_session,
+            owner_id=current_user.id,
+            message=text,
+            request_id=delivery_request_id,
+            lock_scope_id=lock_scope_id,
+            db=db,
+            session_input_id=int(row.id),
+        )
+    except HTTPException:
+        await session_lock_manager.release(lock_scope_id, delivery_request_id)
+        mark_failed(db, int(row.id), error="dispatch rejected")
+        raise
+    except Exception as exc:
+        await session_lock_manager.release(lock_scope_id, delivery_request_id)
+        mark_failed(db, int(row.id), error=str(exc)[:200])
+        logger.exception("attachment dispatch failed for session %s", source_session.id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"dispatch failed: {exc}",
+        ) from exc
+
+    dispatch_status = int(getattr(dispatch_response, "status_code", 200) or 200)
+    if dispatch_status >= 400:
+        mark_failed(db, int(row.id), error=f"dispatch returned {dispatch_status}")
+        raise HTTPException(
+            status_code=dispatch_status,
+            detail=f"managed local dispatch returned {dispatch_status}",
+        )
+
+    mark_delivered(db, int(row.id))
+
+    attachments_list = list_attachments_for_input(db, int(row.id))
+    logger.info(
+        "session_input_attachments_uploaded session=%s input=%d count=%d total_bytes=%d",
+        source_session.id,
+        int(row.id),
+        len(attachments_list),
+        sum(a.byte_size for a in attachments_list),
+    )
+
+    return SessionInputResponse(
+        outcome="sent",
+        input_id=int(row.id),
+        client_request_id=row.client_request_id,
+        intent=row.intent,
+        queued=[],
+    )
+
+
+@agents_router.get(
+    "/{session_id}/inputs/{input_id}/attachments/{attachment_id}/blob",
+)
+async def fetch_attachment_blob(
+    session_id: str,
+    input_id: int,
+    attachment_id: str,
+    db: Session = Depends(get_db),
+    device_token: DeviceToken | None = Depends(verify_agents_token),
+    _single: None = Depends(require_single_tenant),
+) -> StreamingResponse:
+    """Stream a single attachment blob to the engine.
+
+    Always returns 404 on any cross-row mismatch (wrong session, wrong
+    input). The engine still verifies sha256 before handing the path to
+    Codex — the 404 is a defense-in-depth boundary, not a primary
+    integrity contract.
+    """
+    try:
+        attach_uuid = uuid.UUID(attachment_id)
+        session_uuid = uuid.UUID(session_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found") from exc
+
+    if device_token is None:
+        # auth_disabled mode: still require a valid path; the framework already
+        # enforces single-tenant.
+        pass
+
+    row = get_attachment(db, attach_uuid)
+    if row is None or row.session_id != session_uuid or int(row.session_input_id) != input_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+
+    blob_path: Path = absolute_blob_path(row)
+    if not blob_path.exists():
+        logger.warning("attachment row %s exists but blob is missing at %s", row.id, blob_path)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+
+    def _iter_blob():
+        with blob_path.open("rb") as fh:
+            while chunk := fh.read(64 * 1024):
+                yield chunk
+
+    return StreamingResponse(
+        _iter_blob(),
+        media_type=row.mime_type,
+        headers={
+            "X-Attachment-Sha256": row.sha256,
+            "X-Attachment-Bytes": str(int(row.byte_size)),
+            "Content-Length": str(int(row.byte_size)),
+        },
+    )

--- a/server/zerg/routers/session_inputs_attachments.py
+++ b/server/zerg/routers/session_inputs_attachments.py
@@ -122,7 +122,7 @@ def _client_label_from_user_agent(user_agent: str | None) -> str:
     if not user_agent:
         return "unknown"
     lowered = user_agent.lower()
-    if "longhouse-ios" in lowered or "cfnetwork" in lowered:
+    if "longhouse-ios" in lowered:
         return "ios"
     if "mozilla" in lowered or "chrome" in lowered or "safari" in lowered:
         return "web"
@@ -188,8 +188,16 @@ async def create_session_input_with_attachments(
             )
         upload_payloads.append((upload, data))
 
-    source_session = _load_session_for_continuation(db, session_id)
-    _assert_live_session_send_available(db, source_session, owner_id=current_user.id)
+    try:
+        source_session = _load_session_for_continuation(db, session_id)
+    except HTTPException:
+        _record_outcome("rejected_session")
+        raise
+    try:
+        _assert_live_session_send_available(db, source_session, owner_id=current_user.id)
+    except HTTPException:
+        _record_outcome("rejected_live_control")
+        raise
 
     capabilities = current_session_capabilities(db, source_session, owner_id=current_user.id)
     transport = (capabilities.managed_transport.value if capabilities.managed_transport else "")

--- a/server/zerg/routers/session_inputs_attachments.py
+++ b/server/zerg/routers/session_inputs_attachments.py
@@ -44,6 +44,7 @@ from zerg.services.session_current_control import current_session_capabilities
 from zerg.services.session_input_attachments import ALLOWED_MIME_TYPES
 from zerg.services.session_input_attachments import MAX_ATTACHMENT_BYTES
 from zerg.services.session_input_attachments import MAX_ATTACHMENTS_PER_INPUT
+from zerg.services.session_input_attachments import StoredAttachment
 from zerg.services.session_input_attachments import absolute_blob_path
 from zerg.services.session_input_attachments import get_attachment
 from zerg.services.session_input_attachments import list_attachments_for_input
@@ -62,6 +63,30 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/sessions", tags=["session-chat"])
 agents_router = APIRouter(prefix="/agents/sessions", tags=["agents"])
+
+
+def _attachment_ref_for_engine(
+    *,
+    session_id: str,
+    input_id: int,
+    stored: StoredAttachment,
+) -> dict:
+    """Build the JSON the engine needs to fetch this blob over machine auth.
+
+    The path is relative to the runtime host's public origin; the engine
+    resolves it against its own ``api_url`` so we don't need to know the
+    public hostname here. Sha256 + mime + id round-trip into the engine's
+    ``AttachmentRef``.
+    """
+    return {
+        "id": str(stored.id),
+        "mime_type": stored.mime_type,
+        "sha256": stored.sha256,
+        "blob_url": (
+            f"/api/agents/sessions/{session_id}"
+            f"/inputs/{input_id}/attachments/{stored.id}/blob"
+        ),
+    }
 
 
 def _validate_attachments(files: List[UploadFile]) -> None:
@@ -145,6 +170,7 @@ async def create_session_input_with_attachments(
             detail="another dispatch is in flight for this session; try again",
         )
 
+    stored_refs: list[dict] = []
     try:
         row = create_session_input(
             db,
@@ -166,13 +192,20 @@ async def create_session_input_with_attachments(
                         f"{MAX_ATTACHMENT_BYTES // 1024 // 1024}MB"
                     ),
                 )
-            store_attachment_blob(
+            stored = store_attachment_blob(
                 db,
                 session_input=row,
                 mime_type=upload.content_type,
                 data=data,
                 original_filename=upload.filename,
                 original_byte_size=len(data),
+            )
+            stored_refs.append(
+                _attachment_ref_for_engine(
+                    session_id=str(source_session.id),
+                    input_id=int(row.id),
+                    stored=stored,
+                )
             )
     except HTTPException:
         await session_lock_manager.release(lock_scope_id, delivery_request_id)
@@ -196,6 +229,7 @@ async def create_session_input_with_attachments(
             lock_scope_id=lock_scope_id,
             db=db,
             session_input_id=int(row.id),
+            attachments=stored_refs,
         )
     except HTTPException:
         await session_lock_manager.release(lock_scope_id, delivery_request_id)

--- a/server/zerg/services/live_session_dispatch.py
+++ b/server/zerg/services/live_session_dispatch.py
@@ -125,6 +125,7 @@ async def send_text_to_live_session(
     timeout_secs: int = 15,
     verify_turn_started: bool = False,
     verification_timeout_secs: float | None = None,
+    attachments: list[dict] | None = None,
 ) -> ManagedLocalSendResult:
     """Send text to a live session through the single transport dispatch seam.
 
@@ -149,6 +150,7 @@ async def send_text_to_live_session(
             timeout_secs=timeout_secs,
             verify_turn_started=verify_turn_started,
             verification_timeout_secs=verification_timeout_secs,
+            attachments=attachments,
         )
 
     execution_home = (

--- a/server/zerg/services/managed_local_control.py
+++ b/server/zerg/services/managed_local_control.py
@@ -539,6 +539,7 @@ async def send_text_to_managed_local_session(
     timeout_secs: int = 15,
     verify_turn_started: bool = False,
     verification_timeout_secs: float | None = None,
+    attachments: list[dict] | None = None,
 ) -> ManagedLocalSendResult:
     """Send text into a managed-local session via its configured transport.
 
@@ -566,7 +567,11 @@ async def send_text_to_managed_local_session(
         else 0
     )
     try:
-        command = build_managed_local_send_text_command(session=session, text=text)
+        command = build_managed_local_send_text_command(
+            session=session,
+            text=text,
+            attachments=attachments,
+        )
     except ManagedLocalTransportError as exc:
         return ManagedLocalSendResult(ok=False, error=str(exc))
     result = await dispatch_managed_control_command(
@@ -676,6 +681,7 @@ async def steer_text_to_managed_local_session(
     text: str,
     commis_id: str | None = None,
     timeout_secs: int = 15,
+    attachments: list[dict] | None = None,
 ) -> ManagedLocalSendResult:
     """Inject mid-turn steer text into the currently active Codex turn.
 
@@ -700,7 +706,11 @@ async def steer_text_to_managed_local_session(
         return ManagedLocalSendResult(ok=False, error=transport_error)
 
     try:
-        command = build_managed_local_steer_text_command(session=session, text=text)
+        command = build_managed_local_steer_text_command(
+            session=session,
+            text=text,
+            attachments=attachments,
+        )
     except ManagedLocalTransportError as exc:
         return ManagedLocalSendResult(ok=False, error=str(exc))
 

--- a/server/zerg/services/managed_local_transport.py
+++ b/server/zerg/services/managed_local_transport.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import shlex
+from typing import Any, Mapping, Sequence
 
 from zerg.models.agents import AgentSession
 from zerg.services.claude_channel_bridge import build_claude_channel_exec_command
@@ -129,7 +131,35 @@ def build_managed_local_interrupt_command(*, session: AgentSession) -> str:
     )
 
 
-def build_managed_local_send_text_command(*, session: AgentSession, text: str) -> str:
+def _attachment_args(
+    attachments: Sequence[Mapping[str, Any]] | None,
+    *,
+    transport: ManagedSessionTransport,
+) -> tuple[str, ...]:
+    """Serialize attachment refs into `--attachments-json <json>` for the
+    engine codex-bridge subprocess. Returns empty tuple when there are no
+    attachments so text-only sends keep their previous shape.
+
+    Only the codex_app_server transport supports attachments today; for any
+    other transport, a non-empty list is a hard error rather than a silent
+    drop.
+    """
+    if not attachments:
+        return ()
+    if transport != ManagedSessionTransport.CODEX_APP_SERVER:
+        raise ManagedLocalTransportError(
+            "Attachments are only supported on codex_app_server transports",
+        )
+    payload = json.dumps(list(attachments), separators=(",", ":"))
+    return ("--attachments-json", shlex.quote(payload))
+
+
+def build_managed_local_send_text_command(
+    *,
+    session: AgentSession,
+    text: str,
+    attachments: Sequence[Mapping[str, Any]] | None = None,
+) -> str:
     transport = _resolve_transport(getattr(session, "managed_transport", None))
     if transport == ManagedSessionTransport.OPENCODE_PROCESS:
         raise ManagedLocalTransportError("opencode_process does not support remote text sends yet")
@@ -138,11 +168,12 @@ def build_managed_local_send_text_command(*, session: AgentSession, text: str) -
     session_id = str(getattr(session, "id", "") or "").strip()
     if not session_id:
         raise ManagedLocalTransportError("Managed local session is missing session ID")
+    attach_args = _attachment_args(attachments, transport=transport)
     if transport == ManagedSessionTransport.CODEX_APP_SERVER:
         return _build_engine_bridge_shell_command(
             session_id=session_id,
             subcommand="send",
-            args=("--text", shlex.quote(text)),
+            args=("--text", shlex.quote(text), *attach_args),
         )
     return _build_longhouse_cli_shell_command(
         subcommand="send",
@@ -150,7 +181,12 @@ def build_managed_local_send_text_command(*, session: AgentSession, text: str) -
     )
 
 
-def build_managed_local_steer_text_command(*, session: AgentSession, text: str) -> str:
+def build_managed_local_steer_text_command(
+    *,
+    session: AgentSession,
+    text: str,
+    attachments: Sequence[Mapping[str, Any]] | None = None,
+) -> str:
     """Build a mid-turn steer command. Codex-only this batch; Claude channel
     has no equivalent first-class primitive yet."""
     transport = _resolve_transport(getattr(session, "managed_transport", None))
@@ -165,10 +201,11 @@ def build_managed_local_steer_text_command(*, session: AgentSession, text: str) 
     session_id = str(getattr(session, "id", "") or "").strip()
     if not session_id:
         raise ManagedLocalTransportError("Managed local session is missing session ID")
+    attach_args = _attachment_args(attachments, transport=transport)
     return _build_engine_bridge_shell_command(
         session_id=session_id,
         subcommand="steer",
-        args=("--text", shlex.quote(text)),
+        args=("--text", shlex.quote(text), *attach_args),
     )
 
 

--- a/server/zerg/services/session_chat_impl.py
+++ b/server/zerg/services/session_chat_impl.py
@@ -407,6 +407,7 @@ async def _build_managed_local_chat_response(
     lock_scope_id: str,
     db: Session,
     session_input_id: int | None = None,
+    attachments: list[dict] | None = None,
 ) -> JSONResponse:
     """Dispatch text to a managed-local session and return a fast ack.
 
@@ -422,6 +423,7 @@ async def _build_managed_local_chat_response(
         lock_scope_id=lock_scope_id,
         db=db,
         session_input_id=session_input_id,
+        attachments=attachments,
     )
 
 
@@ -854,6 +856,7 @@ async def _dispatch_managed_local_text(
     lock_scope_id: str,
     db: Session,
     session_input_id: int | None = None,
+    attachments: list[dict] | None = None,
 ) -> JSONResponse:
     """Send text to a managed-local session and return acceptance status."""
     tracer = get_tracer(__name__)
@@ -928,6 +931,7 @@ async def _dispatch_managed_local_text(
                 timeout_secs=15,
                 verify_turn_started=True,
                 verification_timeout_secs=15.0,
+                attachments=attachments,
             )
             send_observed_at = datetime.now(timezone.utc)
             set_span_attributes(

--- a/server/zerg/services/session_input_attachments.py
+++ b/server/zerg/services/session_input_attachments.py
@@ -1,0 +1,192 @@
+"""Lifecycle for image attachments hung off SessionInput rows.
+
+Blobs live on disk; metadata lives in ``session_input_attachments``. The
+engine fetches blobs by id over a machine-token endpoint so we never load
+the bytes through Python on the dispatch path.
+
+The model is deliberately narrow: we trust the client's compression and
+the row's sha256 is the integrity contract. Nothing here decodes images.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from pathlib import Path
+from typing import Iterable
+from uuid import UUID
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from zerg.config import get_settings
+from zerg.models.agents import SessionInput
+from zerg.models.agents import SessionInputAttachment
+from zerg.services.session_inputs import INPUT_STATUS_DELIVERED
+from zerg.services.session_inputs import INPUT_STATUS_FAILED
+
+logger = logging.getLogger(__name__)
+
+
+ALLOWED_MIME_TYPES = frozenset({"image/png", "image/jpeg", "image/webp", "image/gif"})
+
+MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024  # 2 MB hard server limit
+MAX_ATTACHMENTS_PER_INPUT = 4
+
+# Blobs older than this whose parent session_input is in a terminal state
+# get reaped on the hourly cleanup pass.
+BLOB_RETENTION_SECS = 24 * 3600
+
+
+@dataclass(frozen=True)
+class StoredAttachment:
+    id: UUID
+    session_input_id: int
+    session_id: UUID
+    mime_type: str
+    byte_size: int
+    sha256: str
+    blob_path: Path
+    original_filename: str | None
+    original_byte_size: int | None
+
+
+def attachment_blob_root() -> Path:
+    """Return the on-disk root for attachment blobs.
+
+    Honors ``LONGHOUSE_ATTACHMENT_BLOB_ROOT`` for tests; otherwise lives
+    under the standard ``data/`` directory alongside the SQLite db.
+    """
+    override = os.getenv("LONGHOUSE_ATTACHMENT_BLOB_ROOT")
+    if override:
+        return Path(override)
+    return get_settings().data_dir / "attachments"
+
+
+def _blob_path_for(session_id: UUID, attach_id: UUID) -> Path:
+    return attachment_blob_root() / str(session_id) / f"{attach_id}.bin"
+
+
+def store_attachment_blob(
+    db: Session,
+    *,
+    session_input: SessionInput,
+    mime_type: str,
+    data: bytes,
+    original_filename: str | None,
+    original_byte_size: int | None,
+) -> StoredAttachment:
+    """Persist a single attachment blob to disk and record its row.
+
+    Caller is responsible for caps (count + size); this is the
+    inner write. The function commits the row so the blob path always
+    has a corresponding metadata record on disk.
+    """
+    if mime_type not in ALLOWED_MIME_TYPES:
+        raise ValueError(f"unsupported mime: {mime_type}")
+    if len(data) == 0:
+        raise ValueError("empty attachment")
+    if len(data) > MAX_ATTACHMENT_BYTES:
+        raise ValueError(f"attachment exceeds {MAX_ATTACHMENT_BYTES} bytes")
+
+    attach_id = uuid4()
+    blob_path = _blob_path_for(session_input.session_id, attach_id)
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(data).hexdigest()
+    # Atomic write so a crash mid-write never leaves a half-blob with a row
+    # claiming integrity over it.
+    tmp_path = blob_path.with_suffix(".tmp")
+    tmp_path.write_bytes(data)
+    os.chmod(tmp_path, 0o600)
+    os.replace(tmp_path, blob_path)
+
+    relative = blob_path.relative_to(attachment_blob_root())
+    row = SessionInputAttachment(
+        id=attach_id,
+        session_input_id=int(session_input.id),
+        session_id=session_input.session_id,
+        mime_type=mime_type,
+        byte_size=len(data),
+        sha256=digest,
+        blob_path=str(relative),
+        original_filename=original_filename,
+        original_byte_size=original_byte_size,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _to_stored(row)
+
+
+def list_attachments_for_input(db: Session, session_input_id: int) -> list[StoredAttachment]:
+    rows = (
+        db.query(SessionInputAttachment)
+        .filter(SessionInputAttachment.session_input_id == session_input_id)
+        .order_by(SessionInputAttachment.created_at.asc(), SessionInputAttachment.id.asc())
+        .all()
+    )
+    return [_to_stored(r) for r in rows]
+
+
+def get_attachment(db: Session, attachment_id: UUID) -> SessionInputAttachment | None:
+    return (
+        db.query(SessionInputAttachment)
+        .filter(SessionInputAttachment.id == attachment_id)
+        .first()
+    )
+
+
+def absolute_blob_path(row: SessionInputAttachment) -> Path:
+    return attachment_blob_root() / row.blob_path
+
+
+def cleanup_stale_blobs(db: Session, *, retention_secs: int = BLOB_RETENTION_SECS) -> int:
+    """Delete blobs+rows whose parent input is terminal and older than retention.
+
+    Cascading FK already deletes the row when a session_input is hard-deleted;
+    this handler covers the soft-terminal case (delivered/failed) where the
+    parent row still exists but the bytes are no longer needed.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=retention_secs)
+    stale: Iterable[SessionInputAttachment] = (
+        db.query(SessionInputAttachment)
+        .join(SessionInput, SessionInput.id == SessionInputAttachment.session_input_id)
+        .filter(
+            SessionInput.status.in_((INPUT_STATUS_DELIVERED, INPUT_STATUS_FAILED)),
+            SessionInputAttachment.created_at < cutoff,
+        )
+        .all()
+    )
+    removed = 0
+    for row in list(stale):
+        path = absolute_blob_path(row)
+        try:
+            if path.exists():
+                path.unlink()
+        except OSError:
+            logger.warning("attachment cleanup: failed to unlink %s", path, exc_info=True)
+        db.delete(row)
+        removed += 1
+    if removed:
+        db.commit()
+        logger.info("attachment cleanup: removed %d stale blobs", removed)
+    return removed
+
+
+def _to_stored(row: SessionInputAttachment) -> StoredAttachment:
+    return StoredAttachment(
+        id=row.id,
+        session_input_id=int(row.session_input_id),
+        session_id=row.session_id,
+        mime_type=row.mime_type,
+        byte_size=int(row.byte_size),
+        sha256=row.sha256,
+        blob_path=absolute_blob_path(row),
+        original_filename=row.original_filename,
+        original_byte_size=int(row.original_byte_size) if row.original_byte_size is not None else None,
+    )

--- a/server/zerg/services/session_input_attachments.py
+++ b/server/zerg/services/session_input_attachments.py
@@ -118,7 +118,17 @@ def store_attachment_blob(
         original_byte_size=original_byte_size,
     )
     db.add(row)
-    db.commit()
+    try:
+        db.commit()
+    except Exception:
+        # Row never landed; remove the just-written blob so disk and metadata
+        # don't drift. The reaper can't see this blob — there's no row to join.
+        db.rollback()
+        try:
+            blob_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("attachment store: failed to unlink orphan blob %s", blob_path, exc_info=True)
+        raise
     db.refresh(row)
     return _to_stored(row)
 

--- a/server/zerg/services/session_inputs.py
+++ b/server/zerg/services/session_inputs.py
@@ -19,6 +19,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from zerg.models.agents import SessionInput
+from zerg.models.agents import SessionInputAttachment
 
 logger = logging.getLogger(__name__)
 
@@ -262,10 +263,13 @@ def requeue_stuck_delivering(db: Session, *, stale_after_secs: float = DELIVERIN
     Called once at runtime startup; wedged rows usually mean the process died
     mid-dispatch.
 
-    - `intent=auto` / `intent=queue` rows: rewind to `queued` so the next
-      terminal-phase drain picks them up. Safe because the user asked for
-      either "best-effort dispatch" or "wait for the next boundary" — both
-      are compatible with a later retry.
+    - `intent=auto` / `intent=queue` rows without attachments: rewind to
+      `queued` so the next terminal-phase drain picks them up. Safe because
+      the user asked for either "best-effort dispatch" or "wait for the next
+      boundary" — both are compatible with a later retry.
+    - rows with attachments: transition to `failed`, never requeue. The
+      queued-input drain currently carries text only; requeueing would silently
+      resend a screenshot turn without the screenshots.
     - `intent=steer` rows: transition to `failed`, never requeue. Steer is
       a corrective, time-sensitive intent; converting it into a queued
       message after a crash would be a silent fallback that violates the
@@ -274,6 +278,8 @@ def requeue_stuck_delivering(db: Session, *, stale_after_secs: float = DELIVERIN
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(seconds=stale_after_secs)
 
+    attached_input_ids = db.query(SessionInputAttachment.session_input_id)
+
     # Intent-aware split.
     requeued = (
         db.query(SessionInput)
@@ -281,11 +287,29 @@ def requeue_stuck_delivering(db: Session, *, stale_after_secs: float = DELIVERIN
             SessionInput.status == INPUT_STATUS_DELIVERING,
             SessionInput.updated_at < cutoff,
             SessionInput.intent != INPUT_INTENT_STEER,
+            ~SessionInput.id.in_(attached_input_ids),
         )
         .update(
             {
                 "status": INPUT_STATUS_QUEUED,
                 "delivery_request_id": None,
+                "updated_at": now,
+            },
+            synchronize_session=False,
+        )
+    )
+    failed_with_attachments = (
+        db.query(SessionInput)
+        .filter(
+            SessionInput.status == INPUT_STATUS_DELIVERING,
+            SessionInput.updated_at < cutoff,
+            SessionInput.intent != INPUT_INTENT_STEER,
+            SessionInput.id.in_(attached_input_ids),
+        )
+        .update(
+            {
+                "status": INPUT_STATUS_FAILED,
+                "last_error": "attachment delivery interrupted by restart",
                 "updated_at": now,
             },
             synchronize_session=False,
@@ -310,6 +334,11 @@ def requeue_stuck_delivering(db: Session, *, stale_after_secs: float = DELIVERIN
     db.commit()
     if requeued:
         logger.info("Requeued %d stuck SessionInput rows from delivering -> queued", requeued)
+    if failed_with_attachments:
+        logger.info(
+            "Marked %d stuck attachment SessionInput rows as failed (no text-only requeue)",
+            failed_with_attachments,
+        )
     if failed:
         logger.info("Marked %d stuck steer SessionInput rows as failed (no silent requeue)", failed)
     return int(requeued)

--- a/server/zerg/services/session_views.py
+++ b/server/zerg/services/session_views.py
@@ -127,7 +127,24 @@ def build_session_capabilities_response(
         can_terminate=(kernel_capabilities.can_terminate if kernel_capabilities is not None else False),
         can_tail_output=(kernel_capabilities.can_tail_output if kernel_capabilities is not None else False),
         can_resume=(kernel_capabilities.can_resume if kernel_capabilities is not None else False),
+        attach_images=_attach_images_capability(capability_flags),
     )
+
+
+def _attach_images_capability(capability_flags) -> bool:
+    """True when this session can accept image attachments.
+
+    Gated on (a) the session having live control and (b) the underlying
+    transport being codex_app_server. The engine-side LocalImage helper
+    only knows how to thread attachments into Codex turns today.
+    """
+    transport = getattr(capability_flags, "managed_transport", None)
+    if transport is None:
+        return False
+    transport_value = getattr(transport, "value", str(transport))
+    if transport_value != "codex_app_server":
+        return False
+    return bool(capability_flags.live_control_available)
 
 
 def _provider_label(session: AgentSession | None) -> str | None:
@@ -479,6 +496,10 @@ class SessionCapabilitiesResponse(BaseModel):
     can_terminate: bool = Field(False, description="Kernel: connection grants terminate capability and is currently live")
     can_tail_output: bool = Field(False, description="Kernel: connection grants output tailing capability")
     can_resume: bool = Field(False, description="Kernel: connection can be resumed (live or reattach)")
+    attach_images: bool = Field(
+        False,
+        description="True when the session can accept image attachments on input (codex_app_server only)",
+    )
 
 
 class SessionRuntimeDisplayResponse(BaseModel):

--- a/web/src/components/AttachmentTray.tsx
+++ b/web/src/components/AttachmentTray.tsx
@@ -1,0 +1,79 @@
+import { useRef } from "react";
+
+import { COMPOSER_ATTACHMENT_LIMITS, type ComposerAttachment } from "../lib/useComposerAttachments";
+
+const ACCEPT = Array.from(COMPOSER_ATTACHMENT_LIMITS.allowedMime).join(",");
+
+interface Props {
+  attachments: ComposerAttachment[];
+  onAddFiles: (files: FileList | File[]) => void;
+  onRemove: (clientId: string) => void;
+  isCompressing?: boolean;
+  error?: string | null;
+  onClearError?: () => void;
+  disabled?: boolean;
+}
+
+export function AttachmentTray({
+  attachments,
+  onAddFiles,
+  onRemove,
+  isCompressing = false,
+  error,
+  onClearError,
+  disabled,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const slotsLeft = COMPOSER_ATTACHMENT_LIMITS.maxAttachments - attachments.length;
+  const canAdd = !disabled && slotsLeft > 0;
+
+  return (
+    <div className="session-chat-attachment-tray" data-testid="attachment-tray">
+      {attachments.map((a) => (
+        <div key={a.clientId} className="session-chat-attachment-tray__item">
+          <img src={a.previewUrl} alt={a.filename} className="session-chat-attachment-tray__thumb" />
+          <button
+            type="button"
+            className="session-chat-attachment-tray__remove"
+            onClick={() => onRemove(a.clientId)}
+            aria-label={`Remove ${a.filename}`}
+            disabled={disabled}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      {canAdd ? (
+        <button
+          type="button"
+          className="session-chat-attachment-tray__add"
+          onClick={() => inputRef.current?.click()}
+          disabled={isCompressing}
+          aria-label="Attach images"
+        >
+          {isCompressing ? "…" : "+"}
+        </button>
+      ) : null}
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPT}
+        multiple
+        hidden
+        onChange={(e) => {
+          if (e.target.files?.length) onAddFiles(e.target.files);
+          e.target.value = "";
+        }}
+      />
+      {error ? (
+        <div
+          className="session-chat-attachment-tray__error"
+          role="alert"
+          onClick={onClearError}
+        >
+          {error}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/AttachmentTray.tsx
+++ b/web/src/components/AttachmentTray.tsx
@@ -12,6 +12,7 @@ interface Props {
   error?: string | null;
   onClearError?: () => void;
   disabled?: boolean;
+  addDisabled?: boolean;
 }
 
 export function AttachmentTray({
@@ -22,10 +23,11 @@ export function AttachmentTray({
   error,
   onClearError,
   disabled,
+  addDisabled,
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const slotsLeft = COMPOSER_ATTACHMENT_LIMITS.maxAttachments - attachments.length;
-  const canAdd = !disabled && slotsLeft > 0;
+  const canAdd = !disabled && !addDisabled && slotsLeft > 0;
 
   return (
     <div className="session-chat-attachment-tray" data-testid="attachment-tray">

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -522,6 +522,9 @@ export function SessionChat({
       // attachment-only sends are valid and the server accepts text="".
       if (!message && !hasAttachments) return;
       if (isSubmitting || isComposerDisabled || isSendBlocked) return;
+      // Block send while compression is in flight; the snapshot would miss
+      // the pending file and the late add could repopulate the cleared tray.
+      if (composerAttachments.isCompressing) return;
 
       setDraft("");
       setError(null);
@@ -568,10 +571,13 @@ export function SessionChat({
   const handleComposerDrop = useCallback(
     (e: React.DragEvent) => {
       if (!attachImagesEnabled) return;
-      const files = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith("image/"));
-      if (!files.length) return;
+      const dropped = Array.from(e.dataTransfer.files);
+      if (!dropped.length) return;
+      // Always preventDefault on file drops — even non-image drops, otherwise
+      // the browser navigates away and the user loses their draft.
       e.preventDefault();
-      void composerAttachments.addFiles(files);
+      const images = dropped.filter((f) => f.type.startsWith("image/"));
+      if (images.length) void composerAttachments.addFiles(images);
     },
     [attachImagesEnabled, composerAttachments],
   );
@@ -1070,7 +1076,7 @@ export function SessionChat({
                       type="submit"
                       variant="primary"
                       size="sm"
-                      disabled={!hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked}
+                      disabled={!hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked || composerAttachments.isCompressing}
                     >
                       {submitButtonLabel}
                     </Button>
@@ -1123,7 +1129,7 @@ export function SessionChat({
                         type="submit"
                         variant="primary"
                         size="sm"
-                        disabled={isComposerDisabled || !hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked}
+                        disabled={isComposerDisabled || !hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked || composerAttachments.isCompressing}
                         title={composerDisabledReason ?? undefined}
                       >
                         {submitButtonLabel}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -434,6 +434,7 @@ export function SessionChat({
         } else {
           setPendingManagedLocalMessage(null);
         }
+        return true;
       } catch (e) {
         // Parse structured backend errors so turn_ended on steer surfaces
         // as an actionable prompt, not a mystery failure.
@@ -446,6 +447,7 @@ export function SessionChat({
           setError(e instanceof Error ? e.message : "Unknown error");
         }
         setPendingManagedLocalMessage(null);
+        return false;
       } finally {
         setIsSubmitting(false);
       }
@@ -493,6 +495,7 @@ export function SessionChat({
   const canSteerNow = isSendLocked && canSteerActiveTurn;
   const canQueueNow = isSendLocked && canQueueNextInput && !queueFull;
   const canInterruptTurn = isManagedLocal && isSendLocked;
+  const attachmentInputEnabled = attachImagesEnabled && !isSendLocked;
   // Inline interrupt is offered for any locked managed-local turn. When the
   // stall-recovery card is showing it already exposes the same action, so we
   // hide the composer copy to avoid two buttons doing the identical thing.
@@ -508,6 +511,8 @@ export function SessionChat({
     : "auto";
   // Primary send is blocked when there's no available action.
   const isSendBlocked = isSendLocked && !canSteerNow && !canQueueNow;
+  const attachmentSendBlocked =
+    composerAttachments.attachments.length > 0 && primaryIntent !== "auto";
   // Attachment-only sends are valid when the route accepts them.
   const hasComposerContent = Boolean(draft.trim()) || composerAttachments.attachments.length > 0;
 
@@ -522,6 +527,10 @@ export function SessionChat({
       // attachment-only sends are valid and the server accepts text="".
       if (!message && !hasAttachments) return;
       if (isSubmitting || isComposerDisabled || isSendBlocked) return;
+      if (hasAttachments && primaryIntent !== "auto") {
+        setError("Image attachments can only be sent when the session is ready for a new turn.");
+        return;
+      }
       // Block send while compression is in flight; the snapshot would miss
       // the pending file and the late add could repopulate the cleared tray.
       if (composerAttachments.isCompressing) return;
@@ -533,11 +542,12 @@ export function SessionChat({
       const attachmentArgs = hasAttachments
         ? pendingAttachments.map((a) => ({ blob: a.blob, filename: a.filename }))
         : [];
-      // Snapshot then clear the tray immediately; if the send fails the user
-      // can re-pick rather than seeing stale thumbnails next to a fresh draft.
-      if (hasAttachments) composerAttachments.clear();
-
-      await handleManagedLocalSend(message, primaryIntent, attachmentArgs);
+      const sent = await handleManagedLocalSend(message, primaryIntent, attachmentArgs);
+      if (sent) {
+        if (hasAttachments) composerAttachments.clear();
+      } else {
+        setDraft(message);
+      }
     },
     [
       draft,
@@ -552,7 +562,7 @@ export function SessionChat({
 
   const handleComposerPaste = useCallback(
     (e: React.ClipboardEvent) => {
-      if (!attachImagesEnabled) return;
+      if (!attachmentInputEnabled) return;
       const files: File[] = [];
       for (const item of Array.from(e.clipboardData.items)) {
         if (item.kind === "file" && item.type.startsWith("image/")) {
@@ -565,12 +575,12 @@ export function SessionChat({
         void composerAttachments.addFiles(files);
       }
     },
-    [attachImagesEnabled, composerAttachments],
+    [attachmentInputEnabled, composerAttachments],
   );
 
   const handleComposerDrop = useCallback(
     (e: React.DragEvent) => {
-      if (!attachImagesEnabled) return;
+      if (!attachmentInputEnabled) return;
       const dropped = Array.from(e.dataTransfer.files);
       if (!dropped.length) return;
       // Always preventDefault on file drops — even non-image drops, otherwise
@@ -579,17 +589,17 @@ export function SessionChat({
       const images = dropped.filter((f) => f.type.startsWith("image/"));
       if (images.length) void composerAttachments.addFiles(images);
     },
-    [attachImagesEnabled, composerAttachments],
+    [attachmentInputEnabled, composerAttachments],
   );
 
   const handleComposerDragOver = useCallback(
     (e: React.DragEvent) => {
-      if (!attachImagesEnabled) return;
+      if (!attachmentInputEnabled) return;
       if (Array.from(e.dataTransfer.items).some((it) => it.kind === "file")) {
         e.preventDefault();
       }
     },
-    [attachImagesEnabled],
+    [attachmentInputEnabled],
   );
 
   const handleSecondaryQueue = useCallback(async () => {
@@ -960,9 +970,9 @@ export function SessionChat({
         className={`session-chat-composer${isDock ? " session-chat-composer--dock" : ""}`}
         onSubmit={handleSend}
         title={composerDisabledReason ?? undefined}
-        onPaste={attachImagesEnabled ? handleComposerPaste : undefined}
-        onDrop={attachImagesEnabled ? handleComposerDrop : undefined}
-        onDragOver={attachImagesEnabled ? handleComposerDragOver : undefined}
+        onPaste={attachmentInputEnabled ? handleComposerPaste : undefined}
+        onDrop={attachmentInputEnabled ? handleComposerDrop : undefined}
+        onDragOver={attachmentInputEnabled ? handleComposerDragOver : undefined}
       >
         {showComposerUnavailableState ? (
           managedLaunchSuggestion ? (
@@ -1024,6 +1034,7 @@ export function SessionChat({
                 error={composerAttachments.error}
                 onClearError={composerAttachments.clearError}
                 disabled={isSubmitting}
+                addDisabled={!attachmentInputEnabled}
               />
             ) : null}
             {isDock ? (
@@ -1076,7 +1087,7 @@ export function SessionChat({
                       type="submit"
                       variant="primary"
                       size="sm"
-                      disabled={!hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked || composerAttachments.isCompressing}
+                      disabled={!hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked || attachmentSendBlocked || composerAttachments.isCompressing}
                     >
                       {submitButtonLabel}
                     </Button>
@@ -1129,7 +1140,7 @@ export function SessionChat({
                         type="submit"
                         variant="primary"
                         size="sm"
-                        disabled={isComposerDisabled || !hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked || composerAttachments.isCompressing}
+                        disabled={isComposerDisabled || !hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked || attachmentSendBlocked || composerAttachments.isCompressing}
                         title={composerDisabledReason ?? undefined}
                       >
                         {submitButtonLabel}

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -19,12 +19,15 @@ import {
   fetchSessionLockStatus,
   interruptLiveSession,
   postSessionInput,
+  postSessionInputMultipart,
   type QueuedInputSummary,
   type SessionLockInfo,
 } from "../services/api";
 import type { AgentSession } from "../services/api/agents";
 import type { ManagedLaunchSuggestion } from "../lib/sessionWorkspace";
+import { useComposerAttachments } from "../lib/useComposerAttachments";
 import { Badge, Button, Spinner } from "./ui";
+import { AttachmentTray } from "./AttachmentTray";
 import { ManagedLaunchHintCard } from "./session-workspace/ManagedLaunchHintCard";
 import "../styles/session-chat.css";
 
@@ -108,7 +111,7 @@ interface SessionChatProps {
   isStalled?: boolean;
 }
 
-export type SessionChatTarget = Pick<AgentSession, "id" | "project" | "provider">;
+export type SessionChatTarget = Pick<AgentSession, "id" | "project" | "provider" | "capabilities">;
 
 function getToolPrefix(toolNotices?: string[]): string {
   return toolNotices?.length ? toolNotices.join("\n") + "\n\n" : "";
@@ -158,6 +161,8 @@ export function SessionChat({
   const isDock = layout === "dock";
   const isManagedLocal = chatMode === "managed_local";
   const isComposerDisabled = Boolean(composerDisabledReason);
+  const attachImagesEnabled = isManagedLocal && Boolean(session.capabilities?.attach_images);
+  const composerAttachments = useComposerAttachments();
   const showComposerUnavailableState = isComposerDisabled;
   const queryClient = useQueryClient();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -383,16 +388,26 @@ export function SessionChat({
   const [turnEndedDraft, setTurnEndedDraft] = useState<string | null>(null);
 
   const handleManagedLocalSend = useCallback(
-    async (message: string, intent: "auto" | "queue" | "steer" = "auto") => {
+    async (
+      message: string,
+      intent: "auto" | "queue" | "steer" = "auto",
+      attachments: { blob: Blob; filename: string }[] = [],
+    ) => {
       const clientRequestId = newClientRequestId();
       setPendingManagedLocalMessage(message);
       setIsSubmitting(true);
       try {
-        const result = await postSessionInput(session.id, {
-          text: message,
-          intent,
-          client_request_id: clientRequestId,
-        });
+        const result = attachments.length
+          ? await postSessionInputMultipart(session.id, {
+              text: message,
+              attachments,
+              client_request_id: clientRequestId,
+            })
+          : await postSessionInput(session.id, {
+              text: message,
+              intent,
+              client_request_id: clientRequestId,
+            });
 
         // Seed the queued-inputs cache immediately so the chip appears
         // before the next poll.
@@ -493,21 +508,82 @@ export function SessionChat({
     : "auto";
   // Primary send is blocked when there's no available action.
   const isSendBlocked = isSendLocked && !canSteerNow && !canQueueNow;
+  // Attachment-only sends are valid when the route accepts them.
+  const hasComposerContent = Boolean(draft.trim()) || composerAttachments.attachments.length > 0;
 
   const handleSend = useCallback(
     async (e: FormEvent) => {
       e.preventDefault();
 
       const message = draft.trim();
-      if (!message || isSubmitting || isComposerDisabled || isSendBlocked) return;
+      const pendingAttachments = composerAttachments.attachments;
+      const hasAttachments = pendingAttachments.length > 0;
+      // Attachments require message text only when the user wrote nothing —
+      // attachment-only sends are valid and the server accepts text="".
+      if (!message && !hasAttachments) return;
+      if (isSubmitting || isComposerDisabled || isSendBlocked) return;
 
       setDraft("");
       setError(null);
       setBlockedKeyboardSubmit(false);
 
-      await handleManagedLocalSend(message, primaryIntent);
+      const attachmentArgs = hasAttachments
+        ? pendingAttachments.map((a) => ({ blob: a.blob, filename: a.filename }))
+        : [];
+      // Snapshot then clear the tray immediately; if the send fails the user
+      // can re-pick rather than seeing stale thumbnails next to a fresh draft.
+      if (hasAttachments) composerAttachments.clear();
+
+      await handleManagedLocalSend(message, primaryIntent, attachmentArgs);
     },
-    [draft, isSubmitting, handleManagedLocalSend, isComposerDisabled, isSendBlocked, primaryIntent],
+    [
+      draft,
+      isSubmitting,
+      handleManagedLocalSend,
+      isComposerDisabled,
+      isSendBlocked,
+      primaryIntent,
+      composerAttachments,
+    ],
+  );
+
+  const handleComposerPaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      if (!attachImagesEnabled) return;
+      const files: File[] = [];
+      for (const item of Array.from(e.clipboardData.items)) {
+        if (item.kind === "file" && item.type.startsWith("image/")) {
+          const f = item.getAsFile();
+          if (f) files.push(f);
+        }
+      }
+      if (files.length) {
+        e.preventDefault();
+        void composerAttachments.addFiles(files);
+      }
+    },
+    [attachImagesEnabled, composerAttachments],
+  );
+
+  const handleComposerDrop = useCallback(
+    (e: React.DragEvent) => {
+      if (!attachImagesEnabled) return;
+      const files = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith("image/"));
+      if (!files.length) return;
+      e.preventDefault();
+      void composerAttachments.addFiles(files);
+    },
+    [attachImagesEnabled, composerAttachments],
+  );
+
+  const handleComposerDragOver = useCallback(
+    (e: React.DragEvent) => {
+      if (!attachImagesEnabled) return;
+      if (Array.from(e.dataTransfer.items).some((it) => it.kind === "file")) {
+        e.preventDefault();
+      }
+    },
+    [attachImagesEnabled],
   );
 
   const handleSecondaryQueue = useCallback(async () => {
@@ -878,6 +954,9 @@ export function SessionChat({
         className={`session-chat-composer${isDock ? " session-chat-composer--dock" : ""}`}
         onSubmit={handleSend}
         title={composerDisabledReason ?? undefined}
+        onPaste={attachImagesEnabled ? handleComposerPaste : undefined}
+        onDrop={attachImagesEnabled ? handleComposerDrop : undefined}
+        onDragOver={attachImagesEnabled ? handleComposerDragOver : undefined}
       >
         {showComposerUnavailableState ? (
           managedLaunchSuggestion ? (
@@ -930,6 +1009,17 @@ export function SessionChat({
                 <span className="session-chat-pending-message__spinner" aria-label="Sending" />
               </div>
             ) : null}
+            {attachImagesEnabled ? (
+              <AttachmentTray
+                attachments={composerAttachments.attachments}
+                onAddFiles={composerAttachments.addFiles}
+                onRemove={composerAttachments.removeAttachment}
+                isCompressing={composerAttachments.isCompressing}
+                error={composerAttachments.error}
+                onClearError={composerAttachments.clearError}
+                disabled={isSubmitting}
+              />
+            ) : null}
             {isDock ? (
               <div className="session-chat-composer-row">
                 <textarea
@@ -980,7 +1070,7 @@ export function SessionChat({
                       type="submit"
                       variant="primary"
                       size="sm"
-                      disabled={!draft.trim() || isSubmitting || isDraftingReply || isSendBlocked}
+                      disabled={!hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked}
                     >
                       {submitButtonLabel}
                     </Button>
@@ -1033,7 +1123,7 @@ export function SessionChat({
                         type="submit"
                         variant="primary"
                         size="sm"
-                        disabled={isComposerDisabled || !draft.trim() || isSubmitting || isDraftingReply || isSendBlocked}
+                        disabled={isComposerDisabled || !hasComposerContent || isSubmitting || isDraftingReply || isSendBlocked}
                         title={composerDisabledReason ?? undefined}
                       >
                         {submitButtonLabel}

--- a/web/src/components/__tests__/AttachmentTray.test.tsx
+++ b/web/src/components/__tests__/AttachmentTray.test.tsx
@@ -41,6 +41,22 @@ describe("AttachmentTray", () => {
     expect(screen.queryByLabelText("Attach images")).toBeNull();
   });
 
+  it("can disable adding without trapping existing attachments", () => {
+    const onRemove = vi.fn();
+    render(
+      <AttachmentTray
+        attachments={[attach("1")]}
+        onAddFiles={vi.fn()}
+        onRemove={onRemove}
+        addDisabled
+      />,
+    );
+
+    expect(screen.queryByLabelText("Attach images")).toBeNull();
+    fireEvent.click(screen.getByLabelText("Remove 1.png"));
+    expect(onRemove).toHaveBeenCalledWith("1");
+  });
+
   it("surfaces compressor errors", () => {
     render(
       <AttachmentTray

--- a/web/src/components/__tests__/AttachmentTray.test.tsx
+++ b/web/src/components/__tests__/AttachmentTray.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AttachmentTray } from "../AttachmentTray";
+import type { ComposerAttachment } from "../../lib/useComposerAttachments";
+
+function attach(id: string, name = `${id}.png`): ComposerAttachment {
+  return {
+    clientId: id,
+    filename: name,
+    mimeType: "image/webp",
+    byteSize: 1024,
+    previewUrl: `blob://${id}`,
+    blob: new Blob(["x"], { type: "image/webp" }),
+  };
+}
+
+describe("AttachmentTray", () => {
+  it("renders a thumbnail per attachment with a remove button", () => {
+    const onRemove = vi.fn();
+    render(
+      <AttachmentTray
+        attachments={[attach("1"), attach("2")]}
+        onAddFiles={vi.fn()}
+        onRemove={onRemove}
+      />,
+    );
+    expect(screen.getAllByRole("img")).toHaveLength(2);
+    fireEvent.click(screen.getByLabelText("Remove 1.png"));
+    expect(onRemove).toHaveBeenCalledWith("1");
+  });
+
+  it("hides the add button once the cap is reached", () => {
+    render(
+      <AttachmentTray
+        attachments={[attach("1"), attach("2"), attach("3"), attach("4")]}
+        onAddFiles={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+    expect(screen.queryByLabelText("Attach images")).toBeNull();
+  });
+
+  it("surfaces compressor errors", () => {
+    render(
+      <AttachmentTray
+        attachments={[]}
+        onAddFiles={vi.fn()}
+        onRemove={vi.fn()}
+        error="too big"
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("too big");
+  });
+});

--- a/web/src/generated/openapi-types.ts
+++ b/web/src/generated/openapi-types.ts
@@ -3019,6 +3019,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/sessions/{session_id}/inputs-multipart": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Session Input With Attachments
+         * @description Send a user input with one or more image attachments.
+         *
+         *     v1 only supports the ``auto`` intent. ``steer`` would need the live
+         *     steer chain to accept attachments and would race the dispatch lock
+         *     that this route already acquires for the regular send path.
+         *     Queue-with-attachments is also rejected because the queued-input
+         *     drain path doesn't load attachments yet.
+         */
+        post: operations["create_session_input_with_attachments_sessions__session_id__inputs_multipart_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/agents/sessions/{session_id}/inputs/{input_id}/attachments/{attachment_id}/blob": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fetch Attachment Blob
+         * @description Stream a single attachment blob to the engine.
+         *
+         *     Always returns 404 on any cross-row mismatch (wrong session, wrong
+         *     input). The engine still verifies sha256 before handing the path to
+         *     Codex — the 404 is a defense-in-depth boundary, not a primary
+         *     integrity contract.
+         */
+        get: operations["fetch_attachment_blob_agents_sessions__session_id__inputs__input_id__attachments__attachment_id__blob_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/timeline/sessions/stream": {
         parameters: {
             query?: never;
@@ -5080,6 +5131,23 @@ export interface components {
              * @default
              */
             message: string;
+        };
+        /** Body_create_session_input_with_attachments_sessions__session_id__inputs_multipart_post */
+        Body_create_session_input_with_attachments_sessions__session_id__inputs_multipart_post: {
+            /**
+             * Text
+             * @default
+             */
+            text: string;
+            /**
+             * Intent
+             * @default auto
+             */
+            intent: string;
+            /** Client Request Id */
+            client_request_id?: string | null;
+            /** Attachments */
+            attachments: string[];
         };
         /** Body_upload_current_user_avatar_users_me_avatar_post */
         Body_upload_current_user_avatar_users_me_avatar_post: {
@@ -8533,6 +8601,12 @@ export interface components {
              * @default false
              */
             can_resume: boolean;
+            /**
+             * Attach Images
+             * @description True when the session can accept image attachments on input (codex_app_server only)
+             * @default false
+             */
+            attach_images: boolean;
         };
         /** SessionControlResponse */
         SessionControlResponse: {
@@ -15788,6 +15862,77 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SessionInterruptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_session_input_with_attachments_sessions__session_id__inputs_multipart_post: {
+        parameters: {
+            query?: {
+                /** @description Optional JWT token (used by EventSource/SSE which can't send Authorization headers). */
+                token?: string | null;
+            };
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_create_session_input_with_attachments_sessions__session_id__inputs_multipart_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionInputResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fetch_attachment_blob_agents_sessions__session_id__inputs__input_id__attachments__attachment_id__blob_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+                input_id: number;
+                attachment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/web/src/lib/__tests__/imageCompression.test.ts
+++ b/web/src/lib/__tests__/imageCompression.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  compressImageForUpload,
+  ImageCompressionError,
+} from "../imageCompression";
+
+class FakeImageBitmap {
+  width: number;
+  height: number;
+  closed = false;
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+let lastCanvas: { width: number; height: number } | null = null;
+
+function installFakeCanvas(emit: { mime: string; bytes: number }) {
+  lastCanvas = null;
+  // jsdom doesn't ship canvas; install a minimal fake that records dimensions
+  // and produces blobs of the requested mime + size.
+  vi.stubGlobal("OffscreenCanvas", class {
+    width: number;
+    height: number;
+    constructor(w: number, h: number) {
+      this.width = w;
+      this.height = h;
+      lastCanvas = { width: w, height: h };
+    }
+    getContext() {
+      return { drawImage: vi.fn() };
+    }
+    convertToBlob(opts?: { type?: string }) {
+      const mime = opts?.type ?? "image/png";
+      if (mime !== emit.mime) {
+        return Promise.reject(new Error("unsupported mime"));
+      }
+      return Promise.resolve(new Blob([new Uint8Array(emit.bytes)], { type: mime }));
+    }
+  });
+}
+
+describe("compressImageForUpload", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubGlobal(
+      "createImageBitmap",
+      vi.fn(async (file: File) => {
+        if (file.name === "broken.png") throw new Error("decode failed");
+        return new FakeImageBitmap(file.name === "huge.png" ? 4096 : 1024, file.name === "huge.png" ? 3072 : 768);
+      }),
+    );
+  });
+
+  it("rejects non-image inputs without calling decode", async () => {
+    const file = new File(["x"], "note.txt", { type: "text/plain" });
+    await expect(compressImageForUpload(file)).rejects.toBeInstanceOf(ImageCompressionError);
+  });
+
+  it("encodes webp when the browser supports it", async () => {
+    installFakeCanvas({ mime: "image/webp", bytes: 1024 });
+    const file = new File([new Uint8Array(2048)], "ok.png", { type: "image/png" });
+    const out = await compressImageForUpload(file);
+    expect(out.mimeType).toBe("image/webp");
+    expect(out.byteSize).toBe(1024);
+  });
+
+  it("scales the longest edge to 2048", async () => {
+    installFakeCanvas({ mime: "image/webp", bytes: 1024 });
+    const file = new File([new Uint8Array(8192)], "huge.png", { type: "image/png" });
+    await compressImageForUpload(file);
+    expect(lastCanvas).toEqual({ width: 2048, height: 1536 });
+  });
+
+  it("falls back to jpeg when webp encoding is unavailable", async () => {
+    installFakeCanvas({ mime: "image/jpeg", bytes: 4096 });
+    const file = new File([new Uint8Array(2048)], "ok.png", { type: "image/png" });
+    const out = await compressImageForUpload(file);
+    expect(out.mimeType).toBe("image/jpeg");
+  });
+
+  it("surfaces decode failures as ImageCompressionError", async () => {
+    installFakeCanvas({ mime: "image/webp", bytes: 1024 });
+    const file = new File([new Uint8Array(2048)], "broken.png", { type: "image/png" });
+    await expect(compressImageForUpload(file)).rejects.toBeInstanceOf(ImageCompressionError);
+  });
+});

--- a/web/src/lib/__tests__/useComposerAttachments.test.tsx
+++ b/web/src/lib/__tests__/useComposerAttachments.test.tsx
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useComposerAttachments } from "../useComposerAttachments";
+
+vi.mock("../imageCompression", () => ({
+  compressImageForUpload: vi.fn(async (file: File) => ({
+    blob: new Blob([new Uint8Array(file.size)], { type: "image/webp" }),
+    mimeType: "image/webp",
+    width: 100,
+    height: 100,
+    byteSize: file.size,
+  })),
+  ImageCompressionError: class extends Error {},
+}));
+
+function makeFile(name: string, type: string, size = 1024): File {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob://mock"),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+describe("useComposerAttachments", () => {
+  it("accepts up to 4 valid images and surfaces an error past the cap", async () => {
+    const { result } = renderHook(() => useComposerAttachments());
+    await act(async () => {
+      await result.current.addFiles([
+        makeFile("a.png", "image/png"),
+        makeFile("b.png", "image/png"),
+        makeFile("c.png", "image/png"),
+        makeFile("d.png", "image/png"),
+      ]);
+    });
+    expect(result.current.attachments).toHaveLength(4);
+
+    await act(async () => {
+      await result.current.addFiles([makeFile("e.png", "image/png")]);
+    });
+    expect(result.current.attachments).toHaveLength(4);
+    expect(result.current.error).toMatch(/max/);
+  });
+
+  it("rejects unsupported mime types", async () => {
+    const { result } = renderHook(() => useComposerAttachments());
+    await act(async () => {
+      await result.current.addFiles([makeFile("x.svg", "image/svg+xml")]);
+    });
+    expect(result.current.attachments).toHaveLength(0);
+    expect(result.current.error).toMatch(/unsupported/);
+  });
+
+  it("rejects items still over the byte cap after compression", async () => {
+    const { compressImageForUpload } = await import("../imageCompression");
+    (compressImageForUpload as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      blob: new Blob([new Uint8Array(3 * 1024 * 1024)], { type: "image/webp" }),
+      mimeType: "image/webp",
+      width: 4000,
+      height: 4000,
+      byteSize: 3 * 1024 * 1024,
+    });
+    const { result } = renderHook(() => useComposerAttachments());
+    await act(async () => {
+      await result.current.addFiles([makeFile("big.png", "image/png", 4 * 1024 * 1024)]);
+    });
+    expect(result.current.attachments).toHaveLength(0);
+    expect(result.current.error).toMatch(/2 MB/);
+  });
+
+  it("removes one and clears all", async () => {
+    const { result } = renderHook(() => useComposerAttachments());
+    await act(async () => {
+      await result.current.addFiles([
+        makeFile("a.png", "image/png"),
+        makeFile("b.png", "image/png"),
+      ]);
+    });
+    const firstId = result.current.attachments[0].clientId;
+    act(() => result.current.removeAttachment(firstId));
+    expect(result.current.attachments).toHaveLength(1);
+
+    act(() => result.current.clear());
+    expect(result.current.attachments).toHaveLength(0);
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/imageCompression.ts
+++ b/web/src/lib/imageCompression.ts
@@ -1,0 +1,101 @@
+/**
+ * Resize + recompress an image attachment before upload.
+ *
+ * Browsers + iPhone screenshots routinely produce 4-8 MB PNGs that the
+ * server would reject (2 MB cap). Compressing client-side keeps the
+ * happy path under the cap without forcing a re-pick. We never change
+ * orientation here; PHPicker / browser file inputs already deliver
+ * upright bitmaps via `createImageBitmap`.
+ */
+
+const MAX_LONG_EDGE = 2048;
+const WEBP_QUALITY = 0.85;
+const JPEG_QUALITY = 0.85;
+
+export interface CompressedImage {
+  blob: Blob;
+  mimeType: string;
+  width: number;
+  height: number;
+  byteSize: number;
+}
+
+export class ImageCompressionError extends Error {}
+
+export async function compressImageForUpload(file: File): Promise<CompressedImage> {
+  if (!file.type.startsWith("image/")) {
+    throw new ImageCompressionError(`unsupported file type: ${file.type || "unknown"}`);
+  }
+
+  const bitmap = await safeCreateImageBitmap(file);
+  try {
+    const { width, height } = scaleToFit(bitmap.width, bitmap.height, MAX_LONG_EDGE);
+    const canvas = createCanvas(width, height);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new ImageCompressionError("2d canvas context unavailable");
+    ctx.drawImage(bitmap, 0, 0, width, height);
+
+    const { blob, mimeType } = await encodeBest(canvas);
+    return { blob, mimeType, width, height, byteSize: blob.size };
+  } finally {
+    bitmap.close?.();
+  }
+}
+
+async function safeCreateImageBitmap(file: File): Promise<ImageBitmap> {
+  try {
+    return await createImageBitmap(file);
+  } catch (err) {
+    throw new ImageCompressionError(
+      `could not decode image: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function scaleToFit(w: number, h: number, maxEdge: number): { width: number; height: number } {
+  const longest = Math.max(w, h);
+  if (longest <= maxEdge) return { width: w, height: h };
+  const ratio = maxEdge / longest;
+  return { width: Math.round(w * ratio), height: Math.round(h * ratio) };
+}
+
+type AnyCanvas = HTMLCanvasElement | OffscreenCanvas;
+
+function createCanvas(width: number, height: number): AnyCanvas {
+  if (typeof OffscreenCanvas !== "undefined") {
+    return new OffscreenCanvas(width, height);
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+async function encodeBest(canvas: AnyCanvas): Promise<{ blob: Blob; mimeType: string }> {
+  // Prefer webp — significantly smaller than png/jpeg at the same visual
+  // quality. Some Safari builds don't encode webp from canvas; fall back
+  // to jpeg in that case rather than raising the byte budget.
+  const webp = await tryEncode(canvas, "image/webp", WEBP_QUALITY);
+  if (webp) return { blob: webp, mimeType: "image/webp" };
+  const jpeg = await tryEncode(canvas, "image/jpeg", JPEG_QUALITY);
+  if (jpeg) return { blob: jpeg, mimeType: "image/jpeg" };
+  throw new ImageCompressionError("canvas did not produce a blob");
+}
+
+async function tryEncode(canvas: AnyCanvas, mime: string, quality: number): Promise<Blob | null> {
+  try {
+    if (canvas instanceof OffscreenCanvas) {
+      const blob = await canvas.convertToBlob({ type: mime, quality });
+      return blob.type === mime ? blob : null;
+    }
+    return await new Promise<Blob | null>((resolve) =>
+      (canvas as HTMLCanvasElement).toBlob(
+        (b) => resolve(b && b.type === mime ? b : null),
+        mime,
+        quality,
+      ),
+    );
+  } catch {
+    return null;
+  }
+}

--- a/web/src/lib/useComposerAttachments.ts
+++ b/web/src/lib/useComposerAttachments.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { compressImageForUpload, ImageCompressionError } from "./imageCompression";
+
+const MAX_ATTACHMENTS = 4;
+const MAX_BYTES = 2 * 1024 * 1024;
+const ALLOWED_MIME = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
+
+export interface ComposerAttachment {
+  /** Stable client-side id for keyed React lists; not sent to the server. */
+  clientId: string;
+  filename: string;
+  mimeType: string;
+  byteSize: number;
+  /** Object URL for thumbnail preview. Revoked when the attachment is dropped. */
+  previewUrl: string;
+  blob: Blob;
+}
+
+export interface UseComposerAttachmentsApi {
+  attachments: ComposerAttachment[];
+  addFiles: (files: FileList | File[]) => Promise<void>;
+  removeAttachment: (clientId: string) => void;
+  clear: () => void;
+  isCompressing: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+export function useComposerAttachments(): UseComposerAttachmentsApi {
+  // Ref is the source of truth so concurrent compress operations agree on the
+  // current count; state mirrors it for render. React 18's batching makes a
+  // pure setState(prev=>...) callback unreliable as a "read latest" path.
+  const ref = useRef<ComposerAttachment[]>([]);
+  const [attachments, setAttachmentsState] = useState<ComposerAttachment[]>([]);
+  const [isCompressing, setIsCompressing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const counterRef = useRef(0);
+
+  const sync = useCallback(() => {
+    setAttachmentsState([...ref.current]);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      ref.current.forEach((a) => URL.revokeObjectURL(a.previewUrl));
+      ref.current = [];
+    };
+  }, []);
+
+  const addFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const incoming = Array.from(files);
+      if (!incoming.length) return;
+      setError(null);
+      setIsCompressing(true);
+      try {
+        const slotsLeft = MAX_ATTACHMENTS - ref.current.length;
+        if (slotsLeft <= 0) {
+          setError(`max ${MAX_ATTACHMENTS} attachments`);
+          return;
+        }
+        for (const file of incoming.slice(0, slotsLeft)) {
+          if (!ALLOWED_MIME.has(file.type)) {
+            setError(`unsupported type: ${file.type || file.name}`);
+            continue;
+          }
+          try {
+            const compressed = await compressImageForUpload(file);
+            if (compressed.byteSize > MAX_BYTES) {
+              setError(
+                `${file.name} is still ${Math.round(compressed.byteSize / 1024)}KB after compression (max 2 MB)`,
+              );
+              continue;
+            }
+            counterRef.current += 1;
+            ref.current.push({
+              clientId: `att-${counterRef.current}`,
+              filename: file.name,
+              mimeType: compressed.mimeType,
+              byteSize: compressed.byteSize,
+              previewUrl: URL.createObjectURL(compressed.blob),
+              blob: compressed.blob,
+            });
+          } catch (err) {
+            if (err instanceof ImageCompressionError) {
+              setError(err.message);
+            } else {
+              setError(err instanceof Error ? err.message : "could not process image");
+            }
+          }
+        }
+        // Cap defensively in case the loop somehow over-pushed.
+        if (ref.current.length > MAX_ATTACHMENTS) {
+          ref.current = ref.current.slice(0, MAX_ATTACHMENTS);
+        }
+        sync();
+      } finally {
+        setIsCompressing(false);
+      }
+    },
+    [sync],
+  );
+
+  const removeAttachment = useCallback(
+    (clientId: string) => {
+      const target = ref.current.find((a) => a.clientId === clientId);
+      if (target) URL.revokeObjectURL(target.previewUrl);
+      ref.current = ref.current.filter((a) => a.clientId !== clientId);
+      sync();
+    },
+    [sync],
+  );
+
+  const clear = useCallback(() => {
+    ref.current.forEach((a) => URL.revokeObjectURL(a.previewUrl));
+    ref.current = [];
+    sync();
+    setError(null);
+  }, [sync]);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return { attachments, addFiles, removeAttachment, clear, isCompressing, error, clearError };
+}
+
+export const COMPOSER_ATTACHMENT_LIMITS = {
+  maxAttachments: MAX_ATTACHMENTS,
+  maxBytes: MAX_BYTES,
+  allowedMime: ALLOWED_MIME,
+} as const;

--- a/web/src/lib/useComposerAttachments.ts
+++ b/web/src/lib/useComposerAttachments.ts
@@ -36,13 +36,16 @@ export function useComposerAttachments(): UseComposerAttachmentsApi {
   const [isCompressing, setIsCompressing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const counterRef = useRef(0);
+  const mountedRef = useRef(true);
 
   const sync = useCallback(() => {
+    if (!mountedRef.current) return;
     setAttachmentsState([...ref.current]);
   }, []);
 
   useEffect(() => {
     return () => {
+      mountedRef.current = false;
       ref.current.forEach((a) => URL.revokeObjectURL(a.previewUrl));
       ref.current = [];
     };
@@ -90,13 +93,16 @@ export function useComposerAttachments(): UseComposerAttachmentsApi {
             }
           }
         }
-        // Cap defensively in case the loop somehow over-pushed.
+        // Cap defensively in case the loop somehow over-pushed; revoke any
+        // overflow previews so we don't leak object URLs.
         if (ref.current.length > MAX_ATTACHMENTS) {
+          const overflow = ref.current.slice(MAX_ATTACHMENTS);
+          overflow.forEach((a) => URL.revokeObjectURL(a.previewUrl));
           ref.current = ref.current.slice(0, MAX_ATTACHMENTS);
         }
         sync();
       } finally {
-        setIsCompressing(false);
+        if (mountedRef.current) setIsCompressing(false);
       }
     },
     [sync],

--- a/web/src/services/api/agents.ts
+++ b/web/src/services/api/agents.ts
@@ -221,6 +221,12 @@ export interface SessionCapabilities {
   composer_enabled?: boolean;
   composer_placeholder?: string;
   composer_disabled_reason?: string | null;
+  /**
+   * True when this session accepts image attachments on input. Today this is
+   * codex_app_server + live_control_available; the server is the source of
+   * truth so the web client doesn't have to know the transport set.
+   */
+  attach_images?: boolean;
 }
 
 export interface AgentSessionsListResponse {

--- a/web/src/services/api/sessionChat.ts
+++ b/web/src/services/api/sessionChat.ts
@@ -69,10 +69,27 @@ export async function postSessionInputMultipart(
   form.append("intent", "auto");
   if (body.client_request_id) form.append("client_request_id", body.client_request_id);
   body.attachments.forEach((a) => form.append("attachments", a.blob, a.filename));
-  return request<SessionInputResponse>(`/sessions/${sessionId}/inputs-multipart`, {
-    method: "POST",
-    body: form,
-  });
+  const totalBytes = body.attachments.reduce((sum, a) => sum + a.blob.size, 0);
+  const started = performance.now();
+  try {
+    const result = await request<SessionInputResponse>(`/sessions/${sessionId}/inputs-multipart`, {
+      method: "POST",
+      body: form,
+    });
+    const elapsedMs = Math.round(performance.now() - started);
+    console.info(
+      `[image-attach] web upload count=${body.attachments.length} ` +
+      `total_bytes=${totalBytes} elapsed_ms=${elapsedMs}`,
+    );
+    return result;
+  } catch (err) {
+    const elapsedMs = Math.round(performance.now() - started);
+    console.warn(
+      `[image-attach] web upload failed count=${body.attachments.length} ` +
+      `total_bytes=${totalBytes} elapsed_ms=${elapsedMs}`,
+    );
+    throw err;
+  }
 }
 
 export async function fetchSessionInputs(

--- a/web/src/services/api/sessionChat.ts
+++ b/web/src/services/api/sessionChat.ts
@@ -50,6 +50,31 @@ export async function postSessionInput(
   });
 }
 
+export interface MultipartAttachment {
+  blob: Blob;
+  filename: string;
+}
+
+export async function postSessionInputMultipart(
+  sessionId: string,
+  body: {
+    text: string;
+    attachments: MultipartAttachment[];
+    client_request_id?: string | null;
+  },
+): Promise<SessionInputResponse> {
+  // Multipart route is auto-intent only in v1; the server enforces this.
+  const form = new FormData();
+  form.append("text", body.text);
+  form.append("intent", "auto");
+  if (body.client_request_id) form.append("client_request_id", body.client_request_id);
+  body.attachments.forEach((a) => form.append("attachments", a.blob, a.filename));
+  return request<SessionInputResponse>(`/sessions/${sessionId}/inputs-multipart`, {
+    method: "POST",
+    body: form,
+  });
+}
+
 export async function fetchSessionInputs(
   sessionId: string,
 ): Promise<QueuedInputSummary[]> {

--- a/web/src/styles/session-chat.css
+++ b/web/src/styles/session-chat.css
@@ -679,3 +679,67 @@
     padding: 4px 0;
   }
 }
+
+.session-chat-attachment-tray {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 0;
+  align-items: center;
+}
+
+.session-chat-attachment-tray__item {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle, rgba(0, 0, 0, 0.08));
+  background: var(--color-surface-2, #f3f3f3);
+}
+
+.session-chat-attachment-tray__thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.session-chat-attachment-tray__remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 18px;
+  height: 18px;
+  line-height: 16px;
+  font-size: 14px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  color: white;
+  cursor: pointer;
+  padding: 0;
+}
+
+.session-chat-attachment-tray__add {
+  width: 56px;
+  height: 56px;
+  border: 1px dashed var(--color-border-subtle, rgba(0, 0, 0, 0.18));
+  border-radius: 6px;
+  background: transparent;
+  font-size: 24px;
+  color: var(--color-text-muted, #888);
+  cursor: pointer;
+}
+
+.session-chat-attachment-tray__add:disabled {
+  cursor: progress;
+  opacity: 0.6;
+}
+
+.session-chat-attachment-tray__error {
+  flex-basis: 100%;
+  font-size: 12px;
+  color: var(--color-text-danger, #b00020);
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary

Ship Codex image attach end-to-end. Composer (web + iOS) uploads images to the runtime host; the Rust engine fetches blobs over `X-Agents-Token` and feeds them to Codex as `UserInput::LocalImage`.

- **Backend:** new `session_input_attachments` table + `POST /api/sessions/{id}/inputs-multipart` (intent=auto, codex_app_server only, 4 images/2 MB each). Machine-token blob fetch at `/api/agents/sessions/{sid}/inputs/{iid}/attachments/{aid}/blob`.
- **Engine:** `AttachmentRef` parser, concurrent `fetch_all` with sha256 verify, owner-only tmpdir per session, orphan cleanup on startup + on send failure.
- **Web composer:** picker / paste / drag-drop / thumbnails, client-side compression, vitest coverage.
- **iOS composer:** PhotosPicker, orientation-preserving thumbnail downscale, multipart upload with Longhouse-iOS UA.
- **Telemetry:** prom counters/histogram by client + outcome, structured engine logs, web/iOS elapsed-ms.

Two rounds of `hatch_codex` review; final review's two cleanup blockers (orphan engine tmpdir + orphan blob on commit failure) are fixed in the last commit.

## Test plan

- [ ] `cd server && uv run pytest tests_lite/test_session_inputs_attachments_api.py` — 8/8 green
- [ ] `cd engine && cargo test codex_attachments` — 12/12 green
- [ ] `bunx vitest run` web tests — 9/9 green
- [ ] iOS xcodebuild scheme tests
- [ ] `make test-e2e` image-attach smoke
- [ ] After merge: `make ship` then `make dogfood-refresh` so menu bar + local engine pick up changes
- [ ] iOS: rebuild via Xcode (no TestFlight pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)