### PR TITLE
Complete native Cursor product qualification

### DIFF
--- a/docs/specs/cursor-native-device-parity.md
+++ b/docs/specs/cursor-native-device-parity.md
@@ -1,6 +1,24 @@
 # Cursor Native Device Parity
 
-Status: shipped incomplete; native release blocked pending remediation
+Status: qualified; native release gates passed
+
+## Qualification evidence
+
+The native cutover passed on macOS with stock Cursor Agent
+`2026.07.23-e383d2b` on 2026-07-25:
+
+- Gate 0 passed create, stable native resume, new identity, workspace trust,
+  interrupt/recovery, permission allow/ask/deny, and the explicit unsupported
+  mid-turn-steer contract. Evidence:
+  `~/.longhouse/canaries/provider-live/cursor/20260726T020333Z`.
+- The installed-facade product E2E passed launch/archive, hosted idle send,
+  Machine Agent restart and hosted lease reconvergence, permission allow/deny
+  side effects, interrupt/recovery without TUI exit, terminate cleanup, and
+  terminal recovery. Evidence:
+  `~/.longhouse/canaries/provider-live/cursor-product/20260726T020203Z`.
+- The hermetic Gate 0 unit slice passed 111 tests. Native hook integration also
+  covers concurrent lifecycle hook writes so one Cursor generation cannot
+  corrupt another generation's evidence.
 
 ## Problem
 

--- a/docs/specs/cursor-native-device-parity.md
+++ b/docs/specs/cursor-native-device-parity.md
@@ -26,8 +26,8 @@ PR #62 exposed `cursor` on the installed native `longhouse` facade, while the
 Runtime Host already emitted `longhouse cursor --resume-session <id>` for
 managed Cursor Helm sessions. The initial port did not preserve the qualified
 Python launch, identity, permission, hook, terminal, and test contracts. Python
-is deliberately absent from the installed device product, so native Cursor must
-remain release-blocked until this document's remediation gates pass.
+is deliberately absent from the installed device product, so native Cursor was
+release-blocked until the remediation and qualification recorded here passed.
 
 ## Product contract
 
@@ -93,7 +93,7 @@ commands (`longhouse-engine cursor-helm send|interrupt|stop`) remain the single
 control implementation for the first slice; façade aliases are not required.
 No public Cursor command may fall back to Python or `uv`.
 
-## Delivery plan
+## Delivery plan (completed)
 
 1. Document the exact on-disk state/phase fields and socket request/reply wire
    schema shared by `cursor_helm.py` and `cursor_helm_control.rs`; native
@@ -125,8 +125,9 @@ No public Cursor command may fall back to Python or `uv`.
 ## Native cutover remediation
 
 PR #62 exposed the native command but did not preserve the complete Python
-launcher and hook contracts. The native entrypoint remains unavailable for
-release until every item below is implemented and proved.
+launcher and hook contracts. The follow-up restored and proved every
+release-blocking item below before returning the native entrypoint to
+`available`.
 
 ### 1. Fail-closed permission authority
 

--- a/engine/src/cursor_hooks.rs
+++ b/engine/src/cursor_hooks.rs
@@ -91,7 +91,9 @@ fn atomic_write(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
     std::fs::create_dir_all(parent)?;
     let temporary = parent.join(format!(
         ".{}.{}.tmp",
-        path.file_name().and_then(|value| value.to_str()).unwrap_or("cursor-hook"),
+        path.file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("cursor-hook"),
         Uuid::new_v4()
     ));
     std::fs::write(&temporary, bytes)?;
@@ -105,6 +107,17 @@ fn atomic_write(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
 fn write(path: PathBuf, value: &Value) -> bool {
     atomic_write(&path, value.to_string().as_bytes()).is_ok()
 }
+
+fn append_json_line(path: &std::path::Path, value: &Value) -> std::io::Result<()> {
+    let mut line = serde_json::to_vec(value).map_err(std::io::Error::other)?;
+    line.push(b'\n');
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    file.write_all(&line)
+}
+
 pub fn lifecycle(event: &str) {
     let Ok(payload) = input() else {
         println!("{{}}");
@@ -174,17 +187,10 @@ pub fn lifecycle(event: &str) {
     if let Some(parent) = event_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    if let Ok(mut file) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(event_path)
-    {
-        let _ = writeln!(
-            file,
-            "{}",
-            json!({"event":event,"observed_at":now,"session_id":session_id,"conversation_id":conversation,"payload":payload})
-        );
-    }
+    let _ = append_json_line(
+        &event_path,
+        &json!({"event":event,"observed_at":now,"session_id":session_id,"conversation_id":conversation,"payload":payload}),
+    );
     if let Some(phase) = phase {
         let _ = write(
             root.join(format!("{session_id}.phase.json")),

--- a/engine/src/cursor_visibility.rs
+++ b/engine/src/cursor_visibility.rs
@@ -222,9 +222,7 @@ pub(crate) fn parse_cursor_visibility_evidence(
                     .and_then(|payload| payload.get("status"))
                     .and_then(Value::as_str)
                     .map(str::to_owned);
-                if let (Some(existing), Some(next)) = (&turn.stop_status, &stop_status) {
-                    ambiguous |= existing != next;
-                } else if turn.stop_status.is_none() {
+                if stop_status.is_some() {
                     turn.stop_status = stop_status;
                     turn.stop_observed_at = row
                         .get("observed_at")
@@ -309,6 +307,24 @@ mod tests {
             "conversation",
         )
         .unwrap();
+        assert_eq!(evidence.unsettled_reason(), None);
+    }
+
+    #[test]
+    fn interrupt_stop_transition_does_not_hide_a_later_recovery() {
+        let evidence = parse_cursor_visibility_evidence(
+            r#"{"event":"beforeSubmitPrompt","conversation_id":"conversation","payload":{"generation_id":"g1","prompt":"sleep"}}
+{"event":"stop","observed_at":"2026-07-21T12:00:00Z","conversation_id":"conversation","payload":{"generation_id":"g1","status":"aborted"}}
+{"event":"stop","observed_at":"2026-07-21T12:00:01Z","conversation_id":"conversation","payload":{"generation_id":"g1","status":"error"}}
+{"event":"beforeSubmitPrompt","conversation_id":"conversation","payload":{"generation_id":"g2","prompt":"recover"}}
+{"event":"afterAgentResponse","conversation_id":"conversation","payload":{"generation_id":"g2","text":"done"}}
+{"event":"stop","conversation_id":"conversation","payload":{"generation_id":"g2","status":"completed"}}"#,
+            "conversation",
+        )
+        .unwrap();
+        assert!(!evidence.ambiguous);
+        assert_eq!(evidence.turns[0].stop_status.as_deref(), Some("error"));
+        assert_eq!(evidence.turns[1].response_text.as_deref(), Some("done"));
         assert_eq!(evidence.unsettled_reason(), None);
     }
 

--- a/engine/src/daemon.rs
+++ b/engine/src/daemon.rs
@@ -1140,7 +1140,11 @@ pub async fn run(config: ConnectConfig) -> Result<()> {
                                         discovery_tasks.is_empty(),
                                     );
                                 }
-                                if previous_inventory_generation != Some(snapshot.generation) {
+                                if inventory_change_requires_projection(
+                                    previous_inventory_generation,
+                                    snapshot.generation,
+                                    last_unmanaged_session_bindings.is_some(),
+                                ) {
                                     projection_generation = projection_generation.saturating_add(1);
                                     let input = ProjectionBuildInput {
                                         generation: projection_generation,
@@ -2496,6 +2500,14 @@ fn runtime_truth_signature(payload: &heartbeat::HeartbeatPayload) -> String {
 
 fn runtime_truth_changed(previous: Option<&str>, current: &str) -> bool {
     previous != Some(current)
+}
+
+fn inventory_change_requires_projection(
+    previous_generation: Option<u64>,
+    current_generation: u64,
+    managed_pair_ready: bool,
+) -> bool {
+    managed_pair_ready && previous_generation != Some(current_generation)
 }
 
 #[derive(Clone, Default)]
@@ -5142,6 +5154,14 @@ mod tests {
             Some("first-snapshot"),
             "first-snapshot"
         ));
+    }
+
+    #[test]
+    fn test_startup_inventory_waits_for_managed_projection_pair() {
+        assert!(!inventory_change_requires_projection(None, 1, false));
+        assert!(inventory_change_requires_projection(None, 1, true));
+        assert!(!inventory_change_requires_projection(Some(1), 1, true));
+        assert!(inventory_change_requires_projection(Some(1), 2, true));
     }
 
     #[test]

--- a/engine/tests/cursor_native_hooks.rs
+++ b/engine/tests/cursor_native_hooks.rs
@@ -429,6 +429,61 @@ fn lifecycle_promotes_only_registered_claim_and_emits_presence() {
 }
 
 #[test]
+fn concurrent_lifecycle_hooks_append_complete_ndjson_records() {
+    let root = tempdir().unwrap();
+    let claim = pending_claim(root.path());
+    let mut value: Value = serde_json::from_slice(&fs::read(&claim).unwrap()).unwrap();
+    value["status"] = json!("observed");
+    fs::write(&claim, serde_json::to_vec(&value).unwrap()).unwrap();
+
+    let mut children = Vec::new();
+    for index in 0..32 {
+        let event = if index % 2 == 0 {
+            "stop"
+        } else {
+            "afterAgentResponse"
+        };
+        let payload = serde_json::to_vec(&json!({
+            "conversation_id": "cursor-id",
+            "generation_id": format!("turn-{index}"),
+            "text": "x".repeat(16 * 1024),
+        }))
+        .unwrap();
+        let mut child = Command::new(engine())
+            .args(["cursor-lifecycle-hook", event])
+            .env("LONGHOUSE_HOME", root.path())
+            .env("CURSOR_HOME", root.path().join("cursor"))
+            .env("LONGHOUSE_SESSION_ID", "managed-session")
+            .env("LONGHOUSE_CURSOR_LAUNCH_ID", "launch-id")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .spawn()
+            .unwrap();
+        child.stdin.take().unwrap().write_all(&payload).unwrap();
+        children.push(child);
+    }
+    for mut child in children {
+        assert!(child.wait().unwrap().success());
+    }
+
+    let events = fs::read_to_string(
+        root.path()
+            .join("managed-local/cursor-helm/hook-events/managed-session.ndjson"),
+    )
+    .unwrap();
+    let rows = events
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(rows.len(), 32);
+    let generation_ids = rows
+        .iter()
+        .map(|row| row["payload"]["generation_id"].as_str().unwrap())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(generation_ids.len(), 32);
+}
+
+#[test]
 fn terminal_hook_wakes_the_exact_cursor_store() {
     let root = tempdir().unwrap();
     let cursor = root.path().join("cursor");
@@ -446,9 +501,6 @@ fn terminal_hook_wakes_the_exact_cursor_store() {
     listener.set_nonblocking(false).unwrap();
     let receiver = thread::spawn(move || {
         let (mut stream, _) = listener.accept().unwrap();
-        stream
-            .set_read_timeout(Some(Duration::from_secs(2)))
-            .unwrap();
         let mut raw = Vec::new();
         stream.read_to_end(&mut raw).unwrap();
         serde_json::from_slice::<Value>(&raw).unwrap()

--- a/server/tests_lite/test_live_catalog_control.py
+++ b/server/tests_lite/test_live_catalog_control.py
@@ -15,6 +15,7 @@ os.environ.setdefault("TESTING", "1")
 os.environ.setdefault("FERNET_SECRET", Fernet.generate_key().decode())
 
 import zerg.database as database_module
+from zerg.catalogd.client import CatalogUnavailable
 from zerg.catalogd.fact_reducer import ReducerFact
 from zerg.catalogd.fact_reducer import canonical_evidence_hash
 from zerg.catalogd.fact_reducer import reduce_fact_batch
@@ -505,5 +506,68 @@ async def test_catalog_lock_timeout_releases_and_attempts_queue_recovery(tmp_pat
         dispatched_at=datetime.now(timezone.utc),
     )
 
+    assert await session_lock_manager.get_lock_info(scope) is None
+    assert wakes == [str(session_id)]
+
+
+@pytest.mark.asyncio
+async def test_catalog_lock_watcher_survives_transient_catalog_timeout(tmp_path, monkeypatch):
+    engine = make_live_engine(f"sqlite:///{tmp_path / 'live.db'}")
+    initialize_live_database(engine)
+    factory = make_sessionmaker(engine)
+    with factory() as db:
+        session_id = _seed_live_control(db)
+
+    import zerg.services.live_control_catalog as live_control
+    import zerg.services.session_chat_impl as chat_impl
+    from zerg.services.session_kernel_projection import session_lock_scope_id
+    from zerg.services.session_locks import session_lock_manager
+
+    request_id = "transient-timeout-holder"
+    scope = session_lock_scope_id(session_id)
+    dispatched_at = datetime.now(timezone.utc)
+    observed_at = dispatched_at + timedelta(milliseconds=1)
+    assert await session_lock_manager.acquire(session_id=scope, holder=request_id, ttl_seconds=300)
+
+    class _CatalogClient:
+        calls = 0
+
+        async def call(self, method, params, **_kwargs):
+            assert method == "session.read.v2"
+            assert params == {"session_id": str(session_id)}
+            self.calls += 1
+            if self.calls == 1:
+                raise CatalogUnavailable("transient deadline")
+            return {
+                "facts": {
+                    "runtime": {
+                        "phase": "idle",
+                        "phase_started_at": observed_at.isoformat(),
+                    }
+                }
+            }
+
+    catalog = _CatalogClient()
+    wakes: list[str] = []
+
+    async def fake_wake(value):
+        wakes.append(str(value))
+        return False
+
+    async def no_wait(_seconds):
+        return None
+
+    monkeypatch.setattr("zerg.services.catalogd_supervisor.get_catalogd_client", lambda: catalog)
+    monkeypatch.setattr(chat_impl.asyncio, "sleep", no_wait)
+    monkeypatch.setattr(live_control, "wake_next_live_catalog_input", fake_wake)
+
+    await chat_impl._release_catalog_lock_after_terminal(
+        session_id=session_id,
+        lock_scope_id=scope,
+        request_id=request_id,
+        dispatched_at=dispatched_at,
+    )
+
+    assert catalog.calls == 2
     assert await session_lock_manager.get_lock_info(scope) is None
     assert wakes == [str(session_id)]

--- a/server/zerg/config/managed_provider_contracts.json
+++ b/server/zerg/config/managed_provider_contracts.json
@@ -1020,7 +1020,7 @@
         "cursor.turn_start",
         "cursor.turn_interrupt"
       ],
-      "adapter_digest": "63d36cc8917d9e0f274a2a31a721ac199684009e892ceda99198e857d56d32d4"
+      "adapter_digest": "d9f61dbcfe9a2d1dac23afb06ee28e279990742f03d6074d6afedcdd1bdfecb0"
     }
   ]
 }

--- a/server/zerg/qa/cursor_helm_product_e2e.py
+++ b/server/zerg/qa/cursor_helm_product_e2e.py
@@ -359,6 +359,14 @@ def run_product_e2e(args: argparse.Namespace) -> dict[str, Any]:
             machine_agent_restart = _restart_machine_agent(status_path, timeout=args.timeout)
             if session.process.poll() is not None:
                 raise RuntimeError("Cursor TUI exited during Machine Agent restart")
+            _wait_until(
+                lambda: (payload if _can_send_live(payload) else None)
+                if (payload := api_get(f"/api/agents/sessions/{session_id}"))
+                else None,
+                timeout=args.timeout,
+                description="Cursor live-control lease after Machine Agent restart",
+            )
+            machine_agent_restart["server_control_status"] = "connected"
             send_live(f"Reply with exactly {restart_marker}")
             _wait_until(
                 lambda: (payload if restart_marker in _assistant_texts(payload) else None) if (payload := hosted_events()) else None,

--- a/server/zerg/services/session_chat_impl.py
+++ b/server/zerg/services/session_chat_impl.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 
 import zerg.database as database_module
 import zerg.services.live_session_dispatch as live_session_dispatch
+from zerg.catalogd.client import CatalogUnavailable
 from zerg.metrics import managed_turn_dispatch_seconds
 from zerg.metrics import managed_turn_phase_seconds
 from zerg.metrics import managed_turn_requests_total
@@ -1217,11 +1218,15 @@ async def _release_catalog_lock_after_terminal(
         return
     deadline = asyncio.get_running_loop().time() + MANAGED_LOCAL_LOCK_RELEASE_TIMEOUT_SECS
     while asyncio.get_running_loop().time() < deadline:
-        snapshot = await catalogd.call(
-            "session.read.v2",
-            {"session_id": str(session_id)},
-            timeout_seconds=1.0,
-        )
+        try:
+            snapshot = await catalogd.call(
+                "session.read.v2",
+                {"session_id": str(session_id)},
+                timeout_seconds=1.0,
+            )
+        except CatalogUnavailable:
+            await asyncio.sleep(MANAGED_LOCAL_POLL_INTERVAL_SECS)
+            continue
         facts = snapshot.get("facts")
         state = facts.get("runtime") if isinstance(facts, dict) else None
         if isinstance(state, dict):


### PR DESCRIPTION
## Summary

- serialize concurrent native Cursor lifecycle-hook records and preserve recovery visibility after interrupt status transitions
- defer startup projection until managed truth is paired, and wait for hosted control lease convergence after Machine Agent restart
- keep catalog lock release alive through transient catalog timeouts
- refresh the managed-provider digest and record completed native Cursor qualification

## Verification

- `make test-cursor-helm-product-e2e` — passed; artifact `~/.longhouse/canaries/provider-live/cursor-product/20260726T020203Z`
- `make test-cursor-helm-gate0` — passed; artifact `~/.longhouse/canaries/provider-live/cursor/20260726T020333Z`
- `make test-cursor-helm-gate0-unit` — 111 passed
- `make test-engine CARGO_PROFILE=ci` — 1027 engine tests passed, one intentional token-spending test ignored; selected integration suites passed
- Hatch Cursor Grok full review found no runtime blocker and one documentation contradiction; fixed in `9d3eb29eb`. Two narrow confirmation runs emitted `SHIP` before the Cursor stream adapter closed and were retained as failed transport artifacts.