### PR TITLE
Verify Cursor canary restart after launchctl timeout

### DIFF
--- a/server/tests_lite/test_cursor_helm_product_e2e.py
+++ b/server/tests_lite/test_cursor_helm_product_e2e.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 
 import httpx
 
@@ -11,6 +12,26 @@ from zerg.qa.cursor_helm_product_e2e import _pending_pause
 from zerg.qa.cursor_helm_product_e2e import _response_observed_at
 from zerg.qa.cursor_helm_product_e2e import _session_locked
 from zerg.qa.cursor_helm_product_e2e import _state_ids
+
+
+def test_machine_agent_restart_uses_reconnected_status_after_kickstart_timeout(tmp_path, monkeypatch) -> None:
+    from zerg.qa import cursor_helm_product_e2e as product_e2e
+
+    status_path = tmp_path / "engine-status.json"
+    status_path.write_text(json.dumps({"daemon_pid": 101, "control_channel": {"status": "connected"}}))
+
+    def timed_out_kickstart(*_args, **_kwargs):
+        status_path.write_text(json.dumps({"daemon_pid": 202, "control_channel": {"status": "connected"}}))
+        raise subprocess.TimeoutExpired(cmd="launchctl kickstart", timeout=15)
+
+    monkeypatch.setattr(product_e2e.subprocess, "run", timed_out_kickstart)
+
+    assert product_e2e._restart_machine_agent(status_path, timeout=0.1) == {
+        "old_pid": 101,
+        "new_pid": 202,
+        "control_status": "connected",
+        "kickstart_timed_out": True,
+    }
 
 
 def test_product_e2e_helpers_parse_managed_state_hooks_and_visible_events(tmp_path) -> None:

--- a/server/tests_lite/test_cursor_helm_product_e2e.py
+++ b/server/tests_lite/test_cursor_helm_product_e2e.py
@@ -24,6 +24,7 @@ def test_machine_agent_restart_uses_reconnected_status_after_kickstart_timeout(t
         status_path.write_text(json.dumps({"daemon_pid": 202, "control_channel": {"status": "connected"}}))
         raise subprocess.TimeoutExpired(cmd="launchctl kickstart", timeout=15)
 
+    monkeypatch.setattr(product_e2e.sys, "platform", "darwin")
     monkeypatch.setattr(product_e2e.subprocess, "run", timed_out_kickstart)
 
     assert product_e2e._restart_machine_agent(status_path, timeout=0.1) == {

--- a/server/zerg/qa/cursor_helm_product_e2e.py
+++ b/server/zerg/qa/cursor_helm_product_e2e.py
@@ -165,15 +165,23 @@ def _restart_machine_agent(status_path: Path, *, timeout: float) -> dict[str, An
     except (OSError, ValueError) as exc:
         raise RuntimeError(f"Machine Agent status unavailable at {status_path}") from exc
     old_pid = int(before.get("daemon_pid") or 0)
-    result = subprocess.run(
-        ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/com.longhouse.shipper"],
-        text=True,
-        capture_output=True,
-        timeout=15,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError((result.stderr or result.stdout or "Machine Agent restart failed").strip())
+    kickstart_timed_out = False
+    try:
+        result = subprocess.run(
+            ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/com.longhouse.shipper"],
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        # launchctl can wait after launchd has already replaced the process.
+        # The status PID and hosted control reconnect below are the product
+        # outcome; keep waiting for them instead of trusting the client lifetime.
+        kickstart_timed_out = True
+    else:
+        if result.returncode != 0:
+            raise RuntimeError((result.stderr or result.stdout or "Machine Agent restart failed").strip())
 
     def reconnected() -> dict[str, Any] | None:
         try:
@@ -187,7 +195,12 @@ def _restart_machine_agent(status_path: Path, *, timeout: float) -> dict[str, An
         return None
 
     current = _wait_until(reconnected, timeout=timeout, description="Machine Agent restart and control reconnect")
-    return {"old_pid": old_pid, "new_pid": int(current["daemon_pid"]), "control_status": "connected"}
+    return {
+        "old_pid": old_pid,
+        "new_pid": int(current["daemon_pid"]),
+        "control_status": "connected",
+        "kickstart_timed_out": kickstart_timed_out,
+    }
 
 
 def _can_send_live(payload: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary

- treat a timed-out `launchctl kickstart -k` client as indeterminate rather than failed
- still require a changed Machine Agent PID and a reconnected control channel within the existing bounded wait
- retain hard failure for nonzero launchctl exits
- exercise the Darwin path under Linux CI

## Verification

- focused product-E2E helper tests: 2 passed
- exact merged/deployed `bc64a7c8f2` product E2E passed: `~/.longhouse/canaries/provider-live/cursor-product/20260726T022956Z`
- Hatch Cursor Grok found the missing Linux platform simulation; fixed in `7d607ab60`, disposition review emitted `SHIP` before the known Cursor stream-close transport error.