### PR TITLE
Fix managed-local Helm launch blocked by empty attach_command

### DIFF
--- a/docs/specs/managed-local-attach-command-catalog-contract.md
+++ b/docs/specs/managed-local-attach-command-catalog-contract.md
@@ -1,0 +1,53 @@
+# Formal Plan: Helm managed-local launch / catalogd attach_command
+
+Status: Implemented (Sol-refined, 2026-07-13)
+
+## Problem
+
+Cursor/Antigravity Helm launches fail before the provider TUI starts because
+catalogd rejects `attach_command=""` while the product contract requires empty
+attach for non-reattachable transports. The API then erases the real error into
+a fake retryable 503.
+
+## Contract
+
+- `attach_command` remains a **required string** on `session.launch.local.create.v2`.
+- `""` means no host reattach command (valid for Cursor Helm / Antigravity).
+- Non-empty values must be ≤ 4096 characters.
+- Reject `null`, missing field, wrong type, length > 4096.
+- Catalogd validates wire shape only; provider-specific attach *shape* stays in
+  Runtime Host response contract (`session_chat_impl`).
+
+## Scope
+
+In:
+
+1. catalogd local-launch validation accepts empty attach.
+2. Managed-local hot-path catalog error mapping is typed (this route only).
+3. Real CatalogDaemon RPC tests + live-catalog managed-local regression.
+
+Out:
+
+- Deferred/TUI-first Helm registration
+- Soft-launch without durable catalog identity
+- New attach-policy helper / new error-mapper module
+- remote_session_launch error-policy refactor
+- Provider contract / attach command generation changes
+- Search/WAL remediation
+
+## Error mapping (managed-local catalog persist only)
+
+| Exception | HTTP | Detail |
+|---|---|---|
+| `CatalogUnavailable` | 503 | unavailable / deadline; retry |
+| `CatalogRemoteError` `conflict` | 409 | conflict message |
+| `CatalogRemoteError` retryable | 503 | catalog message |
+| `CatalogRemoteError` other (incl. invalid_request) | 500 | catalog message (server-built payload) |
+| unexpected | 500 | generic persist failure |
+
+## Implementation
+
+1. `server/zerg/catalogd/server.py` — empty attach accepted on local launch RPC
+2. `server/zerg/routers/session_chat.py` — typed managed-local catalog error mapping
+3. `server/tests_lite/test_catalogd_launch.py` — empty/invalid/missing attach RPC coverage
+4. `server/tests_lite/test_managed_local_launch.py` — real CatalogDaemon cursor+codex path + rejection surfacing

--- a/server/tests_lite/test_catalogd_launch.py
+++ b/server/tests_lite/test_catalogd_launch.py
@@ -264,3 +264,130 @@ async def test_catalogd_owns_managed_local_launch_transaction(daemon_paths):
             REMOTE_LAUNCH_OUTCOME_KIND,
         ]
     engine.dispose()
+
+
+def _local_launch_payload(
+    *,
+    session_id,
+    provider: str,
+    managed_transport: str,
+    attach_command: object,
+    provider_session_id: str | None = None,
+):
+    now = datetime.now(UTC)
+    return {
+        "owner_id": 7,
+        "git_repo": "cipher982/longhouse",
+        "git_branch": "main",
+        "started_at": now.isoformat(),
+        "expires_at": (now + timedelta(minutes=5)).isoformat(),
+        "plan": {
+            "session_id": str(session_id),
+            "provider": provider,
+            "provider_session_id": provider_session_id,
+            "source_name": "cinder",
+            "source_runner_id": None,
+            "cwd": "/workspace/longhouse",
+            "project": "longhouse",
+            "display_name": "Managed local",
+            "managed_session_name": f"{provider}-managed-1",
+            "loop_mode": "assist",
+            "permission_mode": "bypass",
+            "launch_actor": "human_ui",
+            "launch_surface": "cli",
+            "managed_transport": managed_transport,
+            "attach_command": attach_command,
+        },
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "managed_transport"),
+    [
+        ("cursor", "cursor_helm"),
+        ("antigravity", "antigravity_hook_inbox"),
+    ],
+)
+async def test_catalogd_local_launch_accepts_empty_attach_command(daemon_paths, provider, managed_transport):
+    database_path, socket_path = daemon_paths
+    session_id = uuid4()
+    launch = _local_launch_payload(
+        session_id=session_id,
+        provider=provider,
+        managed_transport=managed_transport,
+        attach_command="",
+    )
+    daemon = CatalogDaemon(database_path=database_path, socket_path=socket_path)
+    await daemon.start()
+    client = CatalogClient(socket_path)
+    try:
+        created = await client.call("session.launch.local.create.v2", {"launch": launch})
+        assert created["created"] is True
+        replay = await client.call("session.launch.local.create.v2", {"launch": launch})
+        assert replay["exact_replay"] is True
+    finally:
+        await client.close()
+        await daemon.close()
+
+    engine = create_catalog_engine(database_path)
+    initialize_catalog_schema(engine)
+    with Session(engine) as db:
+        catalog = db.get(LiveSessionCatalog, str(session_id))
+        assert catalog is not None
+        assert catalog.provider == provider
+        attempt = db.query(LiveSessionLaunchAttempt).one()
+        assert attempt.command_id == f"managed-local-{session_id}"
+        assert db.query(LiveArchiveOutbox).filter_by(kind=MANAGED_LOCAL_LAUNCH_KIND).count() == 1
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "attach_command",
+    [None, 12, "x" * 4097],
+)
+async def test_catalogd_local_launch_rejects_invalid_attach_command(daemon_paths, attach_command):
+    database_path, socket_path = daemon_paths
+    launch = _local_launch_payload(
+        session_id=uuid4(),
+        provider="cursor",
+        managed_transport="cursor_helm",
+        attach_command=attach_command if attach_command is not None else "",
+    )
+    if attach_command is None:
+        launch["plan"]["attach_command"] = None
+    daemon = CatalogDaemon(database_path=database_path, socket_path=socket_path)
+    await daemon.start()
+    client = CatalogClient(socket_path)
+    try:
+        with pytest.raises(CatalogRemoteError) as exc_info:
+            await client.call("session.launch.local.create.v2", {"launch": launch})
+        assert exc_info.value.code == "invalid_request"
+        assert "attach_command" in str(exc_info.value)
+    finally:
+        await client.close()
+        await daemon.close()
+
+
+@pytest.mark.asyncio
+async def test_catalogd_local_launch_rejects_missing_attach_command(daemon_paths):
+    database_path, socket_path = daemon_paths
+    launch = _local_launch_payload(
+        session_id=uuid4(),
+        provider="cursor",
+        managed_transport="cursor_helm",
+        attach_command="",
+    )
+    del launch["plan"]["attach_command"]
+    daemon = CatalogDaemon(database_path=database_path, socket_path=socket_path)
+    await daemon.start()
+    client = CatalogClient(socket_path)
+    try:
+        with pytest.raises(CatalogRemoteError) as exc_info:
+            await client.call("session.launch.local.create.v2", {"launch": launch})
+        assert exc_info.value.code == "invalid_request"
+        assert "plan" in str(exc_info.value)
+    finally:
+        await client.close()
+        await daemon.close()

--- a/server/tests_lite/test_managed_local_launch.py
+++ b/server/tests_lite/test_managed_local_launch.py
@@ -488,66 +488,136 @@ def test_this_device_launch_returns_hot_readiness_when_archive_writer_is_stale(m
         assert response.session_id in outbox.idempotency_key
 
 
-def test_this_device_launch_materializes_live_catalog_without_archive_db(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("provider", "expected_transport", "expect_empty_attach"),
+    [
+        ("cursor", "cursor_helm", True),
+        ("codex", "codex_app_server", False),
+    ],
+)
+def test_this_device_launch_materializes_live_catalog_without_archive_db(
+    monkeypatch,
+    provider,
+    expected_transport,
+    expect_empty_attach,
+):
     import zerg.database as database_module
-    from zerg.catalogd.schema import initialize_catalog_schema
-    from zerg.catalogd.store import CatalogStore
+    from pathlib import Path
+    from uuid import uuid4
+
+    from zerg.catalogd.client import CatalogClient
+    from zerg.catalogd.server import CatalogDaemon
     from zerg.routers import session_chat
 
-    live_url = f"sqlite:///{tmp_path / 'managed-launch-catalog.db'}"
-    live_engine = make_live_engine(live_url)
-    initialize_live_database(live_engine)
-    initialize_catalog_schema(live_engine)
+    root = Path("/tmp") / f"lh-ml-{provider}-{uuid4().hex[:8]}"
+    root.mkdir(mode=0o700)
+    database_path = root / "live.db"
+    socket_path = root / "catalogd.sock"
+    live_engine = make_live_engine(f"sqlite:///{database_path}")
     LiveSession = make_sessionmaker(live_engine)
-    catalog_store = CatalogStore(live_engine)
 
-    class CatalogClient:
+    async def _run_launch():
+        daemon = CatalogDaemon(database_path=database_path, socket_path=socket_path)
+        await daemon.start()
+        client = CatalogClient(socket_path)
+        monkeypatch.setattr(database_module, "live_store_configured", lambda: True)
+        monkeypatch.setattr(database_module, "live_catalog_enabled", lambda: True)
+        monkeypatch.setattr("zerg.services.catalogd_supervisor.get_catalogd_client", lambda: client)
+        monkeypatch.setattr(
+            session_chat,
+            "get_live_write_serializer",
+            lambda: (_ for _ in ()).throw(AssertionError("catalog launch must not use the API live serializer")),
+        )
+        try:
+            return await session_chat._launch_managed_local_session_serialized(
+                SimpleNamespace(),
+                ManagedLocalLaunchParams(
+                    owner_id=42,
+                    runner_target="cinder",
+                    cwd="/tmp/demo",
+                    provider=provider,
+                    project="demo",
+                    machine_name="cinder",
+                ),
+            )
+        finally:
+            await client.close()
+            await daemon.close()
+
+    try:
+        _result, response = asyncio.run(_run_launch())
+        assert response.provider == provider
+        assert response.managed_transport.value == expected_transport
+        if expect_empty_attach:
+            assert response.attach_command == ""
+        else:
+            assert "codex-bridge attach --session-id" in response.attach_command
+            assert response.session_id in response.attach_command
+        assert response.provider_session_id is None
+        with LiveSession() as live_db:
+            catalog = live_db.get(LiveSessionCatalog, response.session_id)
+            assert catalog is not None
+            assert catalog.project == "demo"
+            assert catalog.primary_thread_id is not None
+            assert live_db.get(LiveSessionThread, catalog.primary_thread_id) is not None
+            attempt = live_db.query(LiveSessionLaunchAttempt).one()
+            assert attempt.command_id == f"managed-local-{response.session_id}"
+            assert attempt.state == "pending"
+            run = live_db.query(LiveSessionRun).one()
+            connection = live_db.query(LiveSessionConnection).one()
+            assert connection.run_id == run.id
+            assert connection.state == "detached"
+            assert connection.device_id == "cinder"
+            assert live_db.query(LiveSessionThreadAlias).count() == 0
+    finally:
+        live_engine.dispose()
+        for path in root.iterdir():
+            path.unlink(missing_ok=True)
+        root.rmdir()
+
+
+def test_this_device_launch_surfaces_catalog_rejection_without_retry_theater(monkeypatch):
+    import zerg.database as database_module
+    from zerg.catalogd.client import CatalogRemoteError
+    from zerg.catalogd.protocol import CatalogRpcError
+    from zerg.routers import session_chat
+    from zerg.services.managed_local_launcher import ManagedLocalLaunchError
+
+    class RejectingCatalog:
         async def call(self, method, params, **_kwargs):
             assert method == "session.launch.local.create.v2"
-            launch = dict(params["launch"])
-            launch["started_at"] = datetime.fromisoformat(launch["started_at"])
-            launch["expires_at"] = datetime.fromisoformat(launch["expires_at"])
-            return catalog_store.create_local_launch(launch=launch)
+            raise CatalogRemoteError(
+                CatalogRpcError(
+                    code="invalid_request",
+                    message="local launch.plan.attach_command must be a string of at most 4096 characters",
+                    retryable=False,
+                    retry_after_ms=None,
+                    details={},
+                )
+            )
 
     monkeypatch.setattr(database_module, "live_store_configured", lambda: True)
     monkeypatch.setattr(database_module, "live_catalog_enabled", lambda: True)
-    monkeypatch.setattr("zerg.services.catalogd_supervisor.get_catalogd_client", lambda: CatalogClient())
-    monkeypatch.setattr(
-        session_chat,
-        "get_live_write_serializer",
-        lambda: (_ for _ in ()).throw(AssertionError("catalog launch must not use the API live serializer")),
-    )
+    monkeypatch.setattr("zerg.services.catalogd_supervisor.get_catalogd_client", lambda: RejectingCatalog())
 
-    _result, response = asyncio.run(
-        session_chat._launch_managed_local_session_serialized(
-            SimpleNamespace(),
-            ManagedLocalLaunchParams(
-                owner_id=42,
-                runner_target="cinder",
-                cwd="/tmp/demo",
-                provider="codex",
-                project="demo",
-                machine_name="cinder",
-            ),
+    with pytest.raises(ManagedLocalLaunchError) as exc_info:
+        asyncio.run(
+            session_chat._launch_managed_local_session_serialized(
+                SimpleNamespace(),
+                ManagedLocalLaunchParams(
+                    owner_id=42,
+                    runner_target="cinder",
+                    cwd="/tmp/demo",
+                    provider="cursor",
+                    project="demo",
+                    machine_name="cinder",
+                ),
+            )
         )
-    )
 
-    with LiveSession() as live_db:
-        catalog = live_db.get(LiveSessionCatalog, response.session_id)
-        assert catalog is not None
-        assert catalog.project == "demo"
-        assert catalog.primary_thread_id is not None
-        assert live_db.get(LiveSessionThread, catalog.primary_thread_id) is not None
-        attempt = live_db.query(LiveSessionLaunchAttempt).one()
-        assert attempt.command_id == f"managed-local-{response.session_id}"
-        assert attempt.state == "pending"
-        run = live_db.query(LiveSessionRun).one()
-        connection = live_db.query(LiveSessionConnection).one()
-        assert connection.run_id == run.id
-        assert connection.state == "detached"
-        assert connection.device_id == "cinder"
-        assert live_db.query(LiveSessionThreadAlias).count() == 0
-        assert response.provider_session_id is None
+    assert exc_info.value.status_code == 500
+    assert "attach_command" in exc_info.value.detail
+    assert "retry shortly" not in exc_info.value.detail.lower()
 
 
 def test_this_device_launch_skips_runtime_pubsub_for_hot_readiness(monkeypatch, tmp_path):

--- a/server/zerg/catalogd/server.py
+++ b/server/zerg/catalogd/server.py
@@ -3272,10 +3272,14 @@ def _validate_local_launch_rpc(value: object) -> dict:
         ("loop_mode", 32),
         ("permission_mode", 32),
         ("managed_transport", 64),
-        ("attach_command", 4096),
     ):
         if not _is_string(plan[field], maximum=maximum):
             raise ValueError(f"local launch.plan.{field} must contain 1 to {maximum} characters")
+    # attach_command is a required string. Empty means "no host reattach command"
+    # (valid for Cursor Helm / Antigravity). Non-empty values are bounded.
+    attach_command = plan["attach_command"]
+    if not isinstance(attach_command, str) or len(attach_command) > 4096:
+        raise ValueError("local launch.plan.attach_command must be a string of at most 4096 characters")
     for field, maximum in (("provider_session_id", 512), ("launch_actor", 32), ("launch_surface", 32)):
         raw = plan[field]
         if raw is not None and (not isinstance(raw, str) or not raw or len(raw) > maximum):

--- a/server/zerg/routers/session_chat.py
+++ b/server/zerg/routers/session_chat.py
@@ -225,6 +225,8 @@ async def _write_hot_managed_local_launch_readiness(
     now = datetime.now(timezone.utc)
     expires_at = now + timedelta(seconds=_MANAGED_LOCAL_HOT_LAUNCH_LEASE_SECS)
     if database_module.live_catalog_enabled():
+        from zerg.catalogd.client import CatalogRemoteError
+        from zerg.catalogd.client import CatalogUnavailable
         from zerg.services.catalogd_supervisor import get_catalogd_client
 
         catalogd = get_catalogd_client()
@@ -260,11 +262,34 @@ async def _write_hot_managed_local_launch_readiness(
         try:
             await catalogd.call("session.launch.local.create.v2", {"launch": launch})
             return
+        except CatalogUnavailable as exc:
+            raise ManagedLocalLaunchError(
+                "Managed local launch is blocked because catalogd is unavailable; retry shortly.",
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            ) from exc
+        except CatalogRemoteError as exc:
+            if exc.code == "conflict":
+                raise ManagedLocalLaunchError(
+                    str(exc) or "Managed local launch conflicts with an existing launch identity.",
+                    status_code=status.HTTP_409_CONFLICT,
+                ) from exc
+            if exc.retryable:
+                raise ManagedLocalLaunchError(
+                    str(exc) or "Managed local launch is blocked because catalogd is temporarily unavailable; retry shortly.",
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                ) from exc
+            # Server-built launch payloads that fail catalog validation are
+            # programmer/contract bugs, not client retries.
+            logger.exception("Managed local catalog launch rejected by catalogd")
+            raise ManagedLocalLaunchError(
+                str(exc) or "Managed local launch is blocked because catalogd rejected launch state.",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            ) from exc
         except Exception as exc:
             logger.exception("Managed local catalog launch transaction failed")
             raise ManagedLocalLaunchError(
-                "Managed local launch is blocked because catalogd could not persist launch state; retry shortly.",
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                "Managed local launch is blocked because catalogd could not persist launch state.",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             ) from exc
     if not database_module.live_store_configured():
         raise ManagedLocalLaunchError(


### PR DESCRIPTION
## Summary
- Allow `attach_command=""` on catalogd `session.launch.local.create.v2` (required string; empty means no host reattach for Cursor/Antigravity Helm).
- Surface typed catalog errors on managed-local launch instead of a fake retryable 503.
- Document the Sol-refined contract and cover Cursor/Codex through a real CatalogDaemon.

## Test plan
- [x] `uv run pytest tests_lite/test_catalogd_launch.py tests_lite/test_managed_local_launch.py`
- [x] Hatch Sol final review: approve-merge
- [ ] After deploy: `lhcu` / `longhouse cursor` against david010 succeeds past "Preparing your session…"


Made with [Cursor](https://cursor.com)