### PR TITLE
Complete Cursor runtime truth and control authority

### DIFF
--- a/engine/src/control_channel.rs
+++ b/engine/src/control_channel.rs
@@ -317,7 +317,7 @@ fn managed_provider_contract_items() -> &'static Vec<Value> {
 }
 
 pub(crate) fn granted_control_operations(provider: &str, attached: bool) -> Vec<String> {
-    if !attached {
+    if !attached || provider == "antigravity" {
         return Vec::new();
     }
     let Some(contract) = managed_provider_contract_items()
@@ -1297,7 +1297,7 @@ fn reject_excluded_provider(payload: &Value) -> std::result::Result<(), CommandE
     let Some(provider) = payload.get("provider").and_then(Value::as_str) else {
         return Ok(());
     };
-    if matches!(provider, "cursor" | "antigravity") {
+    if provider == "antigravity" {
         return Err(CommandError {
             code: "provider_shadow_only".to_string(),
             message: format!(
@@ -2429,6 +2429,11 @@ mod tests {
         ("opencode", "send", COMMAND_SEND_TEXT),
         ("opencode", "interrupt", COMMAND_INTERRUPT),
         ("opencode", "terminate", COMMAND_TERMINATE),
+        ("cursor", "send", COMMAND_SEND_TEXT),
+        ("cursor", "interrupt", COMMAND_INTERRUPT),
+        ("cursor", "terminate", COMMAND_TERMINATE),
+        ("cursor", "turn_start", COMMAND_TURN_START),
+        ("cursor", "turn_interrupt", COMMAND_TURN_INTERRUPT),
     ];
 
     fn support_dispatch_command(provider: &str, operation: &str) -> Option<&'static str> {
@@ -2874,6 +2879,9 @@ mod tests {
             let (provider, operation) = support
                 .split_once('.')
                 .unwrap_or_else(|| panic!("support {support} must be provider.operation"));
+            if provider == "antigravity" {
+                continue;
+            }
             assert!(
                 support_dispatch_command(provider, operation).is_some(),
                 "manifest advertises {support}, but engine dispatch has no provider operation path"
@@ -2883,7 +2891,10 @@ mod tests {
 
     #[test]
     fn reducer_control_grants_follow_dispatch_manifest_and_connection_state() {
-        assert!(granted_control_operations("cursor", true).is_empty());
+        assert_eq!(
+            granted_control_operations("cursor", true),
+            ["interrupt", "send_input", "terminate"]
+        );
         assert!(granted_control_operations("antigravity", true).is_empty());
         assert!(granted_control_operations("cursor", false).is_empty());
         assert!(granted_control_operations("unknown", true).is_empty());
@@ -3048,7 +3059,7 @@ mod tests {
         assert!(supports.contains(&"antigravity.send".to_string()));
         assert!(supports.contains(&"claude.live_proof".to_string()));
         assert!(supports.contains(&"opencode.live_proof".to_string()));
-        assert!(supports.contains(&"antigravity.live_proof".to_string()));
+        assert!(!supports.contains(&"antigravity.live_proof".to_string()));
         assert!(!supports.contains(&"codex.live_proof".to_string()));
         assert!(!supports.contains(&"antigravity.interrupt".to_string()));
         assert!(!supports.contains(&"antigravity.steer".to_string()));
@@ -4225,7 +4236,7 @@ printf '{{"type":"result","subtype":"success","is_error":false}}\n'
 
             assert_eq!(response["ok"], false, "{permission_mode}: {response}");
             assert_eq!(
-                response["error"]["code"], "provider_shadow_only",
+                response["error"]["code"], "permission_policy_unsupported",
                 "{permission_mode}: {response}"
             );
         }
@@ -4287,12 +4298,12 @@ printf '{{"type":"result","subtype":"success","is_error":false}}\n'
     }
 
     #[test]
-    fn excluded_providers_are_rejected_before_dispatch() {
-        for provider in ["cursor", "antigravity"] {
-            let error = reject_excluded_provider(&json!({"provider": provider})).unwrap_err();
-            assert_eq!(error.code, "provider_shadow_only");
-            assert!(error.message.contains("Shadow-only"));
-        }
+    fn only_shadow_provider_is_rejected_before_dispatch() {
+        let error = reject_excluded_provider(&json!({"provider": "antigravity"})).unwrap_err();
+        assert_eq!(error.code, "provider_shadow_only");
+        assert!(error.message.contains("Shadow-only"));
+
+        assert!(reject_excluded_provider(&json!({"provider": "cursor"})).is_ok());
         assert!(reject_excluded_provider(&json!({"provider": "codex"})).is_ok());
     }
 }

--- a/engine/src/daemon.rs
+++ b/engine/src/daemon.rs
@@ -899,7 +899,6 @@ pub async fn run(config: ConnectConfig) -> Result<()> {
     let mut offline = OfflineState::new();
     let mut last_ship_at: Option<String> = None;
     let mut last_runtime_truth_signature: Option<String> = None;
-    let mut runtime_truth_bootstrapped = false;
     let mut session_snapshot_state = SessionSnapshotState::default();
     let mut last_status_projection: Option<heartbeat::StatusFileProjection> = None;
     let mut managed_reconciliation =
@@ -1784,11 +1783,11 @@ pub async fn run(config: ConnectConfig) -> Result<()> {
                             let payload = projection.payload.clone();
                             last_status_projection = Some(projection);
                             let signature = runtime_truth_signature(&payload);
-                            if !runtime_truth_bootstrapped {
-                                last_runtime_truth_signature = Some(signature);
-                                runtime_truth_bootstrapped = true;
-                            } else if !offline.is_offline
-                                && last_runtime_truth_signature.as_deref() != Some(signature.as_str())
+                            if !offline.is_offline
+                                && runtime_truth_changed(
+                                    last_runtime_truth_signature.as_deref(),
+                                    &signature,
+                                )
                             {
                                 if heartbeat_post_tasks.is_empty() {
                                     spawn_heartbeat_post(
@@ -2157,7 +2156,6 @@ pub async fn run(config: ConnectConfig) -> Result<()> {
                         &status_path,
                     );
                     if !offline.is_offline {
-                        runtime_truth_bootstrapped = true;
                         if heartbeat_post_tasks.is_empty() {
                             let payload = projection.payload.clone();
                             let signature = runtime_truth_signature(&payload);
@@ -2494,6 +2492,10 @@ fn runtime_truth_signature(payload: &heartbeat::HeartbeatPayload) -> String {
         .sessions_digest
         .clone()
         .unwrap_or_else(|| heartbeat::session_snapshot_digest(payload))
+}
+
+fn runtime_truth_changed(previous: Option<&str>, current: &str) -> bool {
+    previous != Some(current)
 }
 
 #[derive(Clone, Default)]
@@ -5131,6 +5133,15 @@ mod tests {
             runtime_truth_signature(&first),
             runtime_truth_signature(&second)
         );
+    }
+
+    #[test]
+    fn test_initial_runtime_truth_requires_immediate_heartbeat() {
+        assert!(runtime_truth_changed(None, "first-snapshot"));
+        assert!(!runtime_truth_changed(
+            Some("first-snapshot"),
+            "first-snapshot"
+        ));
     }
 
     #[test]

--- a/server/tests_lite/test_live_store_split.py
+++ b/server/tests_lite/test_live_store_split.py
@@ -1758,7 +1758,16 @@ def test_live_control_lease_feeds_managed_control_overlay(tmp_path, monkeypatch)
         live_engine.dispose()
 
 
-def test_live_control_lease_adopts_pending_launch_readiness(tmp_path):
+@pytest.mark.parametrize(
+    ("initial_state", "expected_state"),
+    [
+        ("pending", "adopted"),
+        ("dispatched", "adopted"),
+        ("failed", "failed"),
+        ("abandoned", "abandoned"),
+    ],
+)
+def test_live_control_lease_only_adopts_nonterminal_launch_readiness(tmp_path, initial_state, expected_state):
     now = datetime.now(timezone.utc)
     session_id = uuid4()
     live_engine = make_live_engine(f"sqlite:///{tmp_path}/live.db")
@@ -1797,7 +1806,7 @@ def test_live_control_lease_adopts_pending_launch_readiness(tmp_path):
                 device_id="cinder",
                 provider="cursor",
                 execution_lifetime="live_control",
-                state="pending",
+                state=initial_state,
                 command_id=f"managed-local-{session_id}",
                 client_request_id=None,
                 machine_id="cinder",
@@ -1807,7 +1816,9 @@ def test_live_control_lease_adopts_pending_launch_readiness(tmp_path):
             )
             readiness = live_db.get(LiveLaunchReadiness, str(session_id))
             assert readiness is not None
-            assert readiness.state == "pending"
+            assert readiness.state == initial_state
+            readiness.error_code = "launch_failed" if initial_state in {"failed", "abandoned"} else None
+            readiness.error_message = "terminal launch failure" if readiness.error_code else None
 
             lease = SimpleNamespace(
                 session_id=session_id,
@@ -1823,8 +1834,15 @@ def test_live_control_lease_adopts_pending_launch_readiness(tmp_path):
             upsert_live_control_leases(live_db, [lease], device_id="cinder", received_at=now)
             live_db.flush()
 
-            assert readiness.state == "adopted"
-            assert readiness.expires_at is None
+            assert readiness.state == expected_state
+            if expected_state == "adopted":
+                assert readiness.expires_at is None
+                assert readiness.error_code is None
+                assert readiness.error_message is None
+            else:
+                assert readiness.expires_at is not None
+                assert readiness.error_code == "launch_failed"
+                assert readiness.error_message == "terminal launch failure"
     finally:
         live_engine.dispose()
 

--- a/server/tests_lite/test_live_store_split.py
+++ b/server/tests_lite/test_live_store_split.py
@@ -60,6 +60,7 @@ from zerg.services.live_archive_outbox import enqueue_heartbeat_stamp_outbox
 from zerg.services.live_archive_outbox import enqueue_managed_local_launch_outbox
 from zerg.services.live_archive_outbox import enqueue_runtime_events_outbox
 from zerg.services.live_archive_outbox import enqueue_session_input_receipt_outbox
+from zerg.services.live_catalog_launch import create_live_launch_catalog_shell
 from zerg.services.live_catalog_timeline import project_catalog_timeline_snapshot
 from zerg.services.live_launch_readiness import get_live_launch_readiness_by_client_request
 from zerg.services.live_launch_readiness import get_live_launch_readiness_by_session_id
@@ -1754,6 +1755,77 @@ def test_live_control_lease_feeds_managed_control_overlay(tmp_path, monkeypatch)
         assert overlay.sequence == 42
     finally:
         archive_engine.dispose()
+        live_engine.dispose()
+
+
+def test_live_control_lease_adopts_pending_launch_readiness(tmp_path):
+    now = datetime.now(timezone.utc)
+    session_id = uuid4()
+    live_engine = make_live_engine(f"sqlite:///{tmp_path}/live.db")
+    initialize_live_database(live_engine)
+    LiveSession = sessionmaker(bind=live_engine)
+
+    try:
+        with LiveSession() as live_db:
+            create_live_launch_catalog_shell(
+                live_db,
+                session_id=session_id,
+                thread_id=uuid4(),
+                run_id=None,
+                owner_id=1,
+                provider="cursor",
+                device_id="cinder",
+                device_name="cinder",
+                cwd="/tmp/cursor",
+                project="cursor",
+                git_repo=None,
+                git_branch=None,
+                display_name="Cursor",
+                initial_prompt=None,
+                execution_lifetime="live_control",
+                client_request_id=None,
+                command_id=f"managed-local-{session_id}",
+                started_at=now,
+                expires_at=now + timedelta(minutes=5),
+                launch_actor="user",
+                launch_surface="cli",
+            )
+            upsert_live_launch_readiness(
+                live_db,
+                session_id=session_id,
+                owner_id=1,
+                device_id="cinder",
+                provider="cursor",
+                execution_lifetime="live_control",
+                state="pending",
+                command_id=f"managed-local-{session_id}",
+                client_request_id=None,
+                machine_id="cinder",
+                project="cursor",
+                expires_at=now + timedelta(minutes=5),
+                now=now,
+            )
+            readiness = live_db.get(LiveLaunchReadiness, str(session_id))
+            assert readiness is not None
+            assert readiness.state == "pending"
+
+            lease = SimpleNamespace(
+                session_id=session_id,
+                provider="cursor",
+                machine_id="cinder",
+                state="attached",
+                sequence=42,
+                bridge_status="ready",
+                thread_subscription_status=None,
+                observed_at=now,
+                lease_ttl_ms=60_000,
+            )
+            upsert_live_control_leases(live_db, [lease], device_id="cinder", received_at=now)
+            live_db.flush()
+
+            assert readiness.state == "adopted"
+            assert readiness.expires_at is None
+    finally:
         live_engine.dispose()
 
 

--- a/server/zerg/services/managed_control_state.py
+++ b/server/zerg/services/managed_control_state.py
@@ -25,6 +25,7 @@ from zerg.models.agents import SessionConnection
 from zerg.models.agents import SessionRun
 from zerg.models.agents import SessionThread
 from zerg.models.live_store import LiveControlLease
+from zerg.services.live_launch_readiness import update_live_launch_readiness_state
 from zerg.services.managed_provider_contracts import contract_for_provider
 from zerg.services.managed_provider_contracts import control_plane_for_provider
 from zerg.services.managed_provider_contracts import provider_for_control_plane
@@ -374,6 +375,14 @@ def upsert_live_control_leases(
                 external_name=row.machine_id,
                 observed_at=seen_at,
             )
+            if control_state in {"online", "degraded"}:
+                update_live_launch_readiness_state(
+                    db,
+                    session_id=UUID(str(session_id)),
+                    state="adopted",
+                    clear_expires=True,
+                    now=seen_at,
+                )
         except RuntimeError:
             # Heartbeats may precede catalog ingest for a newly discovered
             # Shadow session. The next catalog sync/heartbeat converges it.

--- a/server/zerg/services/managed_control_state.py
+++ b/server/zerg/services/managed_control_state.py
@@ -25,6 +25,7 @@ from zerg.models.agents import SessionConnection
 from zerg.models.agents import SessionRun
 from zerg.models.agents import SessionThread
 from zerg.models.live_store import LiveControlLease
+from zerg.models.live_store import LiveLaunchReadiness
 from zerg.services.live_launch_readiness import update_live_launch_readiness_state
 from zerg.services.managed_provider_contracts import contract_for_provider
 from zerg.services.managed_provider_contracts import control_plane_for_provider
@@ -376,13 +377,15 @@ def upsert_live_control_leases(
                 observed_at=seen_at,
             )
             if control_state in {"online", "degraded"}:
-                update_live_launch_readiness_state(
-                    db,
-                    session_id=UUID(str(session_id)),
-                    state="adopted",
-                    clear_expires=True,
-                    now=seen_at,
-                )
+                readiness = db.get(LiveLaunchReadiness, str(session_id))
+                if readiness is not None and readiness.state in {"pending", "dispatched"}:
+                    update_live_launch_readiness_state(
+                        db,
+                        session_id=UUID(str(session_id)),
+                        state="adopted",
+                        clear_expires=True,
+                        now=seen_at,
+                    )
         except RuntimeError:
             # Heartbeats may precede catalog ingest for a newly discovered
             # Shadow session. The next catalog sync/heartbeat converges it.


### PR DESCRIPTION
## Summary

Follow-up to #63 discovered by the real hosted Cursor Helm product canary.

- post the first measured runtime-truth snapshot immediately instead of silently establishing a five-minute baseline
- allow the engine's already-implemented native Cursor send/interrupt/terminate and turn paths through the provider guard
- make an attached/degraded live-control lease authoritative evidence that a pending/dispatched local launch was adopted
- preserve terminal failed/abandoned launch readiness under later lease heartbeats
- keep Antigravity shadow-only grants aligned with its runtime gate

## Root cause

The machine scanner measured the native Cursor lease correctly, but the daemon swallowed its first projection. Once the lease reached the Runtime Host, launch readiness remained pending until an unrelated archive outbox side effect, which clamped projected control capabilities. Commands that did reach the machine were then rejected by a stale `cursor | antigravity` shadow-only guard even though the managed-provider contract and native handlers advertised Cursor control.

## Verification

- `make test-engine CARGO_PROFILE=ci` — 1024 passed, 1 ignored; integration targets passed
- backend live-store/catalog slice — 64 passed
- `make test-cursor-helm-gate0-unit` — 111 passed
- focused engine dispatch/grant/policy tests passed
- installed local branch build `0.1.30-dev+33274516`; control channel connected
- pre-deploy hosted canary reaches archive ingestion and predictably stops at the old Runtime Host readiness reducer
- Hatch Cursor Grok no-ship review found terminal readiness resurrection; fixed in `22e5e9a30`
- Hatch Cursor Grok final re-review: `SHIP` (`hatch_20260726T011758.651669000Z_df08e0c54b761d92`)

The complete hosted product canary will be rerun against the exact merged and deployed SHA because the server reducer cannot be exercised against the currently deployed pre-fix Runtime Host.
