### PR TITLE
Native iOS device session auth

### DIFF
--- a/docs/specs/native-ios-device-auth.md
+++ b/docs/specs/native-ios-device-auth.md
@@ -12,7 +12,7 @@ The current hosted iOS flow stores a CP-issued runtime bearer in Keychain and re
 
 - Short-lived runtime access token: signed CP JWT, used as `Authorization: Bearer`.
 - Long-lived native refresh token: opaque random credential, stored in iOS Keychain, hashed in the control-plane database.
-- Rotation on refresh: every refresh returns a new access token and a new refresh token; the previous refresh token is consumed.
+- Rotation on refresh: every refresh returns a new access token and a new refresh token; the previous refresh token remains accepted only inside a short crash/race grace window.
 - Clear error semantics: only explicit rejection clears local auth; network, deploy, and 5xx failures defer and keep the local shell.
 - Backward compatibility: existing bearer-only refresh remains as a temporary migration path and is removed after dogfood stabilizes.
 
@@ -66,9 +66,9 @@ Control Plane
 ### Token Lifetimes
 
 - Runtime access token: 1 hour for now, still configurable by constant.
-- Native refresh token idle lifetime: 90 days.
+- Native refresh token idle lifetime: 90 days, sliding on each successful refresh.
 - Native refresh token absolute lifetime: 180 days.
-- Refresh response includes `runtime_token`, `expires_in`, `refresh_token`, `refresh_expires_in`, and `refresh_token_expires_at`.
+- Refresh response includes `runtime_token`, `expires_in`, `refresh_token`, and `refresh_token_expires_at`.
 
 The product behavior is "you should not think about login." The security behavior is "a stolen refresh credential cannot live forever, can be revoked per device, and rotates on every use."
 
@@ -96,7 +96,6 @@ Response adds native-session fields:
   "token_type": "bearer",
   "expires_in": 3600,
   "refresh_token": "opaque",
-  "refresh_token_expires_in": 15552000,
   "refresh_token_expires_at": "2027-01-04T18:00:00Z",
   "device_session_id": "nds_...",
   "claims": {}
@@ -140,8 +139,10 @@ Rules:
 
 - Missing/unknown/expired/revoked token returns `401`.
 - Tenant mismatch returns `403`.
-- Successful refresh rotates the token hash and updates `last_used_at`.
-- Refresh-token reuse returns `401` and revokes the session family if the row can be identified.
+- Successful refresh rotates the current token hash, records the just-replaced token hash as `previous_token_hash`, updates `rotated_at`, updates `last_used_at`, and slides `idle_expires_at`.
+- Presenting `previous_token_hash` inside the rotation grace window performs another successful rotation. This covers process crashes between response receipt and Keychain persistence, plus unavoidable app/widget races.
+- Presenting `previous_token_hash` outside the grace window revokes the device session and returns `401`.
+- Presenting an unknown token hash returns `401` without changing any row.
 
 ### Control Plane: Native Logout
 
@@ -163,6 +164,7 @@ Rules:
 
 - Best effort and idempotent.
 - Revokes the matching device session if present.
+- Unknown tokens still return success; logout must not fail because the CP already forgot the session.
 
 ### Tenant Runtime Proxy
 
@@ -173,7 +175,15 @@ Tenant routes:
 
 These proxy to CP with `X-Internal-Token`. iOS never talks directly to `control.longhouse.ai` after handoff, which preserves the tenant-runtime boundary and keeps CORS/network policy simple.
 
+Proxy error mapping is part of the auth contract:
+
+- CP-originated `401` and `403` pass through so iOS can clear explicitly rejected credentials.
+- CP network failures, timeouts, and malformed CP responses return `502` or `503`, never `401` or `403`.
+- Missing local refresh token returns `401`; CP-unreachable does not.
+
 `POST /api/auth/refresh-runtime-token` remains temporarily for already-installed iOS builds that only have a runtime bearer.
+
+For migration, the legacy bearer refresh response also returns native-session fields when CP can verify the bearer. New iOS builds that already have only a runtime token silently upgrade on their next proactive refresh or 401 retry. Old iOS builds ignore the extra fields.
 
 ## Data Model
 
@@ -187,7 +197,8 @@ cp_native_device_sessions
   instance_id: FK cp_instances.id
   tenant_subdomain: string
   token_hash: string unique
-  token_family_id: string
+  previous_token_hash: string nullable indexed
+  rotated_at: datetime nullable
   device_label: string nullable
   platform: string default "ios"
   app_build: string nullable
@@ -201,6 +212,19 @@ cp_native_device_sessions
 
 Only `token_hash` is persisted. The raw refresh token is shown exactly once in the exchange/refresh response.
 
+The row is the session family. There is no separate `token_family_id` in this phase.
+
+Reuse handling:
+
+- `token_hash` match: normal refresh.
+- `previous_token_hash` match and `rotated_at` is within 120 seconds: normal refresh.
+- `previous_token_hash` match outside 120 seconds: revoke row with `revoke_reason="refresh_reuse"`.
+
+Pruning:
+
+- Startup and successful refresh opportunistically delete rows revoked or expired more than 30 days ago.
+- Active rows are capped later when signed-in device UI exists; no hard cap in this phase.
+
 Migration is additive:
 
 - `Base.metadata.create_all()` creates the table for new installs.
@@ -212,11 +236,11 @@ Migration is additive:
 `SharedAuthStore` stores a native session bundle per host:
 
 - runtime token in Keychain.
-- refresh token in Keychain.
+- refresh token in Keychain with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`.
 - runtime expiry in app-group defaults.
 - refresh expiry in app-group defaults.
 
-Keychain accessibility remains `kSecAttrAccessibleAfterFirstUnlock` because widgets/background refresh need shared access after first unlock. This is a product/security tradeoff: the credential survives normal use and app updates, and background surfaces work; explicit logout deletes it.
+The runtime token may remain on the current shared Keychain accessibility because it is short-lived. The refresh token must be `ThisDeviceOnly`: it still supports widgets/background access after first unlock, but it does not migrate through encrypted backup restore to a different device. This makes the product phrase "device session" true.
 
 ## iOS Refresh Behavior
 
@@ -224,10 +248,18 @@ Introduce a single refresh authority instead of ad hoc refresh calls:
 
 - On app launch, if runtime token verifies, schedule proactive refresh.
 - If runtime token fails with 401 and refresh token exists, call `/api/auth/refresh-native-session`.
-- If refresh succeeds, save both new tokens and retry once.
+- If refresh succeeds, persist the new refresh token first, then the runtime token, then resolve the in-flight refresh and retry once.
 - If refresh returns 401/403, clear auth.
 - If refresh fails due to network, timeout, 5xx, or bad gateway, keep local session candidate and show cached shell.
 - Concurrent requests share one in-flight refresh task per host.
+- Local expiry timestamps only schedule refresh attempts. They never hard-clear auth; the server decides whether credentials are invalid.
+- The refresh token, not the access token, drives whether the app has a durable signed-in candidate.
+
+Widget behavior:
+
+- Widgets never initiate native refresh.
+- Widgets read the latest Keychain tokens and fetch normally.
+- On 401, widgets show cached data silently and do not clear auth. The main app owns refresh and logout decisions.
 
 ## Compatibility & Rollout
 
@@ -273,9 +305,9 @@ Revisit if: We add a first-class public OAuth/OIDC issuer URL and universal app 
 
 Context: Native clients are public clients and cannot keep a client secret.
 
-Choice: Refresh token rotation is mandatory.
+Choice: Refresh token rotation is mandatory, with a 120-second previous-token grace window.
 
-Rationale: Rotation limits replay and gives us reuse detection. It is the simple modern baseline before more complex sender-constrained schemes.
+Rationale: Rotation limits replay and gives us reuse detection. The grace window prevents false logout when iOS kills the app between receiving and persisting a refresh response, or when the widget observes a token during rotation.
 
 Revisit if: Rotation causes concurrency failures that single-flight cannot solve.
 
@@ -288,6 +320,36 @@ Choice: Only explicit auth rejection clears credentials. Ambiguous failures keep
 Rationale: Product trust is destroyed by false logout. A 5xx does not prove the credential is invalid.
 
 Revisit if: We add a server-pushed account-disabled signal.
+
+### Decision: Legacy Bearer Refresh Upgrades Existing Installs
+
+Context: Dogfood phones may already be signed in with only a runtime token.
+
+Choice: Keep the legacy `/refresh-runtime-token` path and add native-session fields to its successful response.
+
+Rationale: New app builds can silently upgrade without forcing a fresh login. Old app builds ignore the extra fields.
+
+Revisit if: We are willing to force one explicit re-login at launch.
+
+### Decision: Control Plane Tenant Identity For This Phase
+
+Context: Current hosted tenants share `CONTROL_PLANE_INSTANCE_INTERNAL_API_SECRET`, so CP cannot derive a unique tenant identity from the internal token yet.
+
+Choice: In this phase, CP validates the internal token and enforces that the requested tenant matches the native device session's `tenant_subdomain` and `instance_id`. Per-instance internal identity is a follow-up hardening item.
+
+Rationale: This removes user-facing churn now without blocking on a broader hosted secret model. It does not make the current shared internal secret a stronger boundary than it is.
+
+Revisit if: We provision per-instance CP credentials or sign tenant proxy requests with instance-specific keys.
+
+### Decision: Widgets Are Read-Only Auth Consumers
+
+Context: Widgets run in a separate process and cannot share a simple in-memory refresh lock with the app.
+
+Choice: Widgets read tokens and cached snapshots, but never refresh or clear auth.
+
+Rationale: This avoids widget/app refresh races. The main app remains the only process that mutates auth credentials.
+
+Revisit if: We add a cross-process refresh lock with durable compare-and-swap semantics.
 
 ## Implementation Phases
 
@@ -306,9 +368,10 @@ Acceptance criteria:
 - `NativeDeviceSession` model exists.
 - Startup creates/migrates `cp_native_device_sessions`.
 - Handoff exchange returns refresh-token fields.
-- `refresh-native-session` rotates token hashes and mints runtime token.
+- `refresh-native-session` rotates token hashes, honors previous-token grace, slides idle expiry, and mints runtime token.
 - `revoke-native-session` revokes matching session idempotently.
-- Tests cover exchange, refresh rotation, tenant mismatch, expiry, revoked token, reuse detection, and logout.
+- Legacy `/refresh-runtime-token` upgrades bearer-only clients by returning native-session fields.
+- Tests cover exchange, refresh rotation, previous-token grace, previous-token reuse outside grace, tenant mismatch, expiry, revoked token, legacy upgrade, pruning, and logout.
 
 Test command:
 
@@ -325,6 +388,7 @@ Acceptance criteria:
 - `/api/auth/accept-native-handoff` returns native refresh fields.
 - `/api/auth/refresh-native-session` proxies refresh token to CP with internal token.
 - `/api/auth/revoke-native-session` proxies logout best-effort.
+- CP network failure maps to `502/503`, not auth rejection.
 - Existing `/api/auth/refresh-runtime-token` remains compatible.
 - Tests cover proxy success, CP rejection, CP network failure, and missing token.
 
@@ -344,7 +408,8 @@ Acceptance criteria:
 - Refresh is single-flight across concurrent API requests.
 - Explicit 401/403 clears auth; network/5xx preserves local session candidate.
 - Logout calls native revoke before clearing local Keychain state.
-- Legacy bearer refresh fallback works when no refresh token is present.
+- Legacy bearer refresh fallback works when no refresh token is present, and stores native refresh fields if returned.
+- Widget fetches remain read-only and do not mutate auth on 401.
 
 Test command:
 
@@ -376,7 +441,7 @@ make test-ios
 
 ## Open Risks
 
-- Refresh rotation plus concurrent requests can invalidate a session if the client does not single-flight correctly.
-- Widgets may refresh from a separate process. They need either read-only access to the latest Keychain token or a conservative no-refresh fallback.
+- Refresh rotation plus concurrent requests can invalidate a session if the client does not single-flight correctly and CP grace does not cover a race.
 - SQLite migration code must be explicit enough for existing control-plane deployments.
 - Older iOS builds will still use bearer refresh until replaced.
+- Current shared tenant internal secret means CP cannot cryptographically identify the tenant caller beyond the shared secret; this is pre-existing and should be hardened separately.

--- a/docs/specs/native-ios-device-auth.md
+++ b/docs/specs/native-ios-device-auth.md
@@ -1,0 +1,382 @@
+# Native iOS Device Auth
+
+Status: Draft
+Owner: Longhouse
+Scope: hosted iOS sign-in, hosted runtime auth refresh, tenant proxy compatibility
+
+## Executive Summary
+
+The iOS app should behave like a modern native client: a user signs in once, and the app stays signed in across app launches, backgrounding, app updates, backend deploys, and short outages. Re-authentication should happen only after explicit logout, credential revocation, account/security events, or a long absolute device-session lifetime.
+
+The current hosted iOS flow stores a CP-issued runtime bearer in Keychain and refreshes it by presenting that bearer back to the control plane. A short-term fix extended the expired-token refresh leeway, but that still treats a signed JWT as a long-lived refresh credential. This spec replaces that with an explicit native device session:
+
+- Short-lived runtime access token: signed CP JWT, used as `Authorization: Bearer`.
+- Long-lived native refresh token: opaque random credential, stored in iOS Keychain, hashed in the control-plane database.
+- Rotation on refresh: every refresh returns a new access token and a new refresh token; the previous refresh token is consumed.
+- Clear error semantics: only explicit rejection clears local auth; network, deploy, and 5xx failures defer and keep the local shell.
+- Backward compatibility: existing bearer-only refresh remains as a temporary migration path and is removed after dogfood stabilizes.
+
+## Goals
+
+- Eliminate routine iOS re-authentication.
+- Make hosted iOS auth robust to overnight sleep, backend deploys, and control-plane restarts.
+- Keep access tokens short-lived and resource-server friendly.
+- Store only opaque refresh-token hashes server-side.
+- Rotate refresh credentials to limit replay damage.
+- Preserve the current `ASWebAuthenticationSession` sign-in shape.
+- Keep self-host/browser cookie auth out of this refactor.
+
+## Non-Goals
+
+- Full OAuth provider replacement or public OAuth server branding.
+- User-visible signed-in-device management UI in this phase.
+- Biometric app lock. This can be layered on top of Keychain later.
+- Migrating web/browser cookies to the native device-session model.
+- Shipping iOS through TestFlight/App Store.
+
+## Current Architecture
+
+1. iOS opens hosted sign-in with `ASWebAuthenticationSession`.
+2. The control plane authenticates the user and redirects back to the app with a one-use handoff code.
+3. iOS sends the handoff code to the tenant runtime.
+4. Tenant runtime exchanges the code with the control plane and returns a CP runtime JWT.
+5. iOS stores that runtime JWT in Keychain and sends it as `Authorization: Bearer`.
+6. Tenant runtime proxies `/api/auth/refresh-runtime-token` to the CP, using the old runtime JWT as the refresh credential.
+
+This works, but the long-lived credential is a JWT that was designed as an access token. That makes per-device revocation, rotation, and replay handling awkward.
+
+## Target Architecture
+
+```text
+iOS Keychain
+  access token: CP runtime JWT, short lifetime
+  refresh token: opaque native device token, long lifetime
+
+Tenant Runtime
+  validates runtime JWT for normal API auth
+  proxies native refresh/logout requests to Control Plane
+
+Control Plane
+  stores NativeDeviceSession rows
+  stores refresh token hash, not token plaintext
+  rotates refresh token on each refresh
+  mints runtime JWTs for tenant audience
+```
+
+### Token Lifetimes
+
+- Runtime access token: 1 hour for now, still configurable by constant.
+- Native refresh token idle lifetime: 90 days.
+- Native refresh token absolute lifetime: 180 days.
+- Refresh response includes `runtime_token`, `expires_in`, `refresh_token`, `refresh_expires_in`, and `refresh_token_expires_at`.
+
+The product behavior is "you should not think about login." The security behavior is "a stolen refresh credential cannot live forever, can be revoked per device, and rotates on every use."
+
+## API Contract
+
+### Control Plane: Exchange Handoff
+
+`POST /api/identity/exchange-handoff`
+
+Existing request remains:
+
+```json
+{
+  "code": "one-use-code",
+  "tenant": "david010",
+  "tenant_state": "handoff-verifier"
+}
+```
+
+Response adds native-session fields:
+
+```json
+{
+  "runtime_token": "jwt",
+  "token_type": "bearer",
+  "expires_in": 3600,
+  "refresh_token": "opaque",
+  "refresh_token_expires_in": 15552000,
+  "refresh_token_expires_at": "2027-01-04T18:00:00Z",
+  "device_session_id": "nds_...",
+  "claims": {}
+}
+```
+
+The tenant runtime returns these same fields from `/api/auth/accept-native-handoff`.
+
+### Control Plane: Native Refresh
+
+`POST /api/identity/refresh-native-session`
+
+Headers:
+
+- `X-Internal-Token`: tenant internal API secret.
+
+Body:
+
+```json
+{
+  "refresh_token": "opaque",
+  "tenant": "david010"
+}
+```
+
+Response:
+
+```json
+{
+  "runtime_token": "jwt",
+  "token_type": "bearer",
+  "expires_in": 3600,
+  "refresh_token": "opaque-next",
+  "refresh_token_expires_in": 15552000,
+  "refresh_token_expires_at": "2027-01-04T18:00:00Z",
+  "device_session_id": "nds_..."
+}
+```
+
+Rules:
+
+- Missing/unknown/expired/revoked token returns `401`.
+- Tenant mismatch returns `403`.
+- Successful refresh rotates the token hash and updates `last_used_at`.
+- Refresh-token reuse returns `401` and revokes the session family if the row can be identified.
+
+### Control Plane: Native Logout
+
+`POST /api/identity/revoke-native-session`
+
+Headers:
+
+- `X-Internal-Token`: tenant internal API secret.
+
+Body:
+
+```json
+{
+  "refresh_token": "opaque"
+}
+```
+
+Rules:
+
+- Best effort and idempotent.
+- Revokes the matching device session if present.
+
+### Tenant Runtime Proxy
+
+Tenant routes:
+
+- `POST /api/auth/refresh-native-session`
+- `POST /api/auth/revoke-native-session`
+
+These proxy to CP with `X-Internal-Token`. iOS never talks directly to `control.longhouse.ai` after handoff, which preserves the tenant-runtime boundary and keeps CORS/network policy simple.
+
+`POST /api/auth/refresh-runtime-token` remains temporarily for already-installed iOS builds that only have a runtime bearer.
+
+## Data Model
+
+Add `NativeDeviceSession` in the control plane:
+
+```text
+cp_native_device_sessions
+  id: int primary key
+  session_id: string unique, public identifier, "nds_" prefix
+  user_id: FK cp_users.id
+  instance_id: FK cp_instances.id
+  tenant_subdomain: string
+  token_hash: string unique
+  token_family_id: string
+  device_label: string nullable
+  platform: string default "ios"
+  app_build: string nullable
+  created_at: datetime
+  last_used_at: datetime nullable
+  idle_expires_at: datetime indexed
+  absolute_expires_at: datetime indexed
+  revoked_at: datetime nullable
+  revoke_reason: string nullable
+```
+
+Only `token_hash` is persisted. The raw refresh token is shown exactly once in the exchange/refresh response.
+
+Migration is additive:
+
+- `Base.metadata.create_all()` creates the table for new installs.
+- Startup migration creates the table for existing SQLite deployments.
+- No destructive schema changes.
+
+## iOS Storage
+
+`SharedAuthStore` stores a native session bundle per host:
+
+- runtime token in Keychain.
+- refresh token in Keychain.
+- runtime expiry in app-group defaults.
+- refresh expiry in app-group defaults.
+
+Keychain accessibility remains `kSecAttrAccessibleAfterFirstUnlock` because widgets/background refresh need shared access after first unlock. This is a product/security tradeoff: the credential survives normal use and app updates, and background surfaces work; explicit logout deletes it.
+
+## iOS Refresh Behavior
+
+Introduce a single refresh authority instead of ad hoc refresh calls:
+
+- On app launch, if runtime token verifies, schedule proactive refresh.
+- If runtime token fails with 401 and refresh token exists, call `/api/auth/refresh-native-session`.
+- If refresh succeeds, save both new tokens and retry once.
+- If refresh returns 401/403, clear auth.
+- If refresh fails due to network, timeout, 5xx, or bad gateway, keep local session candidate and show cached shell.
+- Concurrent requests share one in-flight refresh task per host.
+
+## Compatibility & Rollout
+
+Phase 1 introduces native-session fields while keeping old fields.
+
+Existing app versions:
+
+- Ignore `refresh_token` fields and continue bearer-leeway refresh.
+
+New app versions:
+
+- Prefer native refresh token when available.
+- Fall back to bearer refresh only if no native refresh token exists.
+
+After dogfood proves stability:
+
+- Shorten or remove bearer refresh leeway.
+- Keep `/refresh-runtime-token` briefly for older builds, then delete.
+
+## Decision Log
+
+### Decision: Opaque Refresh Token Instead Of Long-Lived JWT
+
+Context: The current fix makes expired runtime JWTs refreshable for months.
+
+Choice: Use an opaque random refresh token stored hashed in CP.
+
+Rationale: Opaque tokens are easy to revoke per device, rotate, hash, and expire without encoding long-lived bearer authority in a self-contained token.
+
+Revisit if: We implement sender-constrained tokens using device-bound private keys.
+
+### Decision: Tenant Runtime Proxies Refresh
+
+Context: iOS currently talks to the tenant runtime for API traffic.
+
+Choice: Keep refresh/logout behind tenant routes that proxy to CP.
+
+Rationale: The app only needs its tenant base URL after login; CP remains the issuer and tenant remains the resource boundary.
+
+Revisit if: We add a first-class public OAuth/OIDC issuer URL and universal app callback flow.
+
+### Decision: Rotate On Every Refresh
+
+Context: Native clients are public clients and cannot keep a client secret.
+
+Choice: Refresh token rotation is mandatory.
+
+Rationale: Rotation limits replay and gives us reuse detection. It is the simple modern baseline before more complex sender-constrained schemes.
+
+Revisit if: Rotation causes concurrency failures that single-flight cannot solve.
+
+### Decision: Defer On Ambiguous Failure
+
+Context: Backend deploys and temporary network failures should not log users out.
+
+Choice: Only explicit auth rejection clears credentials. Ambiguous failures keep the local shell and cached data.
+
+Rationale: Product trust is destroyed by false logout. A 5xx does not prove the credential is invalid.
+
+Revisit if: We add a server-pushed account-disabled signal.
+
+## Implementation Phases
+
+### Phase 0: Spec And Review
+
+Acceptance criteria:
+
+- Spec is committed.
+- `hatch claude fable` reviews the spec from first principles.
+- Review synthesis is folded back into this document.
+
+### Phase 1: Control-Plane Native Device Sessions
+
+Acceptance criteria:
+
+- `NativeDeviceSession` model exists.
+- Startup creates/migrates `cp_native_device_sessions`.
+- Handoff exchange returns refresh-token fields.
+- `refresh-native-session` rotates token hashes and mints runtime token.
+- `revoke-native-session` revokes matching session idempotently.
+- Tests cover exchange, refresh rotation, tenant mismatch, expiry, revoked token, reuse detection, and logout.
+
+Test command:
+
+```bash
+uv sync --frozen --extra dev
+uv run ruff check .
+uv run pytest tests/test_identity_api.py
+```
+
+### Phase 2: Tenant Runtime Proxy
+
+Acceptance criteria:
+
+- `/api/auth/accept-native-handoff` returns native refresh fields.
+- `/api/auth/refresh-native-session` proxies refresh token to CP with internal token.
+- `/api/auth/revoke-native-session` proxies logout best-effort.
+- Existing `/api/auth/refresh-runtime-token` remains compatible.
+- Tests cover proxy success, CP rejection, CP network failure, and missing token.
+
+Test command:
+
+```bash
+make test
+```
+
+### Phase 3: iOS Native Session Storage And Refresh
+
+Acceptance criteria:
+
+- `SharedAuthStore` persists and clears native refresh token per host.
+- Hosted sign-in stores both runtime and refresh token when present.
+- Proactive refresh and 401 retry prefer native refresh.
+- Refresh is single-flight across concurrent API requests.
+- Explicit 401/403 clears auth; network/5xx preserves local session candidate.
+- Logout calls native revoke before clearing local Keychain state.
+- Legacy bearer refresh fallback works when no refresh token is present.
+
+Test command:
+
+```bash
+make test-ios
+```
+
+### Phase 4: End-To-End Review And Rollout
+
+Acceptance criteria:
+
+- Hatch DeepSeek reviews each implementation phase before the next phase.
+- Full control-plane tests pass.
+- Longhouse relevant tests pass.
+- Branches are pushed.
+- Changes are merged to `main`.
+- Control-plane is deployed and health verified.
+- Public Longhouse workflows are checked for the pushed SHA.
+
+Test command:
+
+```bash
+uv sync --frozen --extra dev
+uv run ruff check .
+uv run pytest tests
+make check-push-readiness
+make test-ios
+```
+
+## Open Risks
+
+- Refresh rotation plus concurrent requests can invalidate a session if the client does not single-flight correctly.
+- Widgets may refresh from a separate process. They need either read-only access to the latest Keychain token or a conservative no-refresh fallback.
+- SQLite migration code must be explicit enough for existing control-plane deployments.
+- Older iOS builds will still use bearer refresh until replaced.

--- a/ios/Sources/LonghouseApp/LonghouseApp.swift
+++ b/ios/Sources/LonghouseApp/LonghouseApp.swift
@@ -144,6 +144,7 @@ final class AppState: ObservableObject {
             SharedAuthStore.primeSharedCookieStorage(for: trimmedServerURL)
             hasCandidate = SharedAuthStore.hasManagedCookies(for: trimmedServerURL)
                 || SharedAuthStore.hasRuntimeToken(for: trimmedServerURL)
+                || SharedAuthStore.hasNativeRefreshToken(for: trimmedServerURL)
         } else {
             hasCandidate = false
         }
@@ -180,7 +181,8 @@ final class AppState: ObservableObject {
         let hasRefresh = cookies.contains(where: { $0.name == SharedAuthStore.refreshCookieName })
         let hasSession = cookies.contains(where: { $0.name == SharedAuthStore.sessionCookieName })
         let hasRuntimeToken = SharedAuthStore.hasRuntimeToken(for: serverURL)
-        hasLocalSessionCandidate = hasRuntimeToken || hasSession || hasRefresh
+        let hasNativeRefreshToken = SharedAuthStore.hasNativeRefreshToken(for: serverURL)
+        hasLocalSessionCandidate = hasRuntimeToken || hasNativeRefreshToken || hasSession || hasRefresh
 
         var result: SessionRestoreResult
         if hasRuntimeToken {
@@ -199,6 +201,15 @@ final class AppState: ObservableObject {
                     result = .indeterminate
                 }
             }
+        } else if hasNativeRefreshToken {
+            switch await refreshRuntimeTokenProactively(requireExistingRuntimeToken: false) {
+            case .refreshed:
+                result = await verifyBrowserSession()
+            case .rejected:
+                result = .unauthenticated
+            case .deferred:
+                result = .indeterminate
+            }
         } else if hasRefresh {
             result = await refreshBrowserSession()
         } else if hasSession {
@@ -212,15 +223,15 @@ final class AppState: ObservableObject {
             isAuthenticated = true
             hasLocalSessionCandidate = true
             authError = nil
-            if hasRuntimeToken {
+            if SharedAuthStore.hasRuntimeToken(for: serverURL) {
                 scheduleRuntimeTokenRefresh()
             }
             Task { [weak self] in
                 await self?.syncStoredAPNSTokenIfPossible()
             }
         case .indeterminate:
-            isAuthenticated = hasRuntimeToken || hasSession || hasRefresh
-            hasLocalSessionCandidate = hasRuntimeToken || hasSession || hasRefresh
+            isAuthenticated = hasRuntimeToken || hasNativeRefreshToken || hasSession || hasRefresh
+            hasLocalSessionCandidate = hasRuntimeToken || hasNativeRefreshToken || hasSession || hasRefresh
         case .unauthenticated:
             await clearLocalSession()
         }
@@ -279,6 +290,7 @@ final class AppState: ObservableObject {
             TranscriptSnapshotStore.shared.clear(serverURL: previousURL)
             PushNotificationStore.clearAPNSDeviceSyncState()
             SharedAuthStore.clearRuntimeToken(for: previousURL)
+            SharedAuthStore.clearNativeRefreshToken(for: previousURL)
             KeychainHelper.deleteAuthToken()
         }
         SharedAuthStore.primeSharedCookieStorage(for: trimmed)
@@ -321,14 +333,26 @@ final class AppState: ObservableObject {
             }
             let expiresIn = json["expires_in"] as? Int
             let expiresAt = expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
-            return await finishHostedRuntimeToken(runtimeToken, expiresAt: expiresAt)
+            let refreshToken = json["refresh_token"] as? String
+            let refreshExpiresAt = LonghouseAPI.parseServerDate(json["refresh_token_expires_at"] as? String)
+            return await finishHostedRuntimeToken(
+                runtimeToken,
+                expiresAt: expiresAt,
+                refreshToken: refreshToken,
+                refreshExpiresAt: refreshExpiresAt
+            )
         } catch {
             authError = "Network error: \(error.localizedDescription)"
             return false
         }
     }
 
-    func finishHostedRuntimeToken(_ runtimeToken: String, expiresAt: Date? = nil) async -> Bool {
+    func finishHostedRuntimeToken(
+        _ runtimeToken: String,
+        expiresAt: Date? = nil,
+        refreshToken: String? = nil,
+        refreshExpiresAt: Date? = nil
+    ) async -> Bool {
         let token = runtimeToken.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !token.isEmpty else {
             authError = "Hosted sign-in returned without a session token"
@@ -341,11 +365,18 @@ final class AppState: ObservableObject {
 
         SharedAuthStore.clearManagedCookies(for: serverURL)
         SharedAuthStore.removeSharedCookieStorage(for: serverURL)
-        SharedAuthStore.saveRuntimeToken(token, expiresAt: expiresAt, for: serverURL)
+        SharedAuthStore.saveHostedTokens(
+            runtimeToken: token,
+            runtimeExpiresAt: expiresAt,
+            refreshToken: refreshToken,
+            refreshExpiresAt: refreshExpiresAt,
+            for: serverURL
+        )
 
         let result = await verifyBrowserSession()
         guard result == .authenticated else {
             SharedAuthStore.clearRuntimeToken(for: serverURL)
+            SharedAuthStore.clearNativeRefreshToken(for: serverURL)
             authError = "Hosted sign-in failed"
             isAuthenticated = false
             hasLocalSessionCandidate = false
@@ -390,6 +421,8 @@ final class AppState: ObservableObject {
         if !previousURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             SharedAuthStore.clearManagedCookies(for: previousURL)
             SharedAuthStore.removeSharedCookieStorage(for: previousURL)
+            SharedAuthStore.clearRuntimeToken(for: previousURL)
+            SharedAuthStore.clearNativeRefreshToken(for: previousURL)
         }
 
         KeychainHelper.deleteAuthToken()
@@ -430,6 +463,7 @@ final class AppState: ObservableObject {
                 TranscriptSnapshotStore.shared.clear(serverURL: previousURL)
                 PushNotificationStore.clearAPNSDeviceSyncState()
                 SharedAuthStore.clearRuntimeToken(for: previousURL)
+                SharedAuthStore.clearNativeRefreshToken(for: previousURL)
                 KeychainHelper.deleteAuthToken()
             }
             SharedAuthStore.primeSharedCookieStorage(for: trimmed)
@@ -585,19 +619,23 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func refreshRuntimeTokenProactively() async -> RuntimeTokenRefreshResult {
+    private func refreshRuntimeTokenProactively(requireExistingRuntimeToken: Bool = true) async -> RuntimeTokenRefreshResult {
         // Snapshot the server URL: signout/server-switch may land during the
         // await and we must not write a refreshed token back into a cleared or
         // switched keychain slot.
         let capturedServerURL = serverURL
+        guard let api = LonghouseAPI(host: capturedServerURL) else {
+            return .rejected
+        }
         do {
-            let (token, expiresAt) = try await callRefreshRuntimeTokenRoute(serverURL: capturedServerURL)
-            guard serverURL == capturedServerURL,
-                  SharedAuthStore.hasRuntimeToken(for: capturedServerURL) else {
+            try await api.refreshRuntimeToken()
+            guard serverURL == capturedServerURL else {
                 // Session was cleared or server switched while we were refreshing.
                 return .deferred
             }
-            SharedAuthStore.saveRuntimeToken(token, expiresAt: expiresAt, for: capturedServerURL)
+            guard !requireExistingRuntimeToken || SharedAuthStore.hasRuntimeToken(for: capturedServerURL) else {
+                return .deferred
+            }
             scheduleRuntimeTokenRefresh()
             return .refreshed
         } catch LonghouseAPIError.notAuthenticated {
@@ -612,48 +650,25 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func callRefreshRuntimeTokenRoute(serverURL: String) async throws -> (String, Date?) {
-        guard let url = URL(string: "\(serverURL)/api/auth/refresh-runtime-token") else {
-            throw URLError(.badURL)
-        }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.timeoutInterval = 10
-        if let authorizationHeader = SharedAuthStore.authorizationHeader(for: serverURL) {
-            request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
-        }
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let http = response as? HTTPURLResponse else {
-            throw URLError(.badServerResponse)
-        }
-        guard http.statusCode == 200 else {
-            switch http.statusCode {
-            case 401, 403:
-                throw LonghouseAPIError.notAuthenticated
-            case 502:
-                throw LonghouseAPIError.upstreamFailed
-            case 503:
-                throw LonghouseAPIError.serviceUnavailable
-            default:
-                throw LonghouseAPIError.requestFailed
-            }
-        }
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let token = json["runtime_token"] as? String else {
-            throw URLError(.cannotDecodeContentData)
-        }
-        let expiresIn = json["expires_in"] as? Int
-        let expiresAt = expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
-        return (token, expiresAt)
-    }
-
     private func signOutLocallyAndRemotely() async {
-        // Fire-and-forget the server logout while cookies are still present.
-        if let url = URL(string: "\(serverURL)/api/auth/logout") {
+        let capturedServerURL = serverURL
+        let nativeRefreshToken = SharedAuthStore.nativeRefreshToken(for: capturedServerURL)
+
+        if let nativeRefreshToken, let url = URL(string: "\(capturedServerURL)/api/auth/revoke-native-session") {
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
             request.timeoutInterval = 5
-            if let authorizationHeader = SharedAuthStore.authorizationHeader(for: serverURL) {
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try? JSONSerialization.data(withJSONObject: ["refresh_token": nativeRefreshToken])
+            _ = try? await URLSession.shared.data(for: request)
+        }
+
+        // Fire-and-forget the server logout while cookies are still present.
+        if let url = URL(string: "\(capturedServerURL)/api/auth/logout") {
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.timeoutInterval = 5
+            if let authorizationHeader = SharedAuthStore.authorizationHeader(for: capturedServerURL) {
                 request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
             }
             _ = try? await URLSession.shared.data(for: request)
@@ -672,6 +687,7 @@ final class AppState: ObservableObject {
         SharedAuthStore.clearManagedCookies(for: serverURL)
         SharedAuthStore.removeSharedCookieStorage(for: serverURL)
         SharedAuthStore.clearRuntimeToken(for: serverURL)
+        SharedAuthStore.clearNativeRefreshToken(for: serverURL)
         WidgetSessionSnapshotStore.clear()
         TimelineCacheStore.clear(serverURL: serverURL)
         TranscriptSnapshotStore.shared.clear(serverURL: serverURL)

--- a/ios/Sources/LonghouseWidget/LonghouseWidget.swift
+++ b/ios/Sources/LonghouseWidget/LonghouseWidget.swift
@@ -294,7 +294,8 @@ struct SessionsWidgetPushHandler: WidgetPushHandler {
         guard widgets.contains(where: { $0.kind == LonghouseWidgetConstants.pushSessionsKind }) else {
             return
         }
-        guard let serverURL = SharedAuthStore.loadServerURL(), let api = LonghouseAPI(host: serverURL) else {
+        guard let serverURL = SharedAuthStore.loadServerURL(),
+              let api = LonghouseAPI(host: serverURL, allowsAuthRefresh: false) else {
             return
         }
 

--- a/ios/Sources/Shared/LonghouseAPI.swift
+++ b/ios/Sources/Shared/LonghouseAPI.swift
@@ -138,18 +138,40 @@ private struct APIPauseRequestResponsePayload: Decodable {
     let pauseRequest: APISessionPauseRequestProjectionResponse
 }
 
+private actor RuntimeTokenRefreshCoordinator {
+    private var inFlight: [String: Task<Void, Error>] = [:]
+
+    func run(key: String, operation: @escaping @Sendable () async throws -> Void) async throws {
+        if let task = inFlight[key] {
+            return try await task.value
+        }
+
+        let task = Task {
+            try await operation()
+        }
+        inFlight[key] = task
+        defer {
+            inFlight[key] = nil
+        }
+        return try await task.value
+    }
+}
+
 struct LonghouseAPI: Sendable {
     private static let logger = Logger(subsystem: "ai.longhouse.ios", category: "SessionOpen")
+    private static let authRefreshCoordinator = RuntimeTokenRefreshCoordinator()
 
     let baseURL: URL
+    let allowsAuthRefresh: Bool
 
-    init(baseURL: URL) {
+    init(baseURL: URL, allowsAuthRefresh: Bool = true) {
         self.baseURL = baseURL
+        self.allowsAuthRefresh = allowsAuthRefresh
     }
 
-    init?(host: String) {
+    init?(host: String, allowsAuthRefresh: Bool = true) {
         guard let url = URL(string: host) else { return nil }
-        self.init(baseURL: url)
+        self.init(baseURL: url, allowsAuthRefresh: allowsAuthRefresh)
     }
 
     func sessionsNeedingAttention() async throws -> [SessionSummary] {
@@ -653,17 +675,37 @@ struct LonghouseAPI: Sendable {
         }
     }
 
-    /// Refresh a hosted CP runtime bearer token via the longhouse proxy. The
-    /// current bearer is forwarded to the CP, which re-mints within its refresh
-    /// leeway window. The new token + expiry are persisted to ``SharedAuthStore``
-    /// so the next request picks them up automatically.
+    /// Refresh a hosted CP runtime bearer token via the Longhouse proxy.
+    ///
+    /// Native refresh tokens are preferred. The legacy bearer-refresh endpoint
+    /// remains as a migration path and can upgrade old installs by returning
+    /// native refresh fields. Persist refresh before access so a process crash
+    /// after response receipt does not strand the session on a consumed token.
     func refreshRuntimeToken() async throws {
+        try await Self.authRefreshCoordinator.run(key: baseURL.absoluteString) {
+            try await self.performRefreshRuntimeToken()
+        }
+    }
+
+    private func performRefreshRuntimeToken() async throws {
         var request = URLRequest(url: baseURL.appendingPathComponent("/api/auth/refresh-runtime-token"))
+        var requestBody: [String: Any]?
+        if let refreshToken = SharedAuthStore.nativeRefreshToken(for: baseURL.absoluteString) {
+            request = URLRequest(url: baseURL.appendingPathComponent("/api/auth/refresh-native-session"))
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            requestBody = ["refresh_token": refreshToken]
+        }
         request.httpMethod = "POST"
         request.timeoutInterval = 15
+        if let requestBody {
+            request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+        }
 
         let (data, httpResponse) = try await data(for: request, allowRetry: false)
         guard httpResponse.statusCode == 200 else {
+            if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+                throw LonghouseAPIError.notAuthenticated
+            }
             throw LonghouseAPIError.from(statusCode: httpResponse.statusCode)
         }
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -672,7 +714,15 @@ struct LonghouseAPI: Sendable {
         }
         let expiresIn = json["expires_in"] as? Int
         let expiresAt = expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
-        SharedAuthStore.saveRuntimeToken(token, expiresAt: expiresAt, for: baseURL.absoluteString)
+        let refreshToken = json["refresh_token"] as? String
+        let refreshExpiresAt = Self.parseServerDate(json["refresh_token_expires_at"] as? String)
+        SharedAuthStore.saveHostedTokens(
+            runtimeToken: token,
+            runtimeExpiresAt: expiresAt,
+            refreshToken: refreshToken,
+            refreshExpiresAt: refreshExpiresAt,
+            for: baseURL.absoluteString
+        )
     }
 
     private func data(for request: URLRequest, allowRetry: Bool = true) async throws -> (Data, HTTPURLResponse) {
@@ -693,7 +743,7 @@ struct LonghouseAPI: Sendable {
         }
         persistResponseCookies(from: httpResponse, requestURL: request.url)
 
-        if httpResponse.statusCode == 401 && allowRetry {
+        if httpResponse.statusCode == 401 && allowRetry && allowsAuthRefresh {
             do {
                 if authorizationHeader != nil {
                     try await refreshRuntimeToken()
@@ -711,6 +761,17 @@ struct LonghouseAPI: Sendable {
             }
         }
         return (data, httpResponse)
+    }
+
+    static func parseServerDate(_ rawValue: String?) -> Date? {
+        guard let rawValue, !rawValue.isEmpty else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: rawValue) {
+            return date
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: rawValue)
     }
 
     private func persistResponseCookies(from response: HTTPURLResponse, requestURL: URL?) {

--- a/ios/Sources/Shared/LonghouseAPI.swift
+++ b/ios/Sources/Shared/LonghouseAPI.swift
@@ -163,15 +163,17 @@ struct LonghouseAPI: Sendable {
 
     let baseURL: URL
     let allowsAuthRefresh: Bool
+    let urlSession: URLSession
 
-    init(baseURL: URL, allowsAuthRefresh: Bool = true) {
+    init(baseURL: URL, allowsAuthRefresh: Bool = true, urlSession: URLSession = .shared) {
         self.baseURL = baseURL
         self.allowsAuthRefresh = allowsAuthRefresh
+        self.urlSession = urlSession
     }
 
-    init?(host: String, allowsAuthRefresh: Bool = true) {
+    init?(host: String, allowsAuthRefresh: Bool = true, urlSession: URLSession = .shared) {
         guard let url = URL(string: host) else { return nil }
-        self.init(baseURL: url, allowsAuthRefresh: allowsAuthRefresh)
+        self.init(baseURL: url, allowsAuthRefresh: allowsAuthRefresh, urlSession: urlSession)
     }
 
     func sessionsNeedingAttention() async throws -> [SessionSummary] {
@@ -714,7 +716,14 @@ struct LonghouseAPI: Sendable {
         }
         let expiresIn = json["expires_in"] as? Int
         let expiresAt = expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
-        let refreshToken = json["refresh_token"] as? String
+        let refreshToken = (json["refresh_token"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if requestBody != nil && (refreshToken == nil || refreshToken?.isEmpty == true) {
+            // Native refresh rotates the refresh token every time. If a buggy or
+            // mid-deploy CP response omits the replacement, never keep the now-
+            // stale token; presenting it later can look like token reuse.
+            SharedAuthStore.clearNativeRefreshToken(for: baseURL.absoluteString)
+        }
         let refreshExpiresAt = Self.parseServerDate(json["refresh_token_expires_at"] as? String)
         SharedAuthStore.saveHostedTokens(
             runtimeToken: token,
@@ -737,7 +746,7 @@ struct LonghouseAPI: Sendable {
             request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await urlSession.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw LonghouseAPIError.requestFailed
         }

--- a/ios/Sources/Shared/SharedAuthStore.swift
+++ b/ios/Sources/Shared/SharedAuthStore.swift
@@ -7,9 +7,15 @@ struct SharedAuthDebugState: Sendable {
     let serverURL: String?
     let host: String?
     let cookieNames: [String]
+    let hasRuntimeToken: Bool
+    let hasNativeRefreshToken: Bool
 
     var cookieCount: Int {
         cookieNames.count
+    }
+
+    var hasCredentials: Bool {
+        cookieCount > 0 || hasRuntimeToken || hasNativeRefreshToken
     }
 }
 
@@ -23,6 +29,8 @@ enum SharedAuthStore {
     private static let cookieStoragePrefix = "managed_cookies."
     private static let runtimeTokenStoragePrefix = "runtime_tokens."
     private static let runtimeTokenExpiryPrefix = "runtime_token_expires_at."
+    private static let nativeRefreshTokenStoragePrefix = "native_refresh_tokens."
+    private static let nativeRefreshTokenExpiryPrefix = "native_refresh_token_expires_at."
     private static let keychainService = "ai.longhouse.shared-cookies"
 
     private static var defaults: UserDefaults? {
@@ -100,6 +108,19 @@ enum SharedAuthStore {
         saveRuntimeTokenExpiry(expiresAt, for: serverURL)
     }
 
+    static func saveHostedTokens(
+        runtimeToken: String,
+        runtimeExpiresAt: Date?,
+        refreshToken: String?,
+        refreshExpiresAt: Date?,
+        for serverURL: String
+    ) {
+        if let refreshToken {
+            saveNativeRefreshToken(refreshToken, expiresAt: refreshExpiresAt, for: serverURL)
+        }
+        saveRuntimeToken(runtimeToken, expiresAt: runtimeExpiresAt, for: serverURL)
+    }
+
     static func runtimeToken(for serverURL: String) -> String? {
         guard let data = loadKeychainData(account: runtimeTokenStorageKey(for: serverURL)),
               let token = String(data: data, encoding: .utf8)?
@@ -141,6 +162,58 @@ enum SharedAuthStore {
         deleteKeychainData(account: runtimeTokenStorageKey(for: serverURL))
         KeychainHelper.deleteAuthToken()
         saveRuntimeTokenExpiry(nil, for: serverURL)
+    }
+
+    static func saveNativeRefreshToken(_ token: String, expiresAt: Date? = nil, for serverURL: String) {
+        let value = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else {
+            clearNativeRefreshToken(for: serverURL)
+            return
+        }
+        guard let data = value.data(using: .utf8) else {
+            return
+        }
+        saveKeychainData(
+            data,
+            account: nativeRefreshTokenStorageKey(for: serverURL),
+            accessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        )
+        saveNativeRefreshTokenExpiry(expiresAt, for: serverURL)
+    }
+
+    static func nativeRefreshToken(for serverURL: String) -> String? {
+        guard let data = loadKeychainData(account: nativeRefreshTokenStorageKey(for: serverURL)),
+              let token = String(data: data, encoding: .utf8)?
+                  .trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty else {
+            return nil
+        }
+        return token
+    }
+
+    static func hasNativeRefreshToken(for serverURL: String) -> Bool {
+        nativeRefreshToken(for: serverURL) != nil
+    }
+
+    static func nativeRefreshTokenExpiresAt(for serverURL: String) -> Date? {
+        let key = nativeRefreshTokenExpiryKey(for: serverURL)
+        let ts = defaults?.double(forKey: key) ?? 0
+        guard ts > 0 else { return nil }
+        return Date(timeIntervalSince1970: ts)
+    }
+
+    static func saveNativeRefreshTokenExpiry(_ expiresAt: Date?, for serverURL: String) {
+        let key = nativeRefreshTokenExpiryKey(for: serverURL)
+        if let expiresAt {
+            defaults?.set(expiresAt.timeIntervalSince1970, forKey: key)
+        } else {
+            defaults?.removeObject(forKey: key)
+        }
+    }
+
+    static func clearNativeRefreshToken(for serverURL: String) {
+        deleteKeychainData(account: nativeRefreshTokenStorageKey(for: serverURL))
+        saveNativeRefreshTokenExpiry(nil, for: serverURL)
     }
 
     static func setManagedCookies(_ cookies: [HTTPCookie], for serverURL: String) {
@@ -224,7 +297,9 @@ enum SharedAuthStore {
             containerPath: containerURL?.path,
             serverURL: resolvedServerURL,
             host: resolvedServerURL.flatMap(normalizedHost(for:)),
-            cookieNames: cookies.map(\.name).sorted()
+            cookieNames: cookies.map(\.name).sorted(),
+            hasRuntimeToken: resolvedServerURL.map(hasRuntimeToken(for:)) ?? false,
+            hasNativeRefreshToken: resolvedServerURL.map(hasNativeRefreshToken(for:)) ?? false
         )
     }
 
@@ -242,6 +317,14 @@ enum SharedAuthStore {
 
     private static func runtimeTokenExpiryKey(for serverURL: String) -> String {
         runtimeTokenExpiryPrefix + (normalizedHost(for: serverURL) ?? serverURL)
+    }
+
+    private static func nativeRefreshTokenStorageKey(for serverURL: String) -> String {
+        nativeRefreshTokenStoragePrefix + (normalizedHost(for: serverURL) ?? serverURL)
+    }
+
+    private static func nativeRefreshTokenExpiryKey(for serverURL: String) -> String {
+        nativeRefreshTokenExpiryPrefix + (normalizedHost(for: serverURL) ?? serverURL)
     }
 
     private static func cookieDictionary(from cookie: HTTPCookie) -> [String: Any]? {
@@ -286,12 +369,16 @@ enum SharedAuthStore {
         ]
     }
 
-    private static func saveKeychainData(_ data: Data, account: String) {
+    private static func saveKeychainData(
+        _ data: Data,
+        account: String,
+        accessible: CFString = kSecAttrAccessibleAfterFirstUnlock
+    ) {
         let query = keychainQuery(account: account)
         SecItemDelete(query as CFDictionary)
         var addQuery = query
         addQuery[kSecValueData as String] = data
-        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        addQuery[kSecAttrAccessible as String] = accessible
         SecItemAdd(addQuery as CFDictionary, nil)
     }
 

--- a/ios/Sources/Shared/WidgetSessionLoader.swift
+++ b/ios/Sources/Shared/WidgetSessionLoader.swift
@@ -109,16 +109,16 @@ enum WidgetSessionLoader {
         }
 
         let debugState = SharedAuthStore.debugState(for: serverURL)
-        guard debugState.cookieCount > 0 else {
-            logger.error("Widget auth unavailable: no shared cookies for \(serverURL, privacy: .public)")
+        guard debugState.hasCredentials else {
+            logger.error("Widget auth unavailable: no shared credentials for \(serverURL, privacy: .public)")
             return .unavailable(
                 title: "No shared session",
-                message: "Open Longhouse to refresh widget auth.",
+                message: "Open Longhouse to sign in.",
                 debugState: debugState
             )
         }
 
-        guard let api = LonghouseAPI(host: serverURL) else {
+        guard let api = LonghouseAPI(host: serverURL, allowsAuthRefresh: false) else {
             logger.error("Widget auth unavailable: invalid server URL \(serverURL, privacy: .public)")
             return .unavailable(
                 title: "Invalid server URL",
@@ -133,25 +133,8 @@ enum WidgetSessionLoader {
             logger.log("Widget loaded \(sessions.count, privacy: .public) sessions")
             return .loaded(sessions: sessions, debugState: SharedAuthStore.debugState(for: serverURL))
         } catch LonghouseAPIError.notAuthenticated {
-            logger.log("Widget session expired, attempting refresh")
-            do {
-                try await api.refreshSession()
-                let sessions = try await api.recentActiveSessions(limit: 8)
-                WidgetSessionSnapshotStore.save(sessions: sessions)
-                logger.log("Widget refresh succeeded with \(sessions.count, privacy: .public) sessions")
-                return .loaded(sessions: sessions, debugState: SharedAuthStore.debugState(for: serverURL))
-            } catch LonghouseAPIError.notAuthenticated {
-                SharedAuthStore.clearManagedCookies(for: serverURL)
-                logger.error("Widget refresh failed: unauthenticated")
-                return .unavailable(
-                    title: "Session expired",
-                    message: "Open Longhouse to sign in again.",
-                    debugState: SharedAuthStore.debugState(for: serverURL)
-                )
-            } catch {
-                logger.error("Widget refresh failed: \(error.localizedDescription, privacy: .public)")
-                return cachedResult(debugState: SharedAuthStore.debugState(for: serverURL))
-            }
+            logger.log("Widget session unavailable: app refresh required")
+            return cachedResult(debugState: SharedAuthStore.debugState(for: serverURL))
         } catch {
             logger.error("Widget fetch failed: \(error.localizedDescription, privacy: .public)")
             return cachedResult(debugState: SharedAuthStore.debugState(for: serverURL))
@@ -169,7 +152,7 @@ enum WidgetSessionLoader {
         let serverURL = result.debugState.serverURL ?? "nil"
         let title = result.statusTitle ?? "nil"
         let message = result.statusMessage ?? "nil"
-        let summary = "\(source): appGroup=\(result.debugState.appGroupAvailable) server=\(serverURL) cookies=\(result.debugState.cookieCount) signedIn=\(result.isSignedIn) title=\(title) message=\(message)"
+        let summary = "\(source): appGroup=\(result.debugState.appGroupAvailable) server=\(serverURL) cookies=\(result.debugState.cookieCount) runtime=\(result.debugState.hasRuntimeToken) nativeRefresh=\(result.debugState.hasNativeRefreshToken) signedIn=\(result.isSignedIn) title=\(title) message=\(message)"
         logger.log("\(summary, privacy: .public)")
     }
 }

--- a/ios/Tests/LonghouseIOSTests/HostedAuthRefreshTests.swift
+++ b/ios/Tests/LonghouseIOSTests/HostedAuthRefreshTests.swift
@@ -1,0 +1,252 @@
+import Foundation
+import Testing
+@testable import Longhouse
+
+@Suite(.serialized)
+struct HostedAuthRefreshTests {
+    @Test
+    func nativeRefreshUsesRefreshEndpointAndRotatesStoredTokens() async throws {
+        guard SharedAuthStore.isAppGroupAvailable else {
+            return
+        }
+        let serverURL = "https://native-refresh-api-test.longhouse.ai"
+        clearTokens(serverURL)
+        SharedAuthStore.saveNativeRefreshToken("old-refresh", for: serverURL)
+        let recorder = RequestRecorder()
+        let api = makeAPI(serverURL: serverURL) { request in
+            recorder.record(request)
+            return jsonResponse(for: request, statusCode: 200, body: [
+                "runtime_token": "runtime-new",
+                "expires_in": 120,
+                "refresh_token": "refresh-new",
+                "refresh_token_expires_at": "2026-07-08T12:34:56Z",
+                "device_session_id": "device-1",
+            ])
+        }
+
+        try await api.refreshRuntimeToken()
+
+        let requests = recorder.requests()
+        #expect(requests.count == 1)
+        #expect(requests.first?.url?.path == "/api/auth/refresh-native-session")
+        #expect(requests.first?.value(forHTTPHeaderField: "Authorization") == nil)
+        #expect(SharedAuthStore.runtimeToken(for: serverURL) == "runtime-new")
+        #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == "refresh-new")
+        #expect(SharedAuthStore.nativeRefreshTokenExpiresAt(for: serverURL) != nil)
+        clearTokens(serverURL)
+    }
+
+    @Test
+    func legacyBearerRefreshUpgradesStoredNativeRefreshToken() async throws {
+        guard SharedAuthStore.isAppGroupAvailable else {
+            return
+        }
+        let serverURL = "https://legacy-refresh-api-test.longhouse.ai"
+        clearTokens(serverURL)
+        SharedAuthStore.saveRuntimeToken("runtime-old", for: serverURL)
+        let recorder = RequestRecorder()
+        let api = makeAPI(serverURL: serverURL) { request in
+            recorder.record(request)
+            return jsonResponse(for: request, statusCode: 200, body: [
+                "runtime_token": "runtime-new",
+                "expires_in": 120,
+                "refresh_token": "refresh-upgrade",
+                "refresh_token_expires_at": "2026-07-08T12:34:56Z",
+            ])
+        }
+
+        try await api.refreshRuntimeToken()
+
+        let requests = recorder.requests()
+        #expect(requests.count == 1)
+        #expect(requests.first?.url?.path == "/api/auth/refresh-runtime-token")
+        #expect(requests.first?.value(forHTTPHeaderField: "Authorization") == "Bearer runtime-old")
+        #expect(SharedAuthStore.runtimeToken(for: serverURL) == "runtime-new")
+        #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == "refresh-upgrade")
+        clearTokens(serverURL)
+    }
+
+    @Test
+    func nativeRefreshResponseWithoutReplacementClearsStaleRefreshToken() async throws {
+        guard SharedAuthStore.isAppGroupAvailable else {
+            return
+        }
+        let serverURL = "https://missing-refresh-api-test.longhouse.ai"
+        clearTokens(serverURL)
+        SharedAuthStore.saveNativeRefreshToken("old-refresh", for: serverURL)
+        let api = makeAPI(serverURL: serverURL) { request in
+            jsonResponse(for: request, statusCode: 200, body: [
+                "runtime_token": "runtime-new",
+                "expires_in": 120,
+            ])
+        }
+
+        try await api.refreshRuntimeToken()
+
+        #expect(SharedAuthStore.runtimeToken(for: serverURL) == "runtime-new")
+        #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == nil)
+        clearTokens(serverURL)
+    }
+
+    @Test
+    func nativeRefreshUnauthorizedThrowsNotAuthenticated() async throws {
+        guard SharedAuthStore.isAppGroupAvailable else {
+            return
+        }
+        let serverURL = "https://rejected-refresh-api-test.longhouse.ai"
+        clearTokens(serverURL)
+        SharedAuthStore.saveNativeRefreshToken("bad-refresh", for: serverURL)
+        let api = makeAPI(serverURL: serverURL) { request in
+            jsonResponse(for: request, statusCode: 401, body: ["detail": "rejected"])
+        }
+
+        do {
+            try await api.refreshRuntimeToken()
+            Issue.record("expected notAuthenticated")
+        } catch LonghouseAPIError.notAuthenticated {
+            #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == "bad-refresh")
+        } catch {
+            Issue.record("expected notAuthenticated, got \(error)")
+        }
+        clearTokens(serverURL)
+    }
+
+    @Test
+    func concurrentRefreshesShareOneNativeRotation() async throws {
+        guard SharedAuthStore.isAppGroupAvailable else {
+            return
+        }
+        let serverURL = "https://single-flight-refresh-api-test.longhouse.ai"
+        clearTokens(serverURL)
+        SharedAuthStore.saveNativeRefreshToken("old-refresh", for: serverURL)
+        let recorder = RequestRecorder()
+        let api = makeAPI(serverURL: serverURL) { request in
+            recorder.record(request)
+            Thread.sleep(forTimeInterval: 0.15)
+            return jsonResponse(for: request, statusCode: 200, body: [
+                "runtime_token": "runtime-new",
+                "expires_in": 120,
+                "refresh_token": "refresh-new",
+                "refresh_token_expires_at": "2026-07-08T12:34:56Z",
+            ])
+        }
+
+        async let first: Void = api.refreshRuntimeToken()
+        async let second: Void = api.refreshRuntimeToken()
+        _ = try await (first, second)
+
+        #expect(recorder.requests().count == 1)
+        #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == "refresh-new")
+        clearTokens(serverURL)
+    }
+
+    @Test
+    func clientWithAuthRefreshDisabledDoesNotRefreshOnUnauthorizedResponse() async throws {
+        guard SharedAuthStore.isAppGroupAvailable else {
+            return
+        }
+        let serverURL = "https://widget-readonly-auth-test.longhouse.ai"
+        clearTokens(serverURL)
+        SharedAuthStore.saveNativeRefreshToken("refresh-token", for: serverURL)
+        SharedAuthStore.saveRuntimeToken("runtime-old", for: serverURL)
+        let recorder = RequestRecorder()
+        let api = makeAPI(serverURL: serverURL, allowsAuthRefresh: false) { request in
+            recorder.record(request)
+            return jsonResponse(for: request, statusCode: 401, body: ["detail": "expired"])
+        }
+
+        do {
+            _ = try await api.recentSessions(limit: 1)
+            Issue.record("expected notAuthenticated")
+        } catch LonghouseAPIError.notAuthenticated {
+            #expect(recorder.requests().count == 1)
+            #expect(recorder.requests().first?.url?.path == "/api/timeline/sessions")
+            #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == "refresh-token")
+        } catch {
+            Issue.record("expected notAuthenticated, got \(error)")
+        }
+        clearTokens(serverURL)
+    }
+
+    private func makeAPI(
+        serverURL: String,
+        allowsAuthRefresh: Bool = true,
+        handler: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+    ) -> LonghouseAPI {
+        NativeAuthMockURLProtocol.handler = handler
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [NativeAuthMockURLProtocol.self]
+        return LonghouseAPI(
+            baseURL: URL(string: serverURL)!,
+            allowsAuthRefresh: allowsAuthRefresh,
+            urlSession: URLSession(configuration: configuration)
+        )
+    }
+
+    private func clearTokens(_ serverURL: String) {
+        SharedAuthStore.clearRuntimeToken(for: serverURL)
+        SharedAuthStore.clearNativeRefreshToken(for: serverURL)
+        SharedAuthStore.clearManagedCookies(for: serverURL)
+    }
+}
+
+private final class RequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedRequests: [URLRequest] = []
+
+    func record(_ request: URLRequest) {
+        lock.lock()
+        storedRequests.append(request)
+        lock.unlock()
+    }
+
+    func requests() -> [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedRequests
+    }
+}
+
+private final class NativeAuthMockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func jsonResponse(
+    for request: URLRequest,
+    statusCode: Int,
+    body: [String: Any]
+) -> (HTTPURLResponse, Data) {
+    let data = try! JSONSerialization.data(withJSONObject: body)
+    let response = HTTPURLResponse(
+        url: request.url!,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+    )!
+    return (response, data)
+}

--- a/ios/Tests/LonghouseIOSTests/LonghouseAPITests.swift
+++ b/ios/Tests/LonghouseIOSTests/LonghouseAPITests.swift
@@ -308,6 +308,17 @@ struct LonghouseAPITests {
     }
 
     @Test
+    func serverDateParserAcceptsFractionalAndPlainISO8601() throws {
+        let fractional = try #require(LonghouseAPI.parseServerDate("2026-07-08T12:34:56.789Z"))
+        let plain = try #require(LonghouseAPI.parseServerDate("2026-07-08T12:34:56Z"))
+
+        #expect(abs(fractional.timeIntervalSince1970 - 1_783_514_096.789) < 0.001)
+        #expect(abs(plain.timeIntervalSince1970 - 1_783_514_096.0) < 0.001)
+        #expect(LonghouseAPI.parseServerDate(nil) == nil)
+        #expect(LonghouseAPI.parseServerDate("") == nil)
+    }
+
+    @Test
     func workspaceSuggestionsResponseDecodesSnakeCase() throws {
         let json = """
         {

--- a/ios/Tests/LonghouseIOSTests/SharedAuthStoreTests.swift
+++ b/ios/Tests/LonghouseIOSTests/SharedAuthStoreTests.swift
@@ -37,4 +37,63 @@ struct SharedAuthStoreTests {
         #expect(SharedAuthStore.hasRuntimeToken(for: serverURL))
         SharedAuthStore.clearRuntimeToken(for: serverURL)
     }
+
+    @Test
+    func nativeRefreshTokenRoundTripsWithExpiry() throws {
+        guard SharedAuthStore.isAppGroupAvailable else {
+            return
+        }
+        let serverURL = "https://native-refresh-test.longhouse.ai"
+        let expiresAt = Date(timeIntervalSince1970: 1_810_000_000)
+
+        SharedAuthStore.clearNativeRefreshToken(for: serverURL)
+        #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == nil)
+        #expect(SharedAuthStore.nativeRefreshTokenExpiresAt(for: serverURL) == nil)
+
+        SharedAuthStore.saveNativeRefreshToken(" refresh-token ", expiresAt: expiresAt, for: serverURL)
+
+        #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == "refresh-token")
+        #expect(SharedAuthStore.hasNativeRefreshToken(for: serverURL))
+        let roundTripped = SharedAuthStore.nativeRefreshTokenExpiresAt(for: serverURL)
+        #expect(roundTripped != nil)
+        if let roundTripped {
+            #expect(abs(roundTripped.timeIntervalSince1970 - expiresAt.timeIntervalSince1970) < 1.0)
+        }
+
+        SharedAuthStore.clearNativeRefreshToken(for: serverURL)
+        #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == nil)
+        #expect(SharedAuthStore.nativeRefreshTokenExpiresAt(for: serverURL) == nil)
+    }
+
+    @Test
+    func saveHostedTokensPersistsRefreshBeforeRuntimeAndDebugStateSeesBoth() throws {
+        guard SharedAuthStore.isAppGroupAvailable else {
+            return
+        }
+        let serverURL = "https://hosted-token-test.longhouse.ai"
+        let runtimeExpiresAt = Date(timeIntervalSince1970: 1_820_000_000)
+        let refreshExpiresAt = Date(timeIntervalSince1970: 1_830_000_000)
+
+        SharedAuthStore.clearRuntimeToken(for: serverURL)
+        SharedAuthStore.clearNativeRefreshToken(for: serverURL)
+        SharedAuthStore.clearManagedCookies(for: serverURL)
+
+        SharedAuthStore.saveHostedTokens(
+            runtimeToken: "runtime-token",
+            runtimeExpiresAt: runtimeExpiresAt,
+            refreshToken: "refresh-token",
+            refreshExpiresAt: refreshExpiresAt,
+            for: serverURL
+        )
+
+        #expect(SharedAuthStore.runtimeToken(for: serverURL) == "runtime-token")
+        #expect(SharedAuthStore.nativeRefreshToken(for: serverURL) == "refresh-token")
+        let state = SharedAuthStore.debugState(for: serverURL)
+        #expect(state.hasRuntimeToken)
+        #expect(state.hasNativeRefreshToken)
+        #expect(state.hasCredentials)
+
+        SharedAuthStore.clearRuntimeToken(for: serverURL)
+        SharedAuthStore.clearNativeRefreshToken(for: serverURL)
+    }
 }

--- a/server/tests_lite/test_hosted_identity_auth.py
+++ b/server/tests_lite/test_hosted_identity_auth.py
@@ -543,3 +543,47 @@ async def test_revoke_native_session_proxies_to_cp(monkeypatch):
     assert captured["headers"] == {"X-Internal-Token": "secret"}
     assert captured["json"] == {"refresh_token": "lhr_current"}
     assert captured["timeout"] == 5.0
+
+
+@pytest.mark.asyncio
+async def test_revoke_native_session_ignores_empty_token(monkeypatch):
+    monkeypatch.setattr(
+        "zerg.routers.auth_sso.get_settings",
+        lambda: SimpleNamespace(control_plane_url="https://control.longhouse.ai", internal_api_secret="secret"),
+    )
+
+    result = await revoke_native_session(NativeRevokeRequest(refresh_token=" "))
+
+    assert result == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_revoke_native_session_treats_cp_rejection_as_idempotent(monkeypatch):
+    class FakeResponse:
+        status_code = 500
+
+    monkeypatch.setattr(
+        "zerg.routers.auth_sso.get_settings",
+        lambda: SimpleNamespace(control_plane_url="https://control.longhouse.ai", internal_api_secret="secret"),
+    )
+    monkeypatch.setattr("zerg.routers.auth_sso.httpx.post", lambda *a, **k: FakeResponse())
+
+    result = await revoke_native_session(NativeRevokeRequest(refresh_token="lhr_current"))
+
+    assert result == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_revoke_native_session_treats_cp_network_error_as_idempotent(monkeypatch):
+    def fake_post(*a, **k):
+        raise httpx.HTTPError("connection refused")
+
+    monkeypatch.setattr(
+        "zerg.routers.auth_sso.get_settings",
+        lambda: SimpleNamespace(control_plane_url="https://control.longhouse.ai", internal_api_secret="secret"),
+    )
+    monkeypatch.setattr("zerg.routers.auth_sso.httpx.post", fake_post)
+
+    result = await revoke_native_session(NativeRevokeRequest(refresh_token="lhr_current"))
+
+    assert result == {"status": "ok"}

--- a/server/tests_lite/test_hosted_identity_auth.py
+++ b/server/tests_lite/test_hosted_identity_auth.py
@@ -28,9 +28,13 @@ from zerg.dependencies.browser_auth import get_current_browser_user
 from zerg.dependencies.browser_route_auth import get_current_browser_route_user
 from zerg.models.models import User
 from zerg.routers.auth_sso import NativeHandoffRequest
+from zerg.routers.auth_sso import NativeRefreshRequest
+from zerg.routers.auth_sso import NativeRevokeRequest
 from zerg.routers.auth_sso import accept_handoff_request
 from zerg.routers.auth_sso import accept_native_handoff
+from zerg.routers.auth_sso import refresh_native_session
 from zerg.routers.auth_sso import refresh_runtime_token
+from zerg.routers.auth_sso import revoke_native_session
 
 
 @pytest.fixture()
@@ -180,7 +184,7 @@ async def test_accept_handoff_allows_code_only_control_plane_open_instance(monke
 
     def exchange(**kwargs):
         calls.update(kwargs)
-        return ("cp.runtime.jwt", 3600)
+        return {"runtime_token": "cp.runtime.jwt", "expires_in": 3600}
 
     class Strategy:
         def validate_ws_token(self, token, db):
@@ -257,7 +261,13 @@ async def test_accept_native_handoff_exchanges_one_use_code(monkeypatch, db_sess
 
     def exchange(**kwargs):
         calls.update(kwargs)
-        return ("cp.runtime.jwt", 3600)
+        return {
+            "runtime_token": "cp.runtime.jwt",
+            "expires_in": 3600,
+            "refresh_token": "lhr_refresh",
+            "refresh_token_expires_at": "2027-01-01T00:00:00+00:00",
+            "device_session_id": "nds_session",
+        }
 
     class Strategy:
         def validate_ws_token(self, token, db):
@@ -274,7 +284,13 @@ async def test_accept_native_handoff_exchanges_one_use_code(monkeypatch, db_sess
 
     result = await accept_native_handoff(NativeHandoffRequest(code="one-use-code", tenant_state="verifier"), db_session)
 
-    assert result == {"runtime_token": "cp.runtime.jwt", "expires_in": 3600}
+    assert result == {
+        "runtime_token": "cp.runtime.jwt",
+        "expires_in": 3600,
+        "refresh_token": "lhr_refresh",
+        "refresh_token_expires_at": "2027-01-01T00:00:00+00:00",
+        "device_session_id": "nds_session",
+    }
     assert calls == {
         "control_plane_url": "https://control.longhouse.ai",
         "internal_api_secret": "secret",
@@ -306,7 +322,13 @@ async def test_refresh_runtime_token_proxies_bearer_to_cp(monkeypatch):
     class FakeResponse:
         status_code = 200
         def json(self):
-            return {"runtime_token": "cp.fresh.jwt", "expires_in": 3600}
+            return {
+                "runtime_token": "cp.fresh.jwt",
+                "expires_in": 3600,
+                "refresh_token": "lhr_refresh",
+                "refresh_token_expires_at": "2027-01-01T00:00:00+00:00",
+                "device_session_id": "nds_session",
+            }
 
     def fake_post(url, headers, timeout):
         captured["url"] = url
@@ -322,7 +344,13 @@ async def test_refresh_runtime_token_proxies_bearer_to_cp(monkeypatch):
 
     result = await refresh_runtime_token(_refresh_request(auth_header="Bearer cp.current.jwt"))
 
-    assert result == {"runtime_token": "cp.fresh.jwt", "expires_in": 3600}
+    assert result == {
+        "runtime_token": "cp.fresh.jwt",
+        "expires_in": 3600,
+        "refresh_token": "lhr_refresh",
+        "refresh_token_expires_at": "2027-01-01T00:00:00+00:00",
+        "device_session_id": "nds_session",
+    }
     assert captured["url"] == "https://control.longhouse.ai/api/identity/refresh-runtime-token"
     assert captured["headers"] == {"Authorization": "Bearer cp.current.jwt"}
     assert captured["timeout"] == 10.0
@@ -395,3 +423,123 @@ async def test_refresh_runtime_token_returns_502_on_cp_network_error(monkeypatch
     with pytest.raises(HTTPException) as exc:
         await refresh_runtime_token(_refresh_request(auth_header="Bearer cp.jwt"))
     assert exc.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_refresh_native_session_proxies_refresh_token_to_cp(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        def json(self):
+            return {
+                "runtime_token": "cp.fresh.jwt",
+                "expires_in": 3600,
+                "refresh_token": "lhr_next",
+                "refresh_token_expires_at": "2027-01-01T00:00:00+00:00",
+                "device_session_id": "nds_session",
+            }
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "zerg.routers.auth_sso.get_settings",
+        lambda: SimpleNamespace(control_plane_url="https://control.longhouse.ai", internal_api_secret="secret"),
+    )
+    monkeypatch.setattr("zerg.routers.auth_sso.hosted_instance_id", lambda: "david010")
+    monkeypatch.setattr("zerg.routers.auth_sso.httpx.post", fake_post)
+
+    result = await refresh_native_session(NativeRefreshRequest(refresh_token="lhr_current"))
+
+    assert result == {
+        "runtime_token": "cp.fresh.jwt",
+        "expires_in": 3600,
+        "refresh_token": "lhr_next",
+        "refresh_token_expires_at": "2027-01-01T00:00:00+00:00",
+        "device_session_id": "nds_session",
+    }
+    assert captured["url"] == "https://control.longhouse.ai/api/identity/refresh-native-session"
+    assert captured["headers"] == {"X-Internal-Token": "secret"}
+    assert captured["json"] == {"refresh_token": "lhr_current", "tenant": "david010"}
+    assert captured["timeout"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_refresh_native_session_propagates_cp_rejection(monkeypatch):
+    class FakeResponse:
+        status_code = 401
+        def json(self):
+            return {"detail": "revoked"}
+
+    monkeypatch.setattr(
+        "zerg.routers.auth_sso.get_settings",
+        lambda: SimpleNamespace(control_plane_url="https://control.longhouse.ai", internal_api_secret="secret"),
+    )
+    monkeypatch.setattr("zerg.routers.auth_sso.hosted_instance_id", lambda: "david010")
+    monkeypatch.setattr("zerg.routers.auth_sso.httpx.post", lambda *a, **k: FakeResponse())
+
+    with pytest.raises(HTTPException) as exc:
+        await refresh_native_session(NativeRefreshRequest(refresh_token="lhr_revoked"))
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_refresh_native_session_returns_502_on_cp_network_error(monkeypatch):
+    def fake_post(*a, **k):
+        raise httpx.HTTPError("connection refused")
+
+    monkeypatch.setattr(
+        "zerg.routers.auth_sso.get_settings",
+        lambda: SimpleNamespace(control_plane_url="https://control.longhouse.ai", internal_api_secret="secret"),
+    )
+    monkeypatch.setattr("zerg.routers.auth_sso.hosted_instance_id", lambda: "david010")
+    monkeypatch.setattr("zerg.routers.auth_sso.httpx.post", fake_post)
+
+    with pytest.raises(HTTPException) as exc:
+        await refresh_native_session(NativeRefreshRequest(refresh_token="lhr_current"))
+    assert exc.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_refresh_native_session_rejects_missing_token(monkeypatch):
+    monkeypatch.setattr(
+        "zerg.routers.auth_sso.get_settings",
+        lambda: SimpleNamespace(control_plane_url="https://control.longhouse.ai", internal_api_secret="secret"),
+    )
+    with pytest.raises(HTTPException) as exc:
+        await refresh_native_session(NativeRefreshRequest(refresh_token=" "))
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_revoke_native_session_proxies_to_cp(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "zerg.routers.auth_sso.get_settings",
+        lambda: SimpleNamespace(control_plane_url="https://control.longhouse.ai", internal_api_secret="secret"),
+    )
+    monkeypatch.setattr("zerg.routers.auth_sso.httpx.post", fake_post)
+
+    result = await revoke_native_session(NativeRevokeRequest(refresh_token="lhr_current"))
+
+    assert result == {"status": "ok"}
+    assert captured["url"] == "https://control.longhouse.ai/api/identity/revoke-native-session"
+    assert captured["headers"] == {"X-Internal-Token": "secret"}
+    assert captured["json"] == {"refresh_token": "lhr_current"}
+    assert captured["timeout"] == 5.0

--- a/server/zerg/routers/auth_sso.py
+++ b/server/zerg/routers/auth_sso.py
@@ -31,6 +31,30 @@ class NativeHandoffRequest(BaseModel):
     tenant_state: str
 
 
+class NativeRefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class NativeRevokeRequest(BaseModel):
+    refresh_token: str
+
+
+def _runtime_payload(data: dict) -> dict:
+    runtime_token = data.get("runtime_token")
+    expires_in = int(data.get("expires_in") or 3600)
+    if not isinstance(runtime_token, str) or not runtime_token:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Control plane response missing token",
+        )
+    payload = {"runtime_token": runtime_token, "expires_in": expires_in}
+    for key in ("refresh_token", "refresh_token_expires_at", "device_session_id"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            payload[key] = value
+    return payload
+
+
 def _exchange_handoff_code(
     *,
     control_plane_url: str,
@@ -38,7 +62,7 @@ def _exchange_handoff_code(
     code: str,
     tenant: str,
     tenant_state: str | None = None,
-) -> tuple[str, int]:
+) -> dict:
     payload = {"code": code, "tenant": tenant}
     if tenant_state:
         payload["tenant_state"] = tenant_state
@@ -58,15 +82,7 @@ def _exchange_handoff_code(
     if exchange.status_code >= 400:
         raise HTTPException(status_code=exchange.status_code, detail="Control plane rejected handoff")
 
-    data = exchange.json()
-    runtime_token = data.get("runtime_token")
-    expires_in = int(data.get("expires_in") or 3600)
-    if not isinstance(runtime_token, str) or not runtime_token:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Control plane handoff response missing token",
-        )
-    return runtime_token, expires_in
+    return _runtime_payload(exchange.json())
 
 
 @router.get("/accept-handoff")
@@ -91,13 +107,15 @@ async def accept_handoff_request(
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Login state mismatch")
 
     tenant = hosted_instance_id()
-    runtime_token, expires_in = _exchange_handoff_code(
+    payload = _exchange_handoff_code(
         control_plane_url=control_plane_url,
         internal_api_secret=settings.internal_api_secret,
         code=code,
         tenant=tenant,
         tenant_state=tenant_state,
     )
+    runtime_token = payload["runtime_token"]
+    expires_in = payload["expires_in"]
 
     from zerg.dependencies.auth import _get_strategy
 
@@ -130,13 +148,14 @@ async def accept_native_handoff(body: NativeHandoffRequest, db: Session = Depend
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Hosted handoff is not configured")
 
     tenant = hosted_instance_id()
-    runtime_token, expires_in = _exchange_handoff_code(
+    payload = _exchange_handoff_code(
         control_plane_url=control_plane_url,
         internal_api_secret=settings.internal_api_secret,
         code=body.code,
         tenant=tenant,
         tenant_state=body.tenant_state,
     )
+    runtime_token = payload["runtime_token"]
 
     from zerg.dependencies.auth import _get_strategy
 
@@ -144,7 +163,72 @@ async def accept_native_handoff(body: NativeHandoffRequest, db: Session = Depend
     if user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid runtime token")
 
-    return {"runtime_token": runtime_token, "expires_in": expires_in}
+    return payload
+
+
+@router.post("/refresh-native-session")
+async def refresh_native_session(body: NativeRefreshRequest):
+    settings = get_settings()
+    control_plane_url = getattr(settings, "control_plane_url", None)
+    if not control_plane_url:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Hosted native session refresh is not configured",
+        )
+
+    refresh_token = body.refresh_token.strip()
+    if not refresh_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing refresh token")
+
+    try:
+        exchange = httpx.post(
+            f"{control_plane_url.rstrip('/')}/api/identity/refresh-native-session",
+            headers={"X-Internal-Token": settings.internal_api_secret},
+            json={"refresh_token": refresh_token, "tenant": hosted_instance_id()},
+            timeout=10.0,
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Control plane native session refresh failed",
+        ) from exc
+
+    if exchange.status_code >= 400:
+        raise HTTPException(status_code=exchange.status_code, detail="Control plane rejected native refresh")
+
+    return _runtime_payload(exchange.json())
+
+
+@router.post("/revoke-native-session")
+async def revoke_native_session(body: NativeRevokeRequest):
+    settings = get_settings()
+    control_plane_url = getattr(settings, "control_plane_url", None)
+    if not control_plane_url:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Hosted native session revoke is not configured",
+        )
+
+    refresh_token = body.refresh_token.strip()
+    if not refresh_token:
+        return {"status": "ok"}
+
+    try:
+        exchange = httpx.post(
+            f"{control_plane_url.rstrip('/')}/api/identity/revoke-native-session",
+            headers={"X-Internal-Token": settings.internal_api_secret},
+            json={"refresh_token": refresh_token},
+            timeout=5.0,
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Control plane native session revoke failed",
+        ) from exc
+
+    if exchange.status_code >= 500:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Control plane revoke failed")
+    return {"status": "ok"}
 
 
 @router.post("/refresh-runtime-token")
@@ -189,15 +273,17 @@ async def refresh_runtime_token(request: Request):
     if exchange.status_code >= 400:
         raise HTTPException(status_code=exchange.status_code, detail="Control plane rejected refresh")
 
-    data = exchange.json()
-    runtime_token = data.get("runtime_token")
-    expires_in = int(data.get("expires_in") or 3600)
-    if not isinstance(runtime_token, str) or not runtime_token:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Control plane refresh response missing token",
-        )
-    return {"runtime_token": runtime_token, "expires_in": expires_in}
+    return _runtime_payload(exchange.json())
 
 
-__all__ = ["accept_handoff_request", "accept_native_handoff", "refresh_runtime_token", "router"]
+__all__ = [
+    "NativeHandoffRequest",
+    "NativeRefreshRequest",
+    "NativeRevokeRequest",
+    "accept_handoff_request",
+    "accept_native_handoff",
+    "refresh_native_session",
+    "refresh_runtime_token",
+    "revoke_native_session",
+    "router",
+]

--- a/server/zerg/routers/auth_sso.py
+++ b/server/zerg/routers/auth_sso.py
@@ -214,20 +214,18 @@ async def revoke_native_session(body: NativeRevokeRequest):
         return {"status": "ok"}
 
     try:
-        exchange = httpx.post(
+        httpx.post(
             f"{control_plane_url.rstrip('/')}/api/identity/revoke-native-session",
             headers={"X-Internal-Token": settings.internal_api_secret},
             json={"refresh_token": refresh_token},
             timeout=5.0,
         )
-    except httpx.HTTPError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Control plane native session revoke failed",
-        ) from exc
+    except httpx.HTTPError:
+        # Logout must clear local client credentials even when CP is
+        # unreachable. CP revocation is best-effort; old refresh tokens still
+        # expire naturally and refresh failures remain explicit on next use.
+        return {"status": "ok"}
 
-    if exchange.status_code >= 500:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Control plane revoke failed")
     return {"status": "ok"}
 
 

--- a/server/zerg/routers/auth_sso.py
+++ b/server/zerg/routers/auth_sso.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hmac
+import logging
 
 import httpx
 from fastapi import APIRouter
@@ -24,6 +25,7 @@ from zerg.config import get_settings
 from zerg.database import get_db
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+logger = logging.getLogger(__name__)
 
 
 class NativeHandoffRequest(BaseModel):
@@ -224,6 +226,7 @@ async def revoke_native_session(body: NativeRevokeRequest):
         # Logout must clear local client credentials even when CP is
         # unreachable. CP revocation is best-effort; old refresh tokens still
         # expire naturally and refresh failures remain explicit on next use.
+        logger.warning("native session revoke skipped because control plane is unreachable", exc_info=True)
         return {"status": "ok"}
 
     return {"status": "ok"}


### PR DESCRIPTION
Implements native iOS device-session refresh architecture.\n\nHighlights:\n- Adds native device refresh proxy endpoints for hosted tenants.\n- Stores native refresh tokens in iOS shared Keychain and refreshes runtime tokens silently.\n- Keeps widgets read-only for auth so extensions do not mutate or clear credentials.\n- Adds lifecycle tests for native rotation, legacy upgrade, single-flight refresh, missing replacement-token handling, and no-refresh widget clients.\n\nValidation:\n- make test-ios\n- PYTEST_XDIST_WORKERS=0 make test\n- cd server && uv run --extra dev pytest tests_lite/test_hosted_identity_auth.py -p no:warnings --tb=short