### PR TITLE
Capability-gated Degraded Helm for Cursor

### DIFF
--- a/docs/specs/capability-gated-degraded-helm.md
+++ b/docs/specs/capability-gated-degraded-helm.md
@@ -1,0 +1,134 @@
+# Capability-gated Degraded Helm
+
+Status: Draft (Terra-refined) → implement Cursor proving ground
+Date: 2026-07-13
+Product sentence: **Helm always gives you the real provider terminal; Longhouse adds durability and remote control only when it can prove them live.**
+
+## Product decision (locked)
+
+**Posture:** Capability-gated Degraded Helm.
+
+- Local provider TUI is authoritative and must start for a valid local Helm launch.
+- The session remains **Helm** (managed launch ownership), not Shadow.
+- Remote/durable capabilities are independently gated by live proof.
+- Console stays hard-managed (Longhouse is the only UI).
+- Shadow stays unmanaged/observe-only and never becomes Helm by silence.
+
+### Non-negotiable Helm guarantees
+
+1. A valid local launch always reaches the unchanged provider TUI.
+2. Longhouse remote/catalog failure never strands the user without local interaction.
+3. The session has one stable local identity that later convergence must reuse.
+4. Degradation is explicit in the terminal (and later UI).
+5. Remote send/interrupt/steer are enabled only from current capability proof.
+6. Recovery upgrades the same session identity — no replacement session.
+
+### Hard-fail vs soft-fail
+
+**Still hard-fail (local prerequisites — these are not “Longhouse is sick”):**
+- Non-interactive terminal when Helm requires TTY
+- Missing provider binary / inability to establish local PTY
+- Missing Longhouse URL/token configuration (machine not enrolled)
+- Local machine-name / URL contract mismatches that would misroute control
+
+**Soft-fail / async (remote plane):**
+- Runtime Host unreachable / timeout / 5xx
+- catalogd / managed-local registration rejects
+- Timeline/ingest unavailable after launch
+
+### What must never be silently claimed
+
+- Durability before persistence is confirmed
+- Live remote control from launch success or local socket bind alone
+- Full Helm health when only the local TUI is up
+- Unmanaged/Shadow fallback disguised as Helm
+- A second session id created during recovery
+
+## Mode boundaries
+
+| Mode | Launch gate | UI truth |
+|---|---|---|
+| Helm | Local TUI must start; remote plane optional | Capabilities from live proof |
+| Console | Control path + initial visibility required | Hard fail if Longhouse cannot be the UI |
+| Shadow | No Longhouse launch ownership | Observe-only; never implies control |
+
+## Cursor proving-ground lifecycle (authoritative)
+
+Registration must **not** gate the TUI — including hanging on a long HTTP timeout.
+
+```text
+1. Validate local prerequisites (TTY, cursor-agent on PATH, enrolled URL+token, local contract preflight)
+2. Mint stable session_id locally (UUID v4)
+3. Bind local control socket + write local state:
+     registration=pending|degraded, same session_id
+4. Print launch panel with steerable=False until host registration succeeds
+   (local socket bind is NOT remote proof)
+5. Start provider TUI immediately
+6. Background registration thread (bounded retries):
+     POST /api/sessions/managed-local/this-device with client session_id
+     on success: registration=registered on state file (same id)
+     on exhaustion: registration=degraded + last_error; leave warning in scrollback if still useful
+7. Out of scope this PR: mid-session panel upgrade, Runtime Host capability projector redesign
+```
+
+### Identity / reconciliation
+
+- Client mints `session_id` once at launch.
+- API accepts optional `session_id` and materializes that id (idempotent).
+- Background retries always reuse the same id.
+- If registration never succeeds: local Helm session still ran; no remote durability/control; no alternate id invented later.
+- Terminal/runtime events posted best-effort; failure does not kill the TUI.
+
+### Capability claims (Cursor proving ground)
+
+| Claim | When true in this PR |
+|---|---|
+| Local TUI running | After pty.fork child starts |
+| Local control socket up | After bind (engine can attach locally) |
+| Host registration | After successful managed-local POST |
+| Remote steer from web/iOS | Requires host registration **and** engine lease observation (existing path); do **not** claim in launch panel until registration succeeds |
+
+Launch panel uses `steerable=False` until registration succeeds **before** the panel is printed. If registration is still in-flight when the panel prints (because TUI starts first), default to `steerable=False` / “Watch on your timeline” / explicit “registering with Longhouse…” warning. Do not print “Steer from anywhere” on socket bind alone.
+
+Optional short race: start background register immediately after mint, wait up to ~300ms for a fast success before printing the panel; never block the TUI on the full HTTP timeout.
+
+### Explicit non-goals (this PR)
+
+- Claude/Codex/OpenCode/Antigravity launchers
+- Console policy changes
+- Full remote capability state machine / stale-proof downgrade across web/iOS
+- Offline remote-command queuing
+- Redesigning catalog persistence internals
+- Making transcript ingest part of the capability gate
+
+## Tests
+
+1. Cursor: when registration HTTP fails/times out, launcher still proceeds to socket bind + would fork (mock provider bin / stop before fork if needed).
+2. API: client-minted `session_id` accepted and returned unchanged.
+3. Launch panel / registration helper: steerable false while registration pending/failed.
+4. Existing Cursor Helm launcher unit tests still pass.
+5. Hard-fail paths unchanged (missing binary, non-interactive).
+
+## Terra must-fixes (locked before implement)
+
+1. **Registration retry idempotency:** catalog `session.launch.local.create.v2` replay for an existing `managed-local-{session_id}` must succeed when identity fields match, **without** requiring identical `started_at` / `expires_at`. Lost HTTP responses + background retries must return the original launch, not conflict.
+
+2. **Shutdown reconciliation:** background registration is cancelled when the Helm process is exiting. If a register request already committed after exit, immediately best-effort terminalize that session; never leave a falsely-live host session. Do not block process exit on the full HTTP timeout.
+
+3. **Readiness before live lease:** engine Cursor Helm scanner must treat `ready=true` (and live launcher pid + socket) as the live signal. Launcher sets `ready=true` only after the provider child is running. Socket may exist earlier; it must not imply remote steer.
+
+4. **Honest terminal copy:** do not say “Watch on your timeline” or “thread saved” when registration never succeeded. Use registering / local-only / non-durable exit copy.
+
+5. **Tests** cover: idempotent replay with new timestamps; registration aborted/terminalized after provider exit; no live observation when `ready=false`; soft remote failure still starts TUI path.
+
+- Host unreachable / catalog reject / delayed registration: Cursor TUI still starts.
+- No false “Steer from anywhere” before host registration.
+- One local session_id end-to-end; successful register uses that id.
+- Mode remains Helm (managed local state + control socket), never silent Shadow.
+
+## Implementation sequence
+
+1. Land this spec.
+2. API optional `session_id` + lite tests.
+3. Cursor launcher: mint → bind/state → background register → TUI; panel steerable gated; tests.
+4. DeepSeek check-ins between commits; final Terra review; push.

--- a/engine/src/managed_cursor_helm_scan.rs
+++ b/engine/src/managed_cursor_helm_scan.rs
@@ -47,6 +47,10 @@ struct CursorHelmStateFile {
     started_at: Option<String>,
     #[serde(default)]
     updated_at: Option<String>,
+    /// Launcher publishes ready=true only after the provider child is running.
+    /// Missing/false must not produce a live remote-control lease.
+    #[serde(default)]
+    ready: Option<bool>,
 }
 
 pub fn collect_observations() -> Vec<CursorHelmObservation> {
@@ -99,7 +103,8 @@ pub fn collect_observations_from(state_dir: &Path) -> Vec<CursorHelmObservation>
             .as_ref()
             .map(|p| p.exists())
             .unwrap_or(false);
-        let live = launcher_alive && socket_present;
+        let ready = state.ready.unwrap_or(false);
+        let live = launcher_alive && socket_present && ready;
         out.push(CursorHelmObservation {
             session_id,
             state_file: path,
@@ -126,10 +131,21 @@ mod tests {
     }
 
     fn write_state(dir: &Path, session_id: &str, socket: &Path, launcher_pid: Option<u32>) {
+        write_state_with_ready(dir, session_id, socket, launcher_pid, true);
+    }
+
+    fn write_state_with_ready(
+        dir: &Path,
+        session_id: &str,
+        socket: &Path,
+        launcher_pid: Option<u32>,
+        ready: bool,
+    ) {
         let mut value = json!({
             "session_id": session_id,
             "socket_path": socket.to_string_lossy(),
             "cursor_pid": 99999,
+            "ready": ready,
             "started_at": "2026-06-30T00:00:00Z",
             "updated_at": "2026-06-30T00:00:00Z",
         });
@@ -178,6 +194,17 @@ mod tests {
         let obs = collect_observations_from(dir.path());
         let no_sock = obs.iter().find(|o| o.session_id == "sess-no-sock").unwrap();
         assert!(!no_sock.live);
+    }
+
+    #[test]
+    fn not_ready_is_not_live_even_with_pid_and_socket() {
+        let dir = tmp_dir();
+        let socket = dir.path().join("c.sock");
+        fs::File::create(&socket).unwrap();
+        write_state_with_ready(dir.path(), "sess-not-ready", &socket, Some(std::process::id()), false);
+        let obs = collect_observations_from(dir.path());
+        let pending = obs.iter().find(|o| o.session_id == "sess-not-ready").unwrap();
+        assert!(!pending.live);
     }
 
     #[test]

--- a/server/tests_lite/test_catalogd_launch.py
+++ b/server/tests_lite/test_catalogd_launch.py
@@ -302,6 +302,34 @@ def _local_launch_payload(
 
 
 @pytest.mark.asyncio
+async def test_catalogd_local_launch_replays_when_retry_timestamps_differ(daemon_paths):
+    database_path, socket_path = daemon_paths
+    session_id = uuid4()
+    first = _local_launch_payload(
+        session_id=session_id,
+        provider="cursor",
+        managed_transport="cursor_helm",
+        attach_command="",
+    )
+    daemon = CatalogDaemon(database_path=database_path, socket_path=socket_path)
+    await daemon.start()
+    client = CatalogClient(socket_path)
+    try:
+        created = await client.call("session.launch.local.create.v2", {"launch": first})
+        assert created["created"] is True
+        later = dict(first)
+        later["started_at"] = (datetime.now(UTC) + timedelta(seconds=30)).isoformat()
+        later["expires_at"] = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        replay = await client.call("session.launch.local.create.v2", {"launch": later})
+        assert replay["exact_replay"] is True
+        assert replay["idempotency_conflict"] is False
+        assert replay["launch"]["session_id"] == str(session_id)
+    finally:
+        await client.close()
+        await daemon.close()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("provider", "managed_transport"),
     [

--- a/server/tests_lite/test_cursor_helm_launcher.py
+++ b/server/tests_lite/test_cursor_helm_launcher.py
@@ -137,6 +137,94 @@ def test_registration_worker_terminalizes_when_exit_races_success(monkeypatch, t
     assert outcome_box == []
 
 
+def test_reconcile_registration_on_exit_terminalizes_unknown_outcome(monkeypatch):
+    terminal_reasons: list[str] = []
+    monkeypatch.setattr(
+        cursor_helm,
+        "_post_terminal_event",
+        lambda _url, _token, _sid, reason: terminal_reasons.append(reason),
+    )
+
+    finished = threading.Event()
+
+    def _linger():
+        finished.wait(timeout=0.05)
+
+    thread = threading.Thread(target=_linger, daemon=True)
+    thread.start()
+    durable = cursor_helm._reconcile_registration_on_exit(
+        url="https://example.invalid",
+        token="tok",
+        session_id="33333333-3333-4333-8333-333333333333",
+        registration_thread=thread,
+        registration_box=[],
+        registration_lock=threading.Lock(),
+        join_timeout=0.2,
+    )
+    assert durable is False
+    assert terminal_reasons == ["helm_exit_before_ready"]
+
+
+def test_reconcile_registration_on_exit_closes_registered_session(monkeypatch):
+    terminal_reasons: list[str] = []
+    monkeypatch.setattr(
+        cursor_helm,
+        "_post_terminal_event",
+        lambda _url, _token, _sid, reason: terminal_reasons.append(reason),
+    )
+    thread = threading.Thread(target=lambda: None, daemon=True)
+    thread.start()
+    thread.join(timeout=1.0)
+    box = [
+        cursor_helm._RegistrationOutcome(
+            session_id="44444444-4444-4444-8444-444444444444",
+            registered=True,
+            attach_command="",
+        )
+    ]
+    durable = cursor_helm._reconcile_registration_on_exit(
+        url="https://example.invalid",
+        token="tok",
+        session_id="44444444-4444-4444-8444-444444444444",
+        registration_thread=thread,
+        registration_box=box,
+        registration_lock=threading.Lock(),
+        join_timeout=0.1,
+    )
+    assert durable is True
+    assert terminal_reasons == ["helm_exit"]
+
+
+def test_register_session_soft_fails_on_401(monkeypatch, tmp_path):
+    class AuthClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, *args, **kwargs):
+            return cursor_helm.httpx.Response(401, request=cursor_helm.httpx.Request("POST", "https://x"))
+
+    monkeypatch.setattr(cursor_helm.httpx, "Client", AuthClient)
+    outcome = cursor_helm._register_session(
+        url="https://example.invalid",
+        token="tok",
+        cwd=tmp_path,
+        project="demo",
+        name=None,
+        loop_mode=cursor_helm.SessionLoopMode.ASSIST,
+        machine_name="cinder",
+        permission_mode="bypass",
+        session_id="11111111-1111-4111-8111-111111111111",
+    )
+    assert outcome.registered is False
+    assert "authentication failed" in (outcome.error or "")
+
+
 def test_handle_command_send_writes_text_escape_enter_sequence():
     read_fd, write_fd = os.pipe()
     lock = threading.Lock()

--- a/server/tests_lite/test_cursor_helm_launcher.py
+++ b/server/tests_lite/test_cursor_helm_launcher.py
@@ -35,7 +35,14 @@ def test_state_file_round_trip(monkeypatch, tmp_path):
     _state_dir_for(monkeypatch, tmp_path)
     session_id = "11111111-1111-4111-8111-111111111111"
     sock = cursor_helm._socket_path(session_id)
-    cursor_helm._write_state(session_id, socket_path=sock, cursor_pid=123, cwd=tmp_path, ready=True)
+    cursor_helm._write_state(
+        session_id,
+        socket_path=sock,
+        cursor_pid=123,
+        cwd=tmp_path,
+        ready=True,
+        registration="registered",
+    )
 
     raw = cursor_helm._state_file_path(session_id).read_text()
     state = json.loads(raw)
@@ -46,10 +53,88 @@ def test_state_file_round_trip(monkeypatch, tmp_path):
     assert state["launcher_pid"] == os.getpid()
     assert state["cursor_pid"] == 123
     assert state["ready"] is True
+    assert state["registration"] == "registered"
 
     cursor_helm._remove_state(session_id, sock)
     assert not cursor_helm._state_file_path(session_id).exists()
     assert not sock.exists()
+
+
+def test_register_session_soft_fails_on_connect_error(monkeypatch, tmp_path):
+    class BoomClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, *args, **kwargs):
+            raise cursor_helm.httpx.ConnectError("down")
+
+    monkeypatch.setattr(cursor_helm.httpx, "Client", BoomClient)
+    outcome = cursor_helm._register_session(
+        url="https://example.invalid",
+        token="tok",
+        cwd=tmp_path,
+        project="demo",
+        name=None,
+        loop_mode=cursor_helm.SessionLoopMode.ASSIST,
+        machine_name="cinder",
+        permission_mode="bypass",
+        session_id="11111111-1111-4111-8111-111111111111",
+    )
+    assert outcome.registered is False
+    assert outcome.session_id.endswith("1111")
+    assert "connect failed" in (outcome.error or "")
+
+
+def test_registration_worker_terminalizes_when_exit_races_success(monkeypatch, tmp_path):
+    """If register commits after Helm exit, terminalize immediately."""
+    _state_dir_for(monkeypatch, tmp_path)
+    session_id = "22222222-2222-4222-8222-222222222222"
+    sock = cursor_helm._socket_path(session_id)
+    terminal_reasons: list[str] = []
+    stop = threading.Event()
+
+    def _register_then_mark_exit(**_kwargs):
+        stop.set()
+        return cursor_helm._RegistrationOutcome(
+            session_id=session_id,
+            registered=True,
+            attach_command="",
+        )
+
+    monkeypatch.setattr(cursor_helm, "_register_session", _register_then_mark_exit)
+    monkeypatch.setattr(
+        cursor_helm,
+        "_post_terminal_event",
+        lambda _url, _token, _sid, reason: terminal_reasons.append(reason),
+    )
+    monkeypatch.setattr(cursor_helm, "_REGISTER_RETRY_DELAYS_SECONDS", (0.0,))
+
+    outcome_box: list = []
+    cursor_helm._registration_worker(
+        url="https://example.invalid",
+        token="tok",
+        cwd=tmp_path,
+        project="demo",
+        name=None,
+        loop_mode=cursor_helm.SessionLoopMode.ASSIST,
+        machine_name="cinder",
+        permission_mode="bypass",
+        session_id=session_id,
+        sock_path=sock,
+        stop_event=stop,
+        outcome_box=outcome_box,
+        outcome_lock=threading.Lock(),
+        verbose=False,
+    )
+
+    assert terminal_reasons == ["helm_exit_before_ready"]
+    assert outcome_box == []
 
 
 def test_handle_command_send_writes_text_escape_enter_sequence():

--- a/server/tests_lite/test_cursor_helm_launcher.py
+++ b/server/tests_lite/test_cursor_helm_launcher.py
@@ -225,6 +225,43 @@ def test_register_session_soft_fails_on_401(monkeypatch, tmp_path):
     assert "authentication failed" in (outcome.error or "")
 
 
+def test_post_terminal_event_uses_runtime_events_batch(monkeypatch):
+    captured: dict = {}
+
+    class CaptureClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, endpoint, headers=None, json=None):
+            captured["endpoint"] = endpoint
+            captured["headers"] = headers
+            captured["json"] = json
+            return cursor_helm.httpx.Response(200, request=cursor_helm.httpx.Request("POST", endpoint))
+
+    monkeypatch.setattr(cursor_helm.httpx, "Client", CaptureClient)
+    monkeypatch.setattr(cursor_helm, "get_machine_name_label", lambda: "cinder")
+    cursor_helm._post_terminal_event(
+        "https://david010.longhouse.ai",
+        "tok",
+        "55555555-5555-4555-8555-555555555555",
+        "helm_exit",
+    )
+    assert captured["endpoint"] == "https://david010.longhouse.ai/api/agents/runtime/events/batch"
+    assert captured["headers"]["X-Agents-Token"] == "tok"
+    event = captured["json"]["events"][0]
+    assert event["kind"] == "terminal_signal"
+    assert event["provider"] == "cursor"
+    assert event["source"] == "cursor_helm"
+    assert event["payload"]["terminal_state"] == "session_ended"
+    assert event["payload"]["terminal_reason"] == "helm_exit"
+
+
 def test_handle_command_send_writes_text_escape_enter_sequence():
     read_fd, write_fd = os.pipe()
     lock = threading.Lock()

--- a/server/tests_lite/test_launch_ui.py
+++ b/server/tests_lite/test_launch_ui.py
@@ -51,6 +51,28 @@ def test_launch_panel_non_steerable_softens_to_watch(capsys):
     assert "Steer from anywhere" not in out
 
 
+def test_launch_panel_local_only_copy(capsys):
+    launch_ui.launch_panel(
+        provider_label="Cursor",
+        base_url="https://david010.longhouse.ai",
+        machine_name="cinder",
+        session_id=_SESSION_ID,
+        verbose=False,
+        capability="local_only",
+    )
+    out = capsys.readouterr().out
+    assert "Local Helm" in out
+    assert "Steer from anywhere" not in out
+    assert "Watch on your timeline" not in out
+
+
+def test_exit_bookend_non_durable_clean_exit(capsys):
+    launch_ui.exit_bookend(exit_code=0, machine_name="cinder", durable=False)
+    out = capsys.readouterr().out
+    assert "not synced to Longhouse" in out
+    assert "thread saved" not in out
+
+
 def test_launch_panel_verbose_appends_full_detail(capsys):
     launch_ui.launch_panel(
         provider_label="Claude",

--- a/server/tests_lite/test_managed_local_launch.py
+++ b/server/tests_lite/test_managed_local_launch.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 from datetime import datetime
 from types import SimpleNamespace
+from uuid import uuid4
 
 import pytest
 from cryptography.fernet import Fernet
@@ -377,6 +378,41 @@ def test_this_device_launch_does_not_require_runner_record(monkeypatch, tmp_path
     assert payload["source_runner_id"] is None
     assert payload["source_runner_name"] == "cinder"
     assert payload["managed_transport"] == "codex_app_server"
+
+
+def test_this_device_launch_returns_client_minted_session_id_unchanged(monkeypatch, tmp_path):
+    from zerg.services import managed_local_launcher
+
+    SessionLocal = _make_db(tmp_path)
+    minted = uuid4()
+
+    with SessionLocal() as db:
+        user, _runner = _seed_user_and_runner(db)
+        device_token = SimpleNamespace(owner_id=user.id, device_id="cinder")
+        client, api_app = _make_device_client(db, device_token)
+        monkeypatch.setattr(
+            managed_local_launcher,
+            "get_runner_connection_manager",
+            lambda: SimpleNamespace(is_online=lambda *_args: False),
+        )
+
+        try:
+            response = client.post(
+                "/api/sessions/managed-local/this-device",
+                json={
+                    "cwd": "/tmp/demo",
+                    "provider": "cursor",
+                    "project": "demo",
+                    "session_id": str(minted),
+                },
+            )
+        finally:
+            api_app.dependency_overrides = {}
+
+        payload = response.json()
+
+    assert response.status_code == 200, response.text
+    assert payload["session_id"] == str(minted)
 
 
 def test_this_device_launch_uses_live_store_not_archive_writer(monkeypatch, tmp_path, managed_launch_live_store):

--- a/server/zerg/catalogd/store.py
+++ b/server/zerg/catalogd/store.py
@@ -2377,7 +2377,6 @@ class CatalogStore:
                         and existing.owner_id == launch["owner_id"]
                         and str(existing.provider) == plan.provider
                         and str(existing.host_id or "") == plan.source_name
-                        and _as_aware_utc(existing.expires_at) == _as_aware_utc(launch["expires_at"])
                         and catalog is not None
                         and str(catalog.cwd or "") == plan.cwd
                         and str(catalog.project or "") == plan.project
@@ -2388,7 +2387,6 @@ class CatalogStore:
                         and stored_launch.get("owner_id") == launch["owner_id"]
                         and stored_launch.get("git_repo") == launch.get("git_repo")
                         and stored_launch.get("git_branch") == launch.get("git_branch")
-                        and stored_launch.get("started_at") == {"__longhouse_datetime__": observed_at.isoformat()}
                         and stored_launch.get("plan") == expected_plan
                     )
                     result = live_launch_result(existing) if exact_replay else None

--- a/server/zerg/cli/_launch_ui.py
+++ b/server/zerg/cli/_launch_ui.py
@@ -71,18 +71,32 @@ def launch_panel(
     verbose: bool,
     steerable: bool = True,
     attach_command: str | None = None,
+    capability: str | None = None,
 ) -> None:
     """Opening hearth panel: the session is live and yours to drive from anywhere.
 
     Leads with the steer-from-anywhere capability (the product's wedge) rather
-    than a static status lamp. `steerable=False` softens the claim to a watch-only
-    link for providers without a proven live control surface at launch.
+    than a static status lamp. Callers that lack proven remote control must pass
+    ``capability`` (or ``steerable=False``) so copy stays honest.
 
-    Verbose appends the diagnostic block: full session id, full timeline URL, and
-    the attach command when one is supplied.
+    ``capability`` values:
+    - ``steerable``: remote control proven / host registration succeeded
+    - ``registering``: local TUI starting; host registration still in flight
+    - ``local_only``: remote plane failed; local Helm continues
+    - ``watch``: observe link only (e.g. Antigravity without proven steer)
     """
+    resolved_capability = capability
+    if resolved_capability is None:
+        resolved_capability = "steerable" if steerable else "watch"
     short_link = display_host(build_short_session_url(base_url, session_id))
-    call_to_action = "Steer from anywhere" if steerable else "Watch on your timeline"
+    if resolved_capability == "steerable":
+        call_to_action = "Steer from anywhere"
+    elif resolved_capability == "registering":
+        call_to_action = "Registering with Longhouse — local Helm is up"
+    elif resolved_capability == "local_only":
+        call_to_action = "Local Helm — remote steer unavailable until Longhouse recovers"
+    else:
+        call_to_action = "Watch on your timeline"
 
     try:
         from rich.box import ROUNDED
@@ -129,17 +143,25 @@ def exit_bookend(
     machine_name: str,
     reattach_command: str | None = None,
     reattachable_on_nonzero_exit: bool = False,
+    durable: bool = True,
 ) -> None:
     """Closing bookend keyed on the real process exit code. Print-only.
 
     - clean exit                              -> the hearth is banked, thread saved
+    - clean exit, not durable                 -> local session ended (not synced)
     - crash, reattachable_on_nonzero_exit     -> the hearth still burns, rejoin it
       (codex: the bridge is left running and is reattachable, so "scattered/dead"
        would be a lie)
     - crash, otherwise                        -> the fire scattered, rekindle it
     """
     if exit_code == 0:
-        typer.secho(f"·  The hearth banked on {machine_name} — thread saved.", fg=typer.colors.BRIGHT_BLACK)
+        if durable:
+            typer.secho(f"·  The hearth banked on {machine_name} — thread saved.", fg=typer.colors.BRIGHT_BLACK)
+        else:
+            typer.secho(
+                f"·  Local Helm ended on {machine_name} — session was not synced to Longhouse.",
+                fg=typer.colors.BRIGHT_BLACK,
+            )
         return
 
     if reattachable_on_nonzero_exit:

--- a/server/zerg/cli/cursor_helm.py
+++ b/server/zerg/cli/cursor_helm.py
@@ -375,17 +375,33 @@ def _registration_worker(
 
 def _post_terminal_event(url: str, token: str, session_id: str, reason: str) -> None:
     """Best-effort: tell the Runtime Host the Helm session ended."""
-    endpoint = f"{url.rstrip('/')}/api/agents/runtime/event"
-    payload = {
+    occurred_at = _now_iso()
+    device_id = get_machine_name_label()
+    event = {
+        "runtime_key": f"{_PROVIDER}:{session_id}",
         "session_id": session_id,
         "provider": _PROVIDER,
-        "kind": "terminal",
-        "reason": reason,
-        "timestamp": _now_iso(),
+        "device_id": device_id,
+        "source": "cursor_helm",
+        "kind": "terminal_signal",
+        "phase": "finished",
+        "occurred_at": occurred_at,
+        "dedupe_key": f"cursor-helm-terminal:{session_id}:{reason}:{occurred_at}",
+        "payload": {
+            "terminal_state": "session_ended",
+            "terminal_reason": reason,
+            "terminal_source": "cursor_helm",
+            "exit_code": 0,
+        },
     }
+    endpoint = f"{url.rstrip('/')}/api/agents/runtime/events/batch"
     try:
         with httpx.Client(timeout=_TERMINAL_POST_TIMEOUT) as client:
-            client.post(endpoint, headers={"X-Agents-Token": token}, json=payload)
+            client.post(
+                endpoint,
+                headers={"X-Agents-Token": token},
+                json={"events": [event]},
+            )
     except httpx.HTTPError:
         pass
 

--- a/server/zerg/cli/cursor_helm.py
+++ b/server/zerg/cli/cursor_helm.py
@@ -92,8 +92,10 @@ _INJECT_TEXT_SETTLE_SECONDS = _env_seconds("LH_CURSOR_HELM_TEXT_SETTLE_MS", 300)
 _INJECT_ESCAPE_SETTLE_SECONDS = _env_seconds("LH_CURSOR_HELM_ESCAPE_SETTLE_MS", 100)
 _SOCKET_BACKLOG = 4
 _COMMAND_READ_TIMEOUT = 8.0
-_REGISTER_TIMEOUT = 30.0
+# Keep short so Helm exit can join an in-flight attempt without wedging for 30s.
+_REGISTER_TIMEOUT = 5.0
 _REGISTER_RETRY_DELAYS_SECONDS = (0.0, 0.5, 1.5, 3.0)
+_REGISTER_EXIT_JOIN_SECONDS = _REGISTER_TIMEOUT + 1.0
 _TERMINAL_POST_TIMEOUT = 5.0
 _PROVIDER = "cursor"
 _CONTROL_PLANE = "cursor_helm"
@@ -235,9 +237,13 @@ def _register_session(
         return _RegistrationOutcome(session_id=session_id, registered=False, error="registration timed out")
 
     if response.status_code == 401:
-        # Auth is a local enrollment problem — hard fail.
-        typer.secho("Authentication failed. Run 'longhouse auth' to re-authenticate.", fg=typer.colors.RED)
-        raise typer.Exit(code=EXIT_SETUP_FAILED)
+        # Soft-fail: Degraded Helm still runs the local TUI; do not Exit from a
+        # background registration thread (typer.Exit would not stop the launcher).
+        return _RegistrationOutcome(
+            session_id=session_id,
+            registered=False,
+            error="authentication failed; run 'longhouse auth' to re-authenticate",
+        )
     if response.status_code == 422:
         try:
             errors = response.json()
@@ -382,6 +388,34 @@ def _post_terminal_event(url: str, token: str, session_id: str, reason: str) -> 
             client.post(endpoint, headers={"X-Agents-Token": token}, json=payload)
     except httpx.HTTPError:
         pass
+
+
+def _reconcile_registration_on_exit(
+    *,
+    url: str,
+    token: str,
+    session_id: str,
+    registration_thread: threading.Thread,
+    registration_box: list[_RegistrationOutcome],
+    registration_lock: threading.Lock,
+    join_timeout: float = _REGISTER_EXIT_JOIN_SECONDS,
+) -> bool:
+    """Join registration briefly and close any host session that may exist.
+
+    Returns True when registration succeeded (durable exit copy).
+    If the outcome is still unknown after the bounded join, best-effort
+    terminalize so a late host commit cannot linger as falsely live.
+    """
+    registration_thread.join(timeout=join_timeout)
+    with registration_lock:
+        outcome = registration_box[0] if registration_box else None
+    if outcome is not None and outcome.registered:
+        _post_terminal_event(url, token, session_id, "helm_exit")
+        return True
+    if outcome is None:
+        # Abandoned / killed mid-HTTP — host may have committed after our join.
+        _post_terminal_event(url, token, session_id, "helm_exit_before_ready")
+    return False
 
 
 def _set_window_title(text: str) -> None:
@@ -892,8 +926,16 @@ def run_helm(
             pass
     finally:
         stop_event.set()
-        # Bounded: do not wait for full registration HTTP timeout on exit.
-        registration_thread.join(timeout=2.0)
+        # Bounded join covers one in-flight register attempt; unknown outcomes
+        # still get a best-effort terminalize (see _reconcile_registration_on_exit).
+        final_registered = _reconcile_registration_on_exit(
+            url=resolved_url,
+            token=resolved_token,
+            session_id=session_id,
+            registration_thread=registration_thread,
+            registration_box=registration_box,
+            registration_lock=registration_lock,
+        )
         # Let the ingest tailer flush a final poll + record its last outcome
         # before we summarize. Bounded so a hung decode can't wedge exit.
         if ingest_thread is not None:
@@ -916,10 +958,6 @@ def run_helm(
         except OSError:
             pass
         _remove_state(session_id, sock_path)
-        with registration_lock:
-            final_registered = bool(registration_box and registration_box[0].registered)
-        if final_registered:
-            _post_terminal_event(resolved_url, resolved_token, session_id, "helm_exit")
         launch_ui.exit_bookend(exit_code=exit_code, machine_name=machine_name, durable=final_registered)
         if open_browser:
             typer.echo(f"Timeline: {build_session_url(resolved_url, session_id)}")

--- a/server/zerg/cli/cursor_helm.py
+++ b/server/zerg/cli/cursor_helm.py
@@ -40,6 +40,8 @@ import termios
 import threading
 import time
 import tty
+import uuid
+from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -48,7 +50,6 @@ import httpx
 import typer
 
 from zerg.cli import _launch_ui as launch_ui
-from zerg.cli._common import ManagedLocalLaunchResponse
 from zerg.cli._common import build_session_url
 from zerg.cli._common import ensure_managed_launch_preflight
 from zerg.cli._common import git_output
@@ -92,10 +93,19 @@ _INJECT_ESCAPE_SETTLE_SECONDS = _env_seconds("LH_CURSOR_HELM_ESCAPE_SETTLE_MS", 
 _SOCKET_BACKLOG = 4
 _COMMAND_READ_TIMEOUT = 8.0
 _REGISTER_TIMEOUT = 30.0
+_REGISTER_RETRY_DELAYS_SECONDS = (0.0, 0.5, 1.5, 3.0)
 _TERMINAL_POST_TIMEOUT = 5.0
 _PROVIDER = "cursor"
 _CONTROL_PLANE = "cursor_helm"
 _STATE_PROVIDER_DIR = "cursor-helm"
+
+
+@dataclass(frozen=True)
+class _RegistrationOutcome:
+    session_id: str
+    registered: bool
+    attach_command: str = ""
+    error: str | None = None
 
 
 def _now_iso() -> str:
@@ -121,6 +131,8 @@ def _write_state(
     cursor_pid: int,
     cwd: Path,
     ready: bool,
+    registration: str = "pending",
+    registration_error: str | None = None,
 ) -> None:
     state_dir = _state_dir()
     state_dir.mkdir(parents=True, exist_ok=True)
@@ -134,6 +146,8 @@ def _write_state(
         "cursor_pid": cursor_pid,
         "cwd": str(cwd),
         "ready": ready,
+        "registration": registration,
+        "registration_error": registration_error,
         "started_at": _now_iso(),
         "updated_at": _now_iso(),
     }
@@ -186,8 +200,11 @@ def _register_session(
     loop_mode: SessionLoopMode,
     machine_name: str,
     permission_mode: str,
+    session_id: str,
     verbose: bool = False,
-) -> ManagedLocalLaunchResponse:
+) -> _RegistrationOutcome:
+    """Attempt host registration. Remote failures return degraded outcome; do not exit."""
+
     git_repo, git_branch = _infer_git_context(cwd)
     payload = {
         "cwd": str(cwd),
@@ -199,6 +216,7 @@ def _register_session(
         "loop_mode": loop_mode.value,
         "machine_name": machine_name,
         "permission_mode": permission_mode,
+        "session_id": session_id,
     }
     launch_actor, launch_surface = interactive_human_shell_launch_provenance()
     if launch_actor:
@@ -211,17 +229,13 @@ def _register_session(
     try:
         with httpx.Client(timeout=_REGISTER_TIMEOUT) as client:
             response = client.post(launch_url, headers={"X-Agents-Token": token}, json=payload)
-    except httpx.ConnectError:
-        typer.secho(f"Could not connect to {url}", fg=typer.colors.RED)
-        raise typer.Exit(code=EXIT_SETUP_FAILED)
+    except httpx.ConnectError as exc:
+        return _RegistrationOutcome(session_id=session_id, registered=False, error=f"connect failed: {exc}")
     except httpx.TimeoutException:
-        typer.secho(
-            f"Timed out waiting for Longhouse to create the managed cursor session at {url}.",
-            fg=typer.colors.RED,
-        )
-        raise typer.Exit(code=EXIT_SETUP_FAILED)
+        return _RegistrationOutcome(session_id=session_id, registered=False, error="registration timed out")
 
     if response.status_code == 401:
+        # Auth is a local enrollment problem — hard fail.
         typer.secho("Authentication failed. Run 'longhouse auth' to re-authenticate.", fg=typer.colors.RED)
         raise typer.Exit(code=EXIT_SETUP_FAILED)
     if response.status_code == 422:
@@ -229,14 +243,11 @@ def _register_session(
             errors = response.json()
         except ValueError:
             errors = response.text[:200]
-        typer.secho(
-            "Longhouse server rejected the launch request (422).\n"
-            "Your CLI likely drifted from the server schema. Update with:\n"
-            "  cd ~/git/zerg/longhouse && make dogfood-refresh\n"
-            f"Server detail: {errors}",
-            fg=typer.colors.RED,
+        return _RegistrationOutcome(
+            session_id=session_id,
+            registered=False,
+            error=f"server rejected launch (422): {errors}",
         )
-        raise typer.Exit(code=EXIT_SETUP_FAILED)
     if response.status_code != 200:
         detail = ""
         try:
@@ -244,20 +255,116 @@ def _register_session(
             detail = str(body.get("detail") or "").strip()
         except ValueError:
             detail = response.text.strip()
-        typer.secho(detail or "Longhouse session launch failed", fg=typer.colors.RED)
-        raise typer.Exit(code=EXIT_SETUP_FAILED)
+        return _RegistrationOutcome(
+            session_id=session_id,
+            registered=False,
+            error=detail or f"registration failed HTTP {response.status_code}",
+        )
 
     body = response.json()
-    raw_provider_session_id = body.get("provider_session_id")
-    provider_session_id = str(raw_provider_session_id).strip() if raw_provider_session_id else None
-    return ManagedLocalLaunchResponse(
-        session_id=str(body["session_id"]),
-        provider_session_id=provider_session_id,
-        attach_command=str(body["attach_command"]),
-        source_runner_name=str(body.get("source_runner_name") or machine_name),
-        managed_transport=str(body.get("managed_transport") or "") or None,
-        permission_mode=str(body.get("permission_mode") or "bypass"),
+    returned_id = str(body.get("session_id") or "").strip()
+    if returned_id and returned_id != session_id:
+        return _RegistrationOutcome(
+            session_id=session_id,
+            registered=False,
+            error=f"server returned different session_id {returned_id}",
+        )
+    return _RegistrationOutcome(
+        session_id=session_id,
+        registered=True,
+        attach_command=str(body.get("attach_command") or ""),
     )
+
+
+def _registration_worker(
+    *,
+    url: str,
+    token: str,
+    cwd: Path,
+    project: str | None,
+    name: str | None,
+    loop_mode: SessionLoopMode,
+    machine_name: str,
+    permission_mode: str,
+    session_id: str,
+    sock_path: Path,
+    stop_event: threading.Event,
+    outcome_box: list[_RegistrationOutcome],
+    outcome_lock: threading.Lock,
+    verbose: bool,
+) -> None:
+    last_error: str | None = None
+    for delay in _REGISTER_RETRY_DELAYS_SECONDS:
+        if stop_event.is_set():
+            return
+        if delay:
+            stop_event.wait(delay)
+            if stop_event.is_set():
+                return
+        outcome = _register_session(
+            url=url,
+            token=token,
+            cwd=cwd,
+            project=project,
+            name=name,
+            loop_mode=loop_mode,
+            machine_name=machine_name,
+            permission_mode=permission_mode,
+            session_id=session_id,
+            verbose=verbose,
+        )
+        if stop_event.is_set():
+            if outcome.registered:
+                # Host materialized after local exit — terminalize immediately.
+                _post_terminal_event(url, token, session_id, "helm_exit_before_ready")
+            return
+        if outcome.registered:
+            with outcome_lock:
+                outcome_box[:] = [outcome]
+            try:
+                current = json.loads(_state_file_path(session_id).read_text())
+                _write_state(
+                    session_id,
+                    socket_path=sock_path,
+                    cursor_pid=int(current.get("cursor_pid") or 0),
+                    cwd=cwd,
+                    ready=bool(current.get("ready")),
+                    registration="registered",
+                )
+            except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                _write_state(
+                    session_id,
+                    socket_path=sock_path,
+                    cursor_pid=0,
+                    cwd=cwd,
+                    ready=False,
+                    registration="registered",
+                )
+            return
+        last_error = outcome.error
+    with outcome_lock:
+        outcome_box[:] = [_RegistrationOutcome(session_id=session_id, registered=False, error=last_error or "registration failed")]
+    try:
+        current = json.loads(_state_file_path(session_id).read_text())
+        _write_state(
+            session_id,
+            socket_path=sock_path,
+            cursor_pid=int(current.get("cursor_pid") or 0),
+            cwd=cwd,
+            ready=bool(current.get("ready")),
+            registration="degraded",
+            registration_error=last_error,
+        )
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        _write_state(
+            session_id,
+            socket_path=sock_path,
+            cursor_pid=0,
+            cwd=cwd,
+            ready=False,
+            registration="degraded",
+            registration_error=last_error,
+        )
 
 
 def _post_terminal_event(url: str, token: str, session_id: str, reason: str) -> None:
@@ -478,30 +585,21 @@ def run_helm(
     cursor_bin = _resolve_cursor_bin()
 
     launch_ui.progress("Preparing your session…")
-    result = _register_session(
-        url=resolved_url,
-        token=resolved_token,
-        cwd=cwd,
-        project=project,
-        name=name,
-        loop_mode=loop_mode,
-        machine_name=machine_name,
-        permission_mode=permission_mode,
-        verbose=verbose,
-    )
-    session_id = result.session_id
-    if verbose:
-        typer.echo(f"Longhouse: {resolved_url}")
-        typer.echo(f"Session:   {session_id}")
-        typer.echo(f"Timeline:  {build_session_url(resolved_url, session_id)}")
-
+    session_id = str(uuid.uuid4())
     state_dir = _state_dir()
     state_dir.mkdir(parents=True, exist_ok=True)
     sock_path = _socket_path(session_id)
-    _write_state(session_id, socket_path=sock_path, cursor_pid=0, cwd=cwd, ready=False)
+    _write_state(
+        session_id,
+        socket_path=sock_path,
+        cursor_pid=0,
+        cwd=cwd,
+        ready=False,
+        registration="pending",
+    )
 
-    # Bind the control socket before forking so the engine can connect as soon
-    # as the lease is observed.
+    # Bind the control socket before forking. ready=false until the child is
+    # running so the engine does not publish a live remote-control lease early.
     try:
         if sock_path.exists():
             sock_path.unlink()
@@ -513,6 +611,56 @@ def run_helm(
         typer.secho(f"Failed to bind cursor-helm control socket: {exc}", fg=typer.colors.RED)
         _remove_state(session_id, sock_path)
         raise typer.Exit(code=EXIT_SETUP_FAILED)
+
+    stop_event = threading.Event()
+    registration_box: list[_RegistrationOutcome] = []
+    registration_lock = threading.Lock()
+    registration_thread = threading.Thread(
+        target=_registration_worker,
+        kwargs={
+            "url": resolved_url,
+            "token": resolved_token,
+            "cwd": cwd,
+            "project": project,
+            "name": name,
+            "loop_mode": loop_mode,
+            "machine_name": machine_name,
+            "permission_mode": permission_mode,
+            "session_id": session_id,
+            "sock_path": sock_path,
+            "stop_event": stop_event,
+            "outcome_box": registration_box,
+            "outcome_lock": registration_lock,
+            "verbose": verbose,
+        },
+        daemon=True,
+        name="cursor-helm-register",
+    )
+    registration_thread.start()
+    # Brief race: if registration is fast, print steerable panel; never wait
+    # for the full HTTP timeout before starting the TUI.
+    registration_thread.join(timeout=0.3)
+    with registration_lock:
+        early = registration_box[0] if registration_box else None
+    if early is not None and early.registered:
+        panel_capability = "steerable"
+        attach_command = early.attach_command or None
+    elif early is not None and not early.registered:
+        panel_capability = "local_only"
+        attach_command = None
+        typer.secho(
+            f"Warning: Longhouse registration failed ({early.error}). "
+            "Continuing local Cursor Helm; remote steer/timeline may be unavailable.",
+            fg=typer.colors.YELLOW,
+        )
+    else:
+        panel_capability = "registering"
+        attach_command = None
+
+    if verbose:
+        typer.echo(f"Longhouse: {resolved_url}")
+        typer.echo(f"Session:   {session_id}")
+        typer.echo(f"Timeline:  {build_session_url(resolved_url, session_id)}")
 
     # Ownership signal: set the terminal window title. The TUI's alternate
     # screen would clear a printed banner; the title persists.
@@ -535,18 +683,14 @@ def run_helm(
             fg=typer.colors.YELLOW,
         )
 
-    # Hearth splash: print once the control socket is bound (the steer surface
-    # is up, so the "steer from anywhere" claim is honest) and before pty.fork,
-    # so it lands on the cooked terminal before cursor-agent's alt-screen
-    # clears it. It remains in scrollback and reappears when the TUI exits.
     launch_ui.launch_panel(
         provider_label=launch_ui.PROVIDER_LABELS["cursor"],
         base_url=resolved_url,
         machine_name=machine_name,
         session_id=session_id,
         verbose=verbose,
-        steerable=True,
-        attach_command=result.attach_command or None,
+        capability=panel_capability,
+        attach_command=attach_command,
     )
 
     argv = [cursor_bin, *(cursor_args or [])]
@@ -606,11 +750,34 @@ def run_helm(
             sys.stderr.write(f"longhouse cursor: failed to exec {argv[0]}: {exc}\n")
             os._exit(127)
 
-    # Parent: own the PTY master + child pid.
-    _write_state(session_id, socket_path=sock_path, cursor_pid=pid, cwd=cwd, ready=True)
+    # Parent: own the PTY master + child pid. ready=true publishes the live lease.
+    registration_status = "pending"
+    registration_error: str | None = None
+    with registration_lock:
+        if registration_box and registration_box[0].registered:
+            registration_status = "registered"
+        elif registration_box and not registration_box[0].registered:
+            registration_status = "degraded"
+            registration_error = registration_box[0].error
+    try:
+        current = json.loads(_state_file_path(session_id).read_text())
+        if registration_status == "pending":
+            registration_status = str(current.get("registration") or "pending")
+            err = current.get("registration_error")
+            registration_error = err if isinstance(err, str) else None
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        pass
+    _write_state(
+        session_id,
+        socket_path=sock_path,
+        cursor_pid=pid,
+        cwd=cwd,
+        ready=True,
+        registration=registration_status,
+        registration_error=registration_error,
+    )
     _set_pty_size(master_fd, real_rows, real_cols)
 
-    stop_event = threading.Event()
     master_lock = threading.Lock()
 
     def _on_winch(*_args: object) -> None:
@@ -725,6 +892,8 @@ def run_helm(
             pass
     finally:
         stop_event.set()
+        # Bounded: do not wait for full registration HTTP timeout on exit.
+        registration_thread.join(timeout=2.0)
         # Let the ingest tailer flush a final poll + record its last outcome
         # before we summarize. Bounded so a hung decode can't wedge exit.
         if ingest_thread is not None:
@@ -747,8 +916,11 @@ def run_helm(
         except OSError:
             pass
         _remove_state(session_id, sock_path)
-        _post_terminal_event(resolved_url, resolved_token, session_id, "helm_exit")
-        launch_ui.exit_bookend(exit_code=exit_code, machine_name=machine_name)
+        with registration_lock:
+            final_registered = bool(registration_box and registration_box[0].registered)
+        if final_registered:
+            _post_terminal_event(resolved_url, resolved_token, session_id, "helm_exit")
+        launch_ui.exit_bookend(exit_code=exit_code, machine_name=machine_name, durable=final_registered)
         if open_browser:
             typer.echo(f"Timeline: {build_session_url(resolved_url, session_id)}")
 

--- a/server/zerg/routers/session_chat.py
+++ b/server/zerg/routers/session_chat.py
@@ -437,6 +437,13 @@ class ManagedLocalThisDeviceLaunchRequest(BaseModel):
     )
     launch_actor: str | None = Field(None, description="Positive launch actor provenance when known")
     launch_surface: str | None = Field(None, description="Launch surface provenance when known")
+    session_id: uuid.UUID | None = Field(
+        None,
+        description=(
+            "Optional client-minted session UUID for Degraded Helm. Retries and later "
+            "convergence must reuse this identity instead of minting a replacement."
+        ),
+    )
 
 
 class SessionChatError(BaseModel):
@@ -1722,6 +1729,7 @@ async def launch_managed_local_this_device(
             permission_mode=body.permission_mode,
             launch_actor=body.launch_actor,
             launch_surface=body.launch_surface,
+            session_id=body.session_id,
         )
         # Managed-local launch is user-facing and hot-path critical. Claim live
         # readiness first; the archive row converges through LiveArchiveOutbox.

--- a/server/zerg/services/managed_local_launcher.py
+++ b/server/zerg/services/managed_local_launcher.py
@@ -87,6 +87,9 @@ class ManagedLocalLaunchParams:
     permission_mode: str = "bypass"
     launch_actor: str | None = None
     launch_surface: str | None = None
+    # Optional client-minted identity for Degraded Helm: retries/convergence
+    # must reuse this UUID instead of minting a replacement session.
+    session_id: UUID | None = None
 
 
 @dataclass(frozen=True)
@@ -235,7 +238,7 @@ def build_managed_local_launch_plan(
         raise ManagedLocalLaunchError("cwd is required", status_code=400)
 
     source_name = str(getattr(runner, "name", "") or params.runner_target).strip()
-    plan_session_id = session_id or uuid4()
+    plan_session_id = session_id or params.session_id or uuid4()
     provider_session_id = _initial_provider_session_id_for_spawn(provider)
     project = _derive_project(cwd, params.project)
     display_name = (params.display_name or project).strip() or project


### PR DESCRIPTION
## Summary
- Spec + Cursor proving ground for Degraded Helm: local TUI always starts; remote steer only after live registration + ready-gated lease.
- Client-minted session_id with idempotent catalog replay (ignore started_at/expires_at).
- Soft-fail registration, honest local-only/registering terminal copy, and exit terminalization via `/api/agents/runtime/events/batch`.

## Test plan
- [x] Focused pytest: catalog replay, client-minted session_id, soft-fail register, terminalize race, launch UI local_only, runtime events/batch payload
- [x] Engine: `not_ready_is_not_live_even_with_pid_and_socket`
- [x] Hatch Terra final: approve-push

Made with [Cursor](https://cursor.com)