### PR TITLE
Fix Console dispatch truth and reconnect recovery

### DIFF
--- a/engine/src/claude_print.rs
+++ b/engine/src/claude_print.rs
@@ -883,7 +883,7 @@ fn claude_provider_home() -> Result<PathBuf> {
     Ok(PathBuf::from(std::env::var("HOME").context("HOME not set")?).join(".claude"))
 }
 
-fn require_claude_lifecycle_hook() -> Result<()> {
+pub(crate) fn require_claude_lifecycle_hook() -> Result<()> {
     require_claude_lifecycle_hook_at(&claude_provider_home()?)
 }
 
@@ -914,7 +914,7 @@ fn require_claude_lifecycle_hook_at(provider_home: &Path) -> Result<()> {
     });
     if !registered {
         anyhow::bail!(
-            "Claude Console requires the Longhouse SessionStart hook in {}; run `longhouse machine repair`",
+            "Claude Console requires the Longhouse SessionStart hook in {}; run `longhouse claude configure`",
             settings_path.display()
         );
     }

--- a/engine/src/control_channel.rs
+++ b/engine/src/control_channel.rs
@@ -455,6 +455,7 @@ fn provider_binary_available(
 fn control_supports_for_path_with_env(
     path_value: Option<&OsStr>,
     env_lookup: &dyn Fn(&str) -> Option<OsString>,
+    claude_turn_start_ready: bool,
 ) -> Vec<String> {
     let mut supports = Vec::new();
     supports.push(COMMAND_ARCHIVE_BACKLOG_CONTROL.to_string());
@@ -475,7 +476,13 @@ fn control_supports_for_path_with_env(
             .get("machine_control_supports")
             .and_then(Value::as_array)
         {
-            supports.extend(items.iter().filter_map(Value::as_str).map(str::to_string));
+            supports.extend(
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .filter(|support| *support != "claude.turn_start" || claude_turn_start_ready)
+                    .map(str::to_string),
+            );
         }
         if longhouse_available {
             if let Some(provider) = contract.get("provider").and_then(Value::as_str) {
@@ -493,7 +500,11 @@ fn provider_live_proof_supported_provider(provider: &str) -> bool {
 }
 
 fn control_supports_for_path(path_value: Option<&OsStr>) -> Vec<String> {
-    control_supports_for_path_with_env(path_value, &|name| std::env::var_os(name))
+    control_supports_for_path_with_env(
+        path_value,
+        &|name| std::env::var_os(name),
+        crate::claude_print::require_claude_lifecycle_hook().is_ok(),
+    )
 }
 
 fn control_supports() -> Vec<String> {
@@ -843,7 +854,15 @@ async fn handle_command_frame(
             "ok": true,
             "result": result,
         }),
-        Err(CommandError { code, message }) => command_error(&command_id, &code, &message),
+        Err(CommandError { code, message }) => {
+            tracing::warn!(
+                command_id = %command_id,
+                error_code = %code,
+                error_message = %message,
+                "Machine control command failed"
+            );
+            command_error(&command_id, &code, &message)
+        }
     };
     completed_commands.insert(command_id, response.clone());
     response
@@ -1394,6 +1413,12 @@ async fn execute_turn_start(
             message: "Cursor Console currently supports auto_approve permission policy only"
                 .to_string(),
         });
+    }
+    if provider == "claude" {
+        crate::claude_print::require_claude_lifecycle_hook().map_err(|error| CommandError {
+            code: "claude_lifecycle_hook_missing".to_string(),
+            message: error.to_string(),
+        })?;
     }
     let launch_actor = payload_optional_string(payload, "launch_actor");
     let launch_surface = payload_optional_string(payload, "launch_surface");
@@ -2975,7 +3000,7 @@ mod tests {
         }
 
         write_executable(&dir, "opencode");
-        let supports = control_supports_for_path_with_env(Some(dir.as_os_str()), &|_| None);
+        let supports = control_supports_for_path_with_env(Some(dir.as_os_str()), &|_| None, true);
         assert_eq!(
             supports,
             vec![
@@ -2990,7 +3015,7 @@ mod tests {
         );
 
         write_executable(&dir, "longhouse");
-        let supports = control_supports_for_path_with_env(Some(dir.as_os_str()), &|_| None);
+        let supports = control_supports_for_path_with_env(Some(dir.as_os_str()), &|_| None, true);
         assert_eq!(
             supports,
             vec![
@@ -3006,13 +3031,17 @@ mod tests {
         );
 
         write_executable(&dir, "custom-codex");
-        let supports = control_supports_for_path_with_env(Some(dir.as_os_str()), &|name| {
-            if name == "LONGHOUSE_CODEX_BIN" {
-                Some(dir.join("custom-codex").into_os_string())
-            } else {
-                None
-            }
-        });
+        let supports = control_supports_for_path_with_env(
+            Some(dir.as_os_str()),
+            &|name| {
+                if name == "LONGHOUSE_CODEX_BIN" {
+                    Some(dir.join("custom-codex").into_os_string())
+                } else {
+                    None
+                }
+            },
+            true,
+        );
         assert!(!supports.contains(&"codex.launch".to_string()));
         assert!(!supports.contains(&"codex.continue".to_string()));
         assert!(supports.contains(&"codex.run_once".to_string()));
@@ -3024,7 +3053,7 @@ mod tests {
         write_executable(&dir, "claude");
         write_executable(&dir, "agy");
         write_executable(&dir, "cursor-agent");
-        let supports = control_supports_for_path_with_env(Some(dir.as_os_str()), &|_| None);
+        let supports = control_supports_for_path_with_env(Some(dir.as_os_str()), &|_| None, true);
         let mut expected = vec![
             "archive.backlog_control".to_string(),
             "archive.backlog_control.v2".to_string(),
@@ -3053,6 +3082,12 @@ mod tests {
         assert!(!supports.contains(&"claude.launch".to_string()));
         assert!(!supports.contains(&"claude.continue".to_string()));
         assert!(supports.contains(&"claude.send".to_string()));
+        assert!(supports.contains(&"claude.turn_start".to_string()));
+
+        let not_ready = control_supports_for_path_with_env(Some(dir.as_os_str()), &|_| None, false);
+        assert!(not_ready.contains(&"claude.send".to_string()));
+        assert!(not_ready.contains(&"claude.turn_interrupt".to_string()));
+        assert!(!not_ready.contains(&"claude.turn_start".to_string()));
         assert!(!supports.contains(&"opencode.launch".to_string()));
         assert!(supports.contains(&"opencode.terminate".to_string()));
         assert!(supports.contains(&"opencode.turn_start".to_string()));

--- a/scripts/ops/hosted-session-debug.sh
+++ b/scripts/ops/hosted-session-debug.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HOSTED_INSTANCE_HELPER="${HOSTED_INSTANCE_HELPER:-$ROOT_DIR/scripts/lib/hosted-instance.sh}"
-SSH_TARGET="${HOSTED_SESSION_DEBUG_SSH_TARGET:-runtime-host}"
+SSH_TARGET="${HOSTED_SESSION_DEBUG_SSH_TARGET:-zerg}"
 
 if [[ ! -f "$HOSTED_INSTANCE_HELPER" ]]; then
   echo "Hosted instance helper missing: $HOSTED_INSTANCE_HELPER" >&2
@@ -33,7 +33,7 @@ What it does:
 
 Requirements:
   - CONTROL_PLANE_ADMIN_TOKEN (or ADMIN_TOKEN)
-  - SSH access to host alias "runtime-host" (override with HOSTED_SESSION_DEBUG_SSH_TARGET)
+  - SSH access to host alias "zerg" (override with HOSTED_SESSION_DEBUG_SSH_TARGET)
 
 Options:
   --subdomain <name>   Hosted instance subdomain (default: $LONGHOUSE_DEFAULT_SUBDOMAIN or demo)

--- a/server/tests_lite/test_agents_control.py
+++ b/server/tests_lite/test_agents_control.py
@@ -6,11 +6,29 @@ os.environ.setdefault("DATABASE_URL", "sqlite://")
 os.environ.setdefault("TESTING", "1")
 
 from zerg.routers.agents_control import CONTROL_HEARTBEAT_TIMEOUT_SECS
+from zerg.routers.agents_control import _reconcile_console_turns_after_register
 from zerg.routers.agents_control import _reconcile_machine_control_operation_result
 
 
 def test_control_heartbeat_timeout_is_a_watchdog_not_a_stale_socket_lease():
     assert 30 <= CONTROL_HEARTBEAT_TIMEOUT_SECS <= 120
+
+
+@pytest.mark.asyncio
+async def test_control_register_reconciles_starting_console_turns(monkeypatch):
+    calls = []
+
+    async def fake_reconcile(db, *, owner_id, device_id, registry):
+        calls.append((db, owner_id, device_id, registry))
+        return []
+
+    registry = object()
+    monkeypatch.setattr("zerg.routers.agents_control.database_module.live_catalog_enabled", lambda: True)
+    monkeypatch.setattr("zerg.routers.agents_control.reconcile_starting_console_turns_for_device", fake_reconcile)
+
+    await _reconcile_console_turns_after_register(owner_id=7, device_id="cube", registry=registry)
+
+    assert calls == [(None, 7, "cube", registry)]
 
 
 @pytest.mark.asyncio
@@ -44,6 +62,7 @@ async def test_machine_control_result_reconcile_uses_write_serializer(monkeypatc
         ("execute", "machine-control-result", "fallback-db", False),
         ("reconcile", "serializer-db", "machine-op:test", 7, "cinder"),
     ]
+
 
 @pytest.mark.asyncio
 async def test_machine_control_result_reconcile_prefers_live_serializer(monkeypatch):

--- a/server/tests_lite/test_catalogd_console_sessions.py
+++ b/server/tests_lite/test_catalogd_console_sessions.py
@@ -11,7 +11,9 @@ from zerg.catalogd.schema import create_catalog_engine
 from zerg.catalogd.schema import initialize_catalog_schema
 from zerg.catalogd.store import CatalogStore
 from zerg.models.live_store import LiveArchiveOutbox
+from zerg.models.live_store import LiveConsoleTurn
 from zerg.models.live_store import LiveSessionCatalog
+from zerg.models.live_store import LiveSessionInputReceipt
 from zerg.models.live_store import LiveSessionLaunchAttempt
 from zerg.models.live_store import LiveSessionRun
 from zerg.models.live_store import LiveSessionThread
@@ -222,6 +224,27 @@ def test_catalog_console_turns_claim_and_wake_fifo(tmp_path):
     assert settled["next_turn"]["state"] == "starting"
     assert settled["next_turn"]["run_id"]
     assert settled["next_turn"]["resume_provider_thread_id"] == provider_thread_id
+
+    failed = store.update_console_turn(
+        data={
+            "turn_id": settled["next_turn"]["turn_id"],
+            "run_id": settled["next_turn"]["run_id"],
+            "state": "failed",
+            "error_code": "claude_lifecycle_hook_missing",
+            "error": "run `longhouse claude configure`",
+            "updated_at": datetime.now(UTC),
+        }
+    )
+    assert failed["turn"]["state"] == "failed"
+    with Session(engine) as db:
+        failed_turn = db.get(LiveConsoleTurn, settled["next_turn"]["turn_id"])
+        failed_run = db.get(LiveSessionRun, settled["next_turn"]["run_id"])
+        receipt = db.get(LiveSessionInputReceipt, failed_turn.receipt_id)
+        assert failed_run.exit_status == "claude_lifecycle_hook_missing"
+        assert json.loads(receipt.error_json) == {
+            "code": "claude_lifecycle_hook_missing",
+            "message": "run `longhouse claude configure`",
+        }
 
 
 @pytest.mark.asyncio

--- a/server/tests_lite/test_catalogd_console_sessions.py
+++ b/server/tests_lite/test_catalogd_console_sessions.py
@@ -179,21 +179,50 @@ def test_catalog_console_turns_claim_and_wake_fifo(tmp_path):
     assert second["turn"]["state"] == "queued"
     assert second["turn"]["run_id"] is None
     assert second["turn"]["client_request_id"] == "request-2"
+    starting = store.list_starting_console_turns_for_device(owner_id=1, device_id="cinder")
+    assert [turn["run_id"] for turn in starting["turns"]] == [first["turn"]["run_id"]]
+    assert store.list_starting_console_turns_for_device(owner_id=42, device_id="cinder")["turns"] == []
+    assert store.list_starting_console_turns_for_device(owner_id=1, device_id="cube")["turns"] == []
     current = store.read_current_console_turn(session_id=str(session_id), owner_id=1)
     assert current["found"] is True
     assert current["turn"]["turn_id"] == first["turn"]["turn_id"]
     assert store.read_current_console_turn(session_id=str(session_id), owner_id=42) == {"found": False}
     facts = store.read_session(session_id=str(session_id), owner_id=1)["facts"]
     assert facts["latest_console_turn"]["state"] == "starting"
+    uncertain = store.update_console_turn(
+        data={
+            "turn_id": first["turn"]["turn_id"],
+            "run_id": first["turn"]["run_id"],
+            "state": "starting",
+            "expected_state": "starting",
+            "error_code": "turn_start_outcome_unknown",
+            "error": "Machine control channel disconnected",
+            "updated_at": datetime.now(UTC),
+        }
+    )
+    assert uncertain["turn"]["state"] == "starting"
+    with Session(engine) as db:
+        uncertain_turn = db.get(LiveConsoleTurn, first["turn"]["turn_id"])
+        uncertain_receipt = db.get(LiveSessionInputReceipt, uncertain_turn.receipt_id)
+        assert uncertain_receipt.status == "delivering"
+        assert json.loads(uncertain_receipt.error_json) == {
+            "code": "turn_start_outcome_unknown",
+            "message": "Machine control channel disconnected",
+        }
     active = store.update_console_turn(
         data={
             "turn_id": first["turn"]["turn_id"],
             "run_id": first["turn"]["run_id"],
             "state": "active",
+            "expected_state": "starting",
             "updated_at": datetime.now(UTC),
         }
     )
     assert active["turn"]["state"] == "active"
+    with Session(engine) as db:
+        active_turn = db.get(LiveConsoleTurn, first["turn"]["turn_id"])
+        active_receipt = db.get(LiveSessionInputReceipt, active_turn.receipt_id)
+        assert active_receipt.error_json is None
     provider_thread_id = "019f6b93-edf6-7bd0-a757-b5195a61abdd"
     store.apply_session_runtime(
         events=[
@@ -224,6 +253,18 @@ def test_catalog_console_turns_claim_and_wake_fifo(tmp_path):
     assert settled["next_turn"]["state"] == "starting"
     assert settled["next_turn"]["run_id"]
     assert settled["next_turn"]["resume_provider_thread_id"] == provider_thread_id
+    stale_replay = store.update_console_turn(
+        data={
+            "turn_id": first["turn"]["turn_id"],
+            "run_id": first["turn"]["run_id"],
+            "state": "active",
+            "expected_state": "starting",
+            "updated_at": datetime.now(UTC),
+        }
+    )
+    assert stale_replay["applied"] is False
+    assert stale_replay["stale"] is True
+    assert stale_replay["turn"]["state"] == "completed"
 
     failed = store.update_console_turn(
         data={

--- a/server/tests_lite/test_console_turns.py
+++ b/server/tests_lite/test_console_turns.py
@@ -25,6 +25,7 @@ from zerg.services.console_turns import dispatch_next_console_turn
 from zerg.services.console_turns import enqueue_console_turn
 from zerg.services.console_turns import interrupt_console_turn
 from zerg.services.console_turns import mark_console_turn_active
+from zerg.services.console_turns import reconcile_starting_console_turns_for_device
 from zerg.services.console_turns import settle_console_turn
 from zerg.services.session_inputs import INPUT_STATUS_DELIVERED
 from zerg.services.session_inputs import INPUT_STATUS_DELIVERING
@@ -390,9 +391,125 @@ async def test_dispatch_timeout_keeps_durable_claim_starting_and_fifo_blocked(tm
 
     assert result.turn_id == first.turn_id
     assert result.state == SESSION_TURN_STATE_STARTING
-    assert db.get(SessionTurn, first.turn_id).state == SESSION_TURN_STATE_STARTING
+    assert result.error_code == "turn_start_outcome_unknown"
+    first_turn = db.get(SessionTurn, first.turn_id)
+    assert first_turn.state == SESSION_TURN_STATE_STARTING
+    assert first_turn.error_code == "turn_start_outcome_unknown"
+    assert db.get(SessionInput, first.input_id).last_error == "turn_start_outcome_unknown: reply timeout"
     assert db.get(SessionTurn, second.turn_id).state == SESSION_TURN_STATE_QUEUED
     assert claim_next_console_turn(db, thread_id=thread.id) is None
+
+
+@pytest.mark.asyncio
+async def test_control_reconnect_replays_starting_turn_with_same_run_id(tmp_path, monkeypatch):
+    db = _db(tmp_path)
+    session = _session(db)
+    thread = ensure_primary_thread(db, session)
+    set_thread_execution_target(thread, device_id="cube", cwd="/tmp/longhouse")
+    db.commit()
+    enqueue_console_turn(
+        db,
+        session=session,
+        owner_id=1,
+        message="Continue after reconnect",
+        client_request_id="reconnect-request",
+    )
+    claimed = claim_next_console_turn(db, thread_id=thread.id)
+    assert claimed is not None
+
+    class Registry:
+        command = None
+
+        def supports(self, **_kwargs):
+            return True
+
+        async def send_command(self, **kwargs):
+            self.command = kwargs
+            return SimpleNamespace(transport_ok=True, message={"ok": True, "result": {}}, error=None)
+
+    registry = Registry()
+    monkeypatch.setattr("zerg.database.live_catalog_enabled", lambda: False)
+    outcomes = await reconcile_starting_console_turns_for_device(
+        db,
+        owner_id=1,
+        device_id="cube",
+        registry=registry,
+    )
+
+    assert [outcome.state for outcome in outcomes] == [SESSION_TURN_STATE_ACTIVE]
+    assert registry.command["command_id"] == str(claimed.run_id)
+    assert registry.command["payload"]["run_id"] == str(claimed.run_id)
+    assert db.get(SessionTurn, claimed.turn_id).state == SESSION_TURN_STATE_ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_control_reconnect_replays_live_catalog_turn_with_same_run_id(monkeypatch):
+    session_id = uuid4()
+    thread_id = uuid4()
+    turn_id = uuid4()
+    run_id = uuid4()
+    calls = []
+    turn = {
+        "turn_id": str(turn_id),
+        "session_id": str(session_id),
+        "thread_id": str(thread_id),
+        "run_id": str(run_id),
+        "state": SESSION_TURN_STATE_STARTING,
+        "provider": "claude",
+        "device_id": "cube",
+        "cwd": "/tmp/longhouse",
+        "message": "Continue after catalog reconnect",
+        "client_request_id": "catalog-reconnect-request",
+        "provider_config": {"permission_mode": "bypass"},
+        "resume_provider_thread_id": None,
+    }
+
+    class Catalog:
+        async def call(self, method, params):
+            calls.append((method, params))
+            if method == "session.console.turn.starting_for_device.v2":
+                return {"turns": [turn], "commit_seq": "7"}
+            assert method == "session.console.turn.update.v2"
+            assert params["turn"]["run_id"] == str(run_id)
+            assert params["turn"]["expected_state"] == SESSION_TURN_STATE_STARTING
+            return {
+                "found": True,
+                "applied": True,
+                "stale": False,
+                "turn": {**turn, "state": SESSION_TURN_STATE_ACTIVE},
+                "next_turn": None,
+                "commit_seq": "8",
+            }
+
+    class Registry:
+        command = None
+
+        def supports(self, **_kwargs):
+            return True
+
+        async def send_command(self, **kwargs):
+            self.command = kwargs
+            return SimpleNamespace(transport_ok=True, message={"ok": True, "result": {}}, error=None)
+
+    catalog = Catalog()
+    registry = Registry()
+    monkeypatch.setattr("zerg.database.live_catalog_enabled", lambda: True)
+    monkeypatch.setattr("zerg.services.catalogd_supervisor.get_catalogd_client", lambda: catalog)
+
+    outcomes = await reconcile_starting_console_turns_for_device(
+        None,
+        owner_id=1,
+        device_id="cube",
+        registry=registry,
+    )
+
+    assert [outcome.state for outcome in outcomes] == [SESSION_TURN_STATE_ACTIVE]
+    assert registry.command["command_id"] == str(run_id)
+    assert registry.command["payload"]["run_id"] == str(run_id)
+    assert [method for method, _params in calls] == [
+        "session.console.turn.starting_for_device.v2",
+        "session.console.turn.update.v2",
+    ]
 
 
 @pytest.mark.asyncio
@@ -469,9 +586,7 @@ async def test_dispatch_next_console_turn_preserves_engine_failure_code(tmp_path
     assert result.error_code == "claude_lifecycle_hook_missing"
     assert db.get(SessionTurn, queued.turn_id).error_code == "claude_lifecycle_hook_missing"
     assert db.get(SessionRun, result.run_id).exit_status == "claude_lifecycle_hook_missing"
-    assert db.get(SessionInput, queued.input_id).last_error == (
-        "claude_lifecycle_hook_missing: run `longhouse claude configure`"
-    )
+    assert db.get(SessionInput, queued.input_id).last_error == ("claude_lifecycle_hook_missing: run `longhouse claude configure`")
 
 
 def test_run_terminal_event_settles_console_turn_after_output_drain(tmp_path):

--- a/server/tests_lite/test_console_turns.py
+++ b/server/tests_lite/test_console_turns.py
@@ -15,17 +15,17 @@ from zerg.models.agents import SessionTurn
 from zerg.services.agents.kernel_writes import ensure_primary_thread
 from zerg.services.agents.kernel_writes import record_thread_alias
 from zerg.services.agents.kernel_writes import set_thread_execution_target
-from zerg.services.console_turns import begin_console_turn_drain
-from zerg.services.console_turns import claim_next_console_turn
+from zerg.services.console_sessions import create_empty_console_session
 from zerg.services.console_turns import ConsoleTurnConflict
 from zerg.services.console_turns import ConsoleTurnUnavailable
-from zerg.services.console_turns import enqueue_console_turn
-from zerg.services.console_turns import dispatch_next_console_turn
+from zerg.services.console_turns import begin_console_turn_drain
+from zerg.services.console_turns import claim_next_console_turn
 from zerg.services.console_turns import dispatch_catalog_claimed_turn
-from zerg.services.console_turns import mark_console_turn_active
+from zerg.services.console_turns import dispatch_next_console_turn
+from zerg.services.console_turns import enqueue_console_turn
 from zerg.services.console_turns import interrupt_console_turn
+from zerg.services.console_turns import mark_console_turn_active
 from zerg.services.console_turns import settle_console_turn
-from zerg.services.console_sessions import create_empty_console_session
 from zerg.services.session_inputs import INPUT_STATUS_DELIVERED
 from zerg.services.session_inputs import INPUT_STATUS_DELIVERING
 from zerg.services.session_runtime import RuntimeEventIngest
@@ -417,9 +417,61 @@ async def test_dispatch_next_console_turn_fails_typed_when_adapter_is_missing(tm
     result = await dispatch_next_console_turn(db, owner_id=1, thread_id=thread.id, registry=Registry())
 
     assert result.state == SESSION_TURN_STATE_FAILED
+    assert result.error_code == "adapter_unavailable"
     assert "does not advertise" in result.error
-    assert db.get(SessionTurn, queued.turn_id).state == SESSION_TURN_STATE_FAILED
-    assert db.get(SessionRun, result.run_id).ended_at is not None
+    failed_turn = db.get(SessionTurn, queued.turn_id)
+    assert failed_turn.state == SESSION_TURN_STATE_FAILED
+    assert failed_turn.error_code == "adapter_unavailable"
+    failed_input = db.get(SessionInput, queued.input_id)
+    assert failed_input.last_error.startswith("adapter_unavailable: Machine Agent does not advertise")
+    failed_run = db.get(SessionRun, result.run_id)
+    assert failed_run.ended_at is not None
+    assert failed_run.exit_status == "adapter_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_next_console_turn_preserves_engine_failure_code(tmp_path):
+    db = _db(tmp_path)
+    session = _session(db)
+    session.provider = "claude"
+    thread = ensure_primary_thread(db, session)
+    thread.provider = "claude"
+    set_thread_execution_target(thread, device_id="cube", cwd="/tmp/longhouse")
+    db.commit()
+    queued = enqueue_console_turn(
+        db,
+        session=session,
+        owner_id=1,
+        message="Start Claude",
+        client_request_id="request-hook-missing",
+    )
+
+    class Registry:
+        def supports(self, **_kwargs):
+            return True
+
+        async def send_command(self, **_kwargs):
+            return SimpleNamespace(
+                transport_ok=True,
+                message={
+                    "ok": False,
+                    "error": {
+                        "code": "claude_lifecycle_hook_missing",
+                        "message": "run `longhouse claude configure`",
+                    },
+                },
+                error=None,
+            )
+
+    result = await dispatch_next_console_turn(db, owner_id=1, thread_id=thread.id, registry=Registry())
+
+    assert result.state == SESSION_TURN_STATE_FAILED
+    assert result.error_code == "claude_lifecycle_hook_missing"
+    assert db.get(SessionTurn, queued.turn_id).error_code == "claude_lifecycle_hook_missing"
+    assert db.get(SessionRun, result.run_id).exit_status == "claude_lifecycle_hook_missing"
+    assert db.get(SessionInput, queued.input_id).last_error == (
+        "claude_lifecycle_hook_missing: run `longhouse claude configure`"
+    )
 
 
 def test_run_terminal_event_settles_console_turn_after_output_drain(tmp_path):

--- a/server/tests_lite/test_session_inputs_api.py
+++ b/server/tests_lite/test_session_inputs_api.py
@@ -44,23 +44,23 @@ from zerg.models.models import Runner
 from zerg.models.user import User
 from zerg.routers.session_chat import SessionInputRequest
 from zerg.routers.session_chat import _create_session_input_response
+from zerg.routers.session_chat import _live_queued_summary
 from zerg.routers.session_chat import _project_live_input_to_archive
-from zerg.services.live_archive_outbox import SESSION_INPUT_RECEIPT_KIND
-from zerg.services.live_archive_outbox import drain_live_archive_outbox
 from zerg.services.agents import AgentsStore
 from zerg.services.agents import EventIngest
 from zerg.services.agents import SessionIngest
+from zerg.services.live_archive_outbox import SESSION_INPUT_RECEIPT_KIND
+from zerg.services.live_session_inputs import LiveInputReceiptSnapshot
 from zerg.services.machine_control_channel import get_machine_control_channel_registry
 from zerg.services.runner_connection_manager import get_runner_connection_manager
-from zerg.services.session_locks import session_lock_manager
 from zerg.services.session_inputs import INPUT_STATUS_CANCELLED
 from zerg.services.session_inputs import INPUT_STATUS_DELIVERED
 from zerg.services.session_inputs import INPUT_STATUS_DELIVERING
 from zerg.services.session_inputs import INPUT_STATUS_FAILED
 from zerg.services.session_inputs import INPUT_STATUS_QUEUED
 from zerg.services.session_inputs import create_session_input
-from zerg.services.live_session_inputs import LiveInputReceiptSnapshot
 from zerg.services.session_kernel_projection import project_session_control_fields
+from zerg.services.session_locks import session_lock_manager
 from zerg.services.session_runtime import phase_freshness_ms
 from zerg.services.session_runtime import runtime_key_for_session
 
@@ -112,6 +112,30 @@ def _make_client(session_local, current_user):
     api_app.dependency_overrides[get_db] = override_get_db
     api_app.dependency_overrides[get_current_browser_route_user] = override_current_user
     return TestClient(app, backend="asyncio"), api_app
+
+
+def test_live_failed_input_summary_preserves_typed_error():
+    summary = _live_queued_summary(
+        LiveInputReceiptSnapshot(
+            id="live-failed-1",
+            owner_id=1,
+            session_id=str(uuid4()),
+            provider="claude",
+            text="start work",
+            intent="auto",
+            status=INPUT_STATUS_FAILED,
+            client_request_id="request-failed-1",
+            archive_session_input_id=None,
+            error_json=(
+                '{"code":"claude_lifecycle_hook_missing",'
+                '"message":"run `longhouse claude configure`"}'
+            ),
+        )
+    )
+
+    assert summary.last_error == (
+        "claude_lifecycle_hook_missing: run `longhouse claude configure`"
+    )
 
 
 def _seed_live_runtime_state(db, session, *, phase: str = "idle") -> None:

--- a/server/zerg/catalogd/client.py
+++ b/server/zerg/catalogd/client.py
@@ -53,6 +53,7 @@ _SAFE_RETRY_METHODS = {
     "session.console.create.v2",
     "session.console.turn.enqueue.v2",
     "session.console.turn.current.v2",
+    "session.console.turn.starting_for_device.v2",
     "session.console.turn.update.v2",
     "session.launch.local.create.v2",
     "interaction.register.v2",

--- a/server/zerg/catalogd/server.py
+++ b/server/zerg/catalogd/server.py
@@ -1316,6 +1316,10 @@ class CatalogDaemon:
             return self._error(request, "invalid_request", str(exc))
         if data["state"] not in {"active", "completed", "failed", "cancelled"}:
             return self._error(request, "invalid_request", "console turn state is invalid")
+        if data.get("error_code") is not None and (
+            not isinstance(data["error_code"], str) or not data["error_code"].strip() or len(data["error_code"]) > 64
+        ):
+            return self._error(request, "invalid_request", "console turn error_code is invalid")
         assert self._store is not None
         return CatalogRpcResponse(id=request.id, result=await self._run_store(self._store.update_console_turn, data=data))
 

--- a/server/zerg/catalogd/server.py
+++ b/server/zerg/catalogd/server.py
@@ -279,6 +279,8 @@ class CatalogDaemon:
             return await self._enqueue_console_turn(request)
         if request.method == "session.console.turn.current.v2":
             return await self._read_current_console_turn(request)
+        if request.method == "session.console.turn.starting_for_device.v2":
+            return await self._list_starting_console_turns_for_device(request)
         if request.method == "session.console.turn.update.v2":
             return await self._update_console_turn(request)
         if request.method == "session.launch.local.create.v2":
@@ -1300,6 +1302,30 @@ class CatalogDaemon:
             ),
         )
 
+    async def _list_starting_console_turns_for_device(self, request: CatalogRpcRequest) -> CatalogRpcResponse:
+        if set(request.params) != {"owner_id", "device_id"}:
+            return self._error(
+                request,
+                "invalid_request",
+                "session.console.turn.starting_for_device.v2 requires owner_id and device_id",
+            )
+        try:
+            owner_id = int(request.params["owner_id"])
+        except (TypeError, ValueError):
+            return self._error(request, "invalid_request", "console turn owner_id is invalid")
+        device_id = request.params["device_id"]
+        if owner_id <= 0 or not _is_string(device_id, maximum=255):
+            return self._error(request, "invalid_request", "console turn device identity is invalid")
+        assert self._store is not None
+        return CatalogRpcResponse(
+            id=request.id,
+            result=await self._run_store(
+                self._store.list_starting_console_turns_for_device,
+                owner_id=owner_id,
+                device_id=str(device_id),
+            ),
+        )
+
     async def _update_console_turn(self, request: CatalogRpcRequest) -> CatalogRpcResponse:
         if set(request.params) != {"turn"} or not isinstance(request.params["turn"], dict):
             return self._error(request, "invalid_request", "session.console.turn.update.v2 requires turn")
@@ -1314,8 +1340,14 @@ class CatalogDaemon:
             data["updated_at"] = _parse_datetime(data["updated_at"], "console turn.updated_at")
         except ValueError as exc:
             return self._error(request, "invalid_request", str(exc))
-        if data["state"] not in {"active", "completed", "failed", "cancelled"}:
+        if data["state"] not in {"starting", "active", "completed", "failed", "cancelled"}:
             return self._error(request, "invalid_request", "console turn state is invalid")
+        if data.get("expected_state") is not None and data["expected_state"] not in {
+            "starting",
+            "active",
+            "draining",
+        }:
+            return self._error(request, "invalid_request", "console turn expected_state is invalid")
         if data.get("error_code") is not None and (
             not isinstance(data["error_code"], str) or not data["error_code"].strip() or len(data["error_code"]) > 64
         ):

--- a/server/zerg/catalogd/store.py
+++ b/server/zerg/catalogd/store.py
@@ -2778,12 +2778,33 @@ class CatalogStore:
                     orm.rollback()
                     return {"found": False}
                 receipt = orm.get(LiveSessionInputReceipt, turn.receipt_id)
+                expected_state = data.get("expected_state")
+                if expected_state is not None and turn.state != expected_state:
+                    thread = orm.get(LiveSessionThread, turn.thread_id)
+                    result = _live_console_turn_dto(
+                        turn,
+                        message=receipt.text if receipt is not None else None,
+                        client_request_id=receipt.client_request_id if receipt is not None else None,
+                        provider_config=thread.provider_config_json if thread is not None else None,
+                    )
+                    orm.rollback()
+                    return {
+                        "found": True,
+                        "applied": False,
+                        "stale": True,
+                        "turn": result,
+                        "next_turn": None,
+                        "commit_seq": str(_current_commit_seq(connection)),
+                    }
                 next_state = data["state"]
                 turn.state = next_state
                 turn.updated_at = now
                 turn.error = data.get("error")
                 if receipt is not None:
-                    receipt.status = "delivered" if next_state == "active" else ("failed" if next_state == "failed" else receipt.status)
+                    if next_state in {"active", "completed"}:
+                        receipt.status = "delivered"
+                    elif next_state in {"failed", "cancelled"}:
+                        receipt.status = "failed"
                     receipt.error_json = (
                         json.dumps(
                             {
@@ -2860,7 +2881,48 @@ class CatalogStore:
             finally:
                 orm.close()
             commit_seq = _advance_commit_seq(connection, now)
-            return {"found": True, "turn": result, "next_turn": next_turn_result, "commit_seq": str(commit_seq)}
+            return {
+                "found": True,
+                "applied": True,
+                "stale": False,
+                "turn": result,
+                "next_turn": next_turn_result,
+                "commit_seq": str(commit_seq),
+            }
+
+    def list_starting_console_turns_for_device(self, *, owner_id: int, device_id: str) -> dict[str, Any]:
+        """Return durable ambiguous dispatches that can be replayed by stable run_id."""
+
+        with self.engine.connect() as connection:
+            orm = Session(bind=connection)
+            try:
+                rows = (
+                    orm.query(LiveConsoleTurn, LiveSessionInputReceipt, LiveSessionThread)
+                    .join(LiveSessionInputReceipt, LiveSessionInputReceipt.id == LiveConsoleTurn.receipt_id)
+                    .join(LiveSessionThread, LiveSessionThread.id == LiveConsoleTurn.thread_id)
+                    .filter(
+                        LiveConsoleTurn.state == "starting",
+                        LiveConsoleTurn.device_id == device_id,
+                        LiveSessionInputReceipt.owner_id == owner_id,
+                    )
+                    .order_by(LiveConsoleTurn.created_at.asc(), LiveConsoleTurn.id.asc())
+                    .limit(100)
+                    .all()
+                )
+                return {
+                    "turns": [
+                        _live_console_turn_dto(
+                            turn,
+                            message=receipt.text,
+                            client_request_id=receipt.client_request_id,
+                            provider_config=thread.provider_config_json,
+                        )
+                        for turn, receipt, thread in rows
+                    ],
+                    "commit_seq": str(_current_commit_seq(connection)),
+                }
+            finally:
+                orm.close()
 
     def read_current_console_turn(self, *, session_id: str, owner_id: int) -> dict[str, Any]:
         with self.engine.connect() as connection:

--- a/server/zerg/catalogd/store.py
+++ b/server/zerg/catalogd/store.py
@@ -2784,7 +2784,18 @@ class CatalogStore:
                 turn.error = data.get("error")
                 if receipt is not None:
                     receipt.status = "delivered" if next_state == "active" else ("failed" if next_state == "failed" else receipt.status)
-                    receipt.error_json = json.dumps({"message": data["error"]}) if data.get("error") else None
+                    receipt.error_json = (
+                        json.dumps(
+                            {
+                                "code": data.get("error_code"),
+                                "message": data["error"],
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        )
+                        if data.get("error")
+                        else None
+                    )
                     receipt.updated_at = now
                 next_turn_result = None
                 if next_state in {"completed", "failed", "cancelled"}:
@@ -2792,7 +2803,7 @@ class CatalogStore:
                     run = orm.get(LiveSessionRun, turn.run_id)
                     if run is not None:
                         run.ended_at = now
-                        run.exit_status = next_state
+                        run.exit_status = data.get("error_code") or next_state
                     next_turn = (
                         orm.query(LiveConsoleTurn)
                         .filter(LiveConsoleTurn.thread_id == turn.thread_id, LiveConsoleTurn.state == "queued")

--- a/server/zerg/config/managed_provider_contracts.json
+++ b/server/zerg/config/managed_provider_contracts.json
@@ -536,7 +536,7 @@
         "claude.turn_start",
         "claude.turn_interrupt"
       ],
-      "adapter_digest": "374c006fe9207f4f395e321c7da1a7d70cc4a6f90325bde6eabce1c629b23801"
+      "adapter_digest": "a767801eeec8e2da2824fade298a32d98807dbe13cdc941ed089c4fdf7455918"
     },
     {
       "provider": "opencode",

--- a/server/zerg/routers/agents_control.py
+++ b/server/zerg/routers/agents_control.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import Any
 from typing import Mapping
@@ -20,6 +21,7 @@ from zerg.database import get_catalog_session_factory
 from zerg.dependencies.agents_auth import _validate_device_token_for_request
 from zerg.models.device_token import DeviceToken
 from zerg.services.catalogd_supervisor import get_catalogd_client
+from zerg.services.console_turns import reconcile_starting_console_turns_for_device
 from zerg.services.machine_control_channel import get_machine_control_channel_registry
 from zerg.services.machine_control_operations import reconcile_live_machine_control_operation_from_command_result
 from zerg.services.machine_control_operations import reconcile_machine_control_operation_from_command_result
@@ -113,6 +115,36 @@ async def _close_control_ws(websocket: WebSocket, *, code: int = 1008, reason: s
         logger.debug("Ignoring machine control websocket close race: %s", reason)
 
 
+async def _reconcile_console_turns_after_register(*, owner_id: int, device_id: str, registry) -> None:
+    db = None if database_module.live_catalog_enabled() else get_catalog_session_factory()()
+    try:
+        outcomes = await reconcile_starting_console_turns_for_device(
+            db,
+            owner_id=owner_id,
+            device_id=device_id,
+            registry=registry,
+        )
+        if outcomes:
+            logger.info(
+                "Reconciled %d starting Console turn(s) after control reconnect owner=%s device=%s states=%s",
+                len(outcomes),
+                owner_id,
+                device_id,
+                ",".join(outcome.state for outcome in outcomes),
+            )
+    except Exception:  # noqa: BLE001
+        if db is not None:
+            db.rollback()
+        logger.exception(
+            "Failed to reconcile starting Console turns after control reconnect owner=%s device=%s",
+            owner_id,
+            device_id,
+        )
+    finally:
+        if db is not None:
+            db.close()
+
+
 @router.websocket("/ws")
 async def machine_control_websocket(websocket: WebSocket) -> None:
     settings = get_settings()
@@ -120,6 +152,7 @@ async def machine_control_websocket(websocket: WebSocket) -> None:
     registry = get_machine_control_channel_registry()
     owner_id: int | None = None
     device_id: str | None = None
+    console_reconcile_task: asyncio.Task[None] | None = None
 
     await websocket.accept()
     try:
@@ -162,6 +195,13 @@ async def machine_control_websocket(websocket: WebSocket) -> None:
             engine_build=str(hello.get("engine_build") or "") or None,
             supports=supports,
             websocket=websocket,
+        )
+        console_reconcile_task = asyncio.create_task(
+            _reconcile_console_turns_after_register(
+                owner_id=owner_id,
+                device_id=device_id,
+                registry=registry,
+            )
         )
 
         while True:
@@ -213,6 +253,10 @@ async def machine_control_websocket(websocket: WebSocket) -> None:
             else:
                 logger.warning("Unknown machine control message type from %s: %s", device_id, message_type)
     finally:
+        if console_reconcile_task is not None and not console_reconcile_task.done():
+            console_reconcile_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await console_reconcile_task
         if db is not None:
             db.close()
         if owner_id is not None and device_id is not None:

--- a/server/zerg/routers/agents_sessions.py
+++ b/server/zerg/routers/agents_sessions.py
@@ -1166,7 +1166,7 @@ async def create_console_turn(
         if turn.error:
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
-                detail={"code": "provider_launch_failed", "message": turn.error},
+                detail={"code": turn.error_code or "provider_launch_failed", "message": turn.error},
             )
         return ConsoleTurnCreateResponse(
             turn_id=turn.turn_id,

--- a/server/zerg/routers/session_chat.py
+++ b/server/zerg/routers/session_chat.py
@@ -1798,7 +1798,9 @@ def _live_queued_summary(receipt: LiveInputReceiptSnapshot) -> QueuedInputSummar
         try:
             payload = json.loads(receipt.error_json)
             if isinstance(payload, dict):
-                last_error = str(payload.get("message") or "").strip() or None
+                code = str(payload.get("code") or "").strip()
+                message = str(payload.get("message") or "").strip()
+                last_error = f"{code}: {message}" if code and message else (message or code or None)
         except Exception:
             last_error = receipt.error_json
     return QueuedInputSummary(
@@ -2016,7 +2018,10 @@ async def _create_catalog_session_input_response(
         except ConsoleTurnConflict as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         if turn.error:
-            raise HTTPException(status_code=502, detail={"code": "provider_launch_failed", "message": turn.error})
+            raise HTTPException(
+                status_code=502,
+                detail={"code": turn.error_code or "provider_launch_failed", "message": turn.error},
+            )
         return SessionInputResponse(
             outcome="sent" if turn.state == "active" else "queued",
             input_id=None,
@@ -2556,7 +2561,10 @@ async def _create_session_input_response(
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         state = dispatched.state if dispatched.turn_id == queued.turn_id else queued.state
         if dispatched.turn_id == queued.turn_id and dispatched.error:
-            raise HTTPException(status_code=502, detail={"code": "provider_launch_failed", "message": dispatched.error})
+            raise HTTPException(
+                status_code=502,
+                detail={"code": dispatched.error_code or "provider_launch_failed", "message": dispatched.error},
+            )
         return SessionInputResponse(
             outcome="sent" if state == "active" else "queued",
             input_id=queued.input_id,

--- a/server/zerg/services/console_turns.py
+++ b/server/zerg/services/console_turns.py
@@ -353,9 +353,11 @@ def mark_console_turn_active(db: Session, *, turn_id: int) -> None:
         raise ConsoleTurnConflict(f"turn {turn_id} cannot become active from {turn.state}")
     now = datetime.now(timezone.utc)
     turn.state = SESSION_TURN_STATE_ACTIVE
+    turn.error_code = None
     turn.send_accepted_at = turn.send_accepted_at or now
     turn.active_phase_observed_at = turn.active_phase_observed_at or now
     input_row.status = INPUT_STATUS_DELIVERED
+    input_row.last_error = None
     input_row.delivered_at = input_row.delivered_at or now
     db.commit()
 
@@ -395,6 +397,10 @@ def settle_console_turn(
     if outcome != SESSION_TURN_STATE_COMPLETED:
         input_row.status = INPUT_STATUS_FAILED
         input_row.last_error = outcome
+    else:
+        input_row.status = INPUT_STATUS_DELIVERED
+        input_row.last_error = None
+        input_row.delivered_at = input_row.delivered_at or now
     db.commit()
 
 
@@ -415,18 +421,36 @@ async def dispatch_next_console_turn(
         return ConsoleTurnDispatch(turn_id=None, run_id=None, state="idle")
 
     control = registry or get_machine_control_channel_registry()
+    return await _dispatch_claimed_console_turn(
+        db,
+        owner_id=owner_id,
+        claimed=claimed,
+        control=control,
+    )
+
+
+async def _dispatch_claimed_console_turn(
+    db: Session,
+    *,
+    owner_id: int,
+    claimed: ClaimedConsoleTurn,
+    control,
+) -> ConsoleTurnDispatch:
     capability = f"{claimed.provider}.turn_start"
     if not control.supports(
         owner_id=owner_id,
         device_id=claimed.device_id,
         capability=capability,
     ):
-        _fail_starting_console_turn(
-            db,
-            turn_id=claimed.turn_id,
-            error_code="adapter_unavailable",
-            error=f"Machine Agent does not advertise {capability}",
-        )
+        try:
+            _fail_starting_console_turn(
+                db,
+                turn_id=claimed.turn_id,
+                error_code="adapter_unavailable",
+                error=f"Machine Agent does not advertise {capability}",
+            )
+        except ConsoleTurnConflict:
+            return _current_cold_dispatch(db, claimed)
         return ConsoleTurnDispatch(
             turn_id=claimed.turn_id,
             run_id=claimed.run_id,
@@ -465,17 +489,26 @@ async def dispatch_next_console_turn(
         # may already own the durable run claim and have spawned the provider.
         # Keep the FIFO blocked until runtime truth or an idempotent retry of
         # this same run_id resolves the outcome.
+        error = str(response.error or "Console turn dispatch outcome is unknown")
+        try:
+            _mark_starting_console_turn_unknown(db, turn_id=claimed.turn_id, error=error)
+        except ConsoleTurnConflict:
+            return _current_cold_dispatch(db, claimed)
         return ConsoleTurnDispatch(
             turn_id=claimed.turn_id,
             run_id=claimed.run_id,
             state=SESSION_TURN_STATE_STARTING,
-            error=str(response.error or "Console turn dispatch outcome is unknown"),
+            error_code="turn_start_outcome_unknown",
+            error=error,
         )
     if message.get("ok") is not True:
         detail = message.get("error") if isinstance(message.get("error"), dict) else {}
         error_code = str(detail.get("code") or "provider_launch_failed")
         error = str(detail.get("message") or response.error or "Console turn dispatch failed")
-        _fail_starting_console_turn(db, turn_id=claimed.turn_id, error_code=error_code, error=error)
+        try:
+            _fail_starting_console_turn(db, turn_id=claimed.turn_id, error_code=error_code, error=error)
+        except ConsoleTurnConflict:
+            return _current_cold_dispatch(db, claimed)
         return ConsoleTurnDispatch(
             turn_id=claimed.turn_id,
             run_id=claimed.run_id,
@@ -484,12 +517,69 @@ async def dispatch_next_console_turn(
             error=error,
         )
 
-    mark_console_turn_active(db, turn_id=claimed.turn_id)
+    try:
+        mark_console_turn_active(db, turn_id=claimed.turn_id)
+    except ConsoleTurnConflict:
+        return _current_cold_dispatch(db, claimed)
     return ConsoleTurnDispatch(
         turn_id=claimed.turn_id,
         run_id=claimed.run_id,
         state=SESSION_TURN_STATE_ACTIVE,
     )
+
+
+def _current_cold_dispatch(db: Session, claimed: ClaimedConsoleTurn) -> ConsoleTurnDispatch:
+    db.expire_all()
+    turn = db.get(SessionTurn, claimed.turn_id)
+    return ConsoleTurnDispatch(
+        turn_id=claimed.turn_id,
+        run_id=claimed.run_id,
+        state=str(turn.state) if turn is not None else "unknown",
+        error_code=str(turn.error_code) if turn is not None and turn.error_code else None,
+    )
+
+
+def _starting_cold_console_turns_for_device(
+    db: Session,
+    *,
+    owner_id: int,
+    device_id: str,
+) -> list[ClaimedConsoleTurn]:
+    rows = (
+        db.query(SessionTurn, SessionThread, SessionInput)
+        .join(SessionThread, SessionThread.id == SessionTurn.thread_id)
+        .join(SessionInput, SessionInput.id == SessionTurn.session_input_id)
+        .filter(
+            SessionTurn.source_kind == SESSION_TURN_SOURCE_CONSOLE,
+            SessionTurn.state == SESSION_TURN_STATE_STARTING,
+            SessionThread.device_id == device_id,
+            SessionInput.owner_id == owner_id,
+        )
+        .order_by(SessionTurn.created_at.asc(), SessionTurn.id.asc())
+        .limit(100)
+        .all()
+    )
+    claimed: list[ClaimedConsoleTurn] = []
+    for turn, thread, input_row in rows:
+        if turn.run_id is None:
+            continue
+        claimed.append(
+            ClaimedConsoleTurn(
+                input_id=int(input_row.id),
+                turn_id=int(turn.id),
+                run_id=UUID(str(turn.run_id)),
+                session_id=UUID(str(turn.session_id)),
+                thread_id=UUID(str(thread.id)),
+                provider=str(thread.provider),
+                device_id=str(thread.device_id),
+                cwd=str(thread.cwd),
+                message=str(input_row.body),
+                client_request_id=str(input_row.client_request_id or turn.request_id or ""),
+                provider_config=dict(thread.provider_config_json or {}),
+                resume_provider_thread_id=_provider_resume_identity(db, thread),
+            )
+        )
+    return claimed
 
 
 async def enqueue_catalog_console_turn(
@@ -598,12 +688,30 @@ async def enqueue_catalog_console_turn(
             int((time.monotonic() - accepted_mono) * 1000),
         )
         if not response.transport_ok:
+            error = str(response.error or "Console turn dispatch outcome is unknown")
+            update_result = await _mark_catalog_start_outcome_unknown(
+                client,
+                turn_id=turn_id,
+                run_id=run_id,
+                error=error,
+            )
+            persisted_turn = dict(update_result.get("turn") or {})
+            persisted_state = str(persisted_turn.get("state") or SESSION_TURN_STATE_STARTING)
+            if update_result.get("applied") is False:
+                return CatalogConsoleTurn(
+                    turn_id=turn_id,
+                    run_id=run_id,
+                    state=persisted_state,
+                    created=bool(result.get("created")),
+                    error=str(persisted_turn.get("error") or "") or None,
+                )
             return CatalogConsoleTurn(
                 turn_id=turn_id,
                 run_id=run_id,
-                state=SESSION_TURN_STATE_STARTING,
+                state=persisted_state,
                 created=bool(result.get("created")),
-                error=str(response.error or "Console turn dispatch outcome is unknown"),
+                error_code="turn_start_outcome_unknown",
+                error=error,
             )
         if response_message.get("ok") is not True:
             error_code = response_error_code or "provider_launch_failed"
@@ -617,12 +725,23 @@ async def enqueue_catalog_console_turn(
                 "turn_id": str(turn_id),
                 "run_id": str(run_id),
                 "state": state,
+                "expected_state": SESSION_TURN_STATE_STARTING,
                 "error_code": error_code,
                 "error": error,
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             }
         },
     )
+    persisted_turn = dict(update_result.get("turn") or {})
+    state = str(persisted_turn.get("state") or state)
+    if update_result.get("applied") is False:
+        return CatalogConsoleTurn(
+            turn_id=turn_id,
+            run_id=run_id,
+            state=state,
+            created=bool(result.get("created")),
+            error=str(persisted_turn.get("error") or "") or None,
+        )
     next_turn = update_result.get("next_turn")
     if isinstance(next_turn, dict):
         await dispatch_catalog_claimed_turn(
@@ -694,12 +813,30 @@ async def dispatch_catalog_claimed_turn(
         )
         message = dict(response.message or {})
         if not response.transport_ok:
+            error = str(response.error or "Console turn dispatch outcome is unknown")
+            update_result = await _mark_catalog_start_outcome_unknown(
+                catalog,
+                turn_id=turn_id,
+                run_id=run_id,
+                error=error,
+            )
+            persisted_turn = dict(update_result.get("turn") or {})
+            persisted_state = str(persisted_turn.get("state") or SESSION_TURN_STATE_STARTING)
+            if update_result.get("applied") is False:
+                return CatalogConsoleTurn(
+                    turn_id=turn_id,
+                    run_id=run_id,
+                    state=persisted_state,
+                    created=True,
+                    error=str(persisted_turn.get("error") or "") or None,
+                )
             return CatalogConsoleTurn(
                 turn_id=turn_id,
                 run_id=run_id,
-                state=SESSION_TURN_STATE_STARTING,
+                state=persisted_state,
                 created=True,
-                error=str(response.error or "Console turn dispatch outcome is unknown"),
+                error_code="turn_start_outcome_unknown",
+                error=error,
             )
         if message.get("ok") is not True:
             detail = message.get("error") if isinstance(message.get("error"), dict) else {}
@@ -713,12 +850,23 @@ async def dispatch_catalog_claimed_turn(
                 "turn_id": str(turn_id),
                 "run_id": str(run_id),
                 "state": state,
+                "expected_state": SESSION_TURN_STATE_STARTING,
                 "error_code": error_code,
                 "error": error,
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             }
         },
     )
+    persisted_turn = dict(update_result.get("turn") or {})
+    state = str(persisted_turn.get("state") or state)
+    if update_result.get("applied") is False:
+        return CatalogConsoleTurn(
+            turn_id=turn_id,
+            run_id=run_id,
+            state=state,
+            created=True,
+            error=str(persisted_turn.get("error") or "") or None,
+        )
     next_turn = update_result.get("next_turn")
     if isinstance(next_turn, dict):
         await dispatch_catalog_claimed_turn(
@@ -737,6 +885,130 @@ async def dispatch_catalog_claimed_turn(
     )
 
 
+async def reconcile_starting_console_turns_for_device(
+    db: Session | None,
+    *,
+    owner_id: int,
+    device_id: str,
+    registry=None,
+) -> list[CatalogConsoleTurn | ConsoleTurnDispatch]:
+    """Replay ambiguous dispatches after a Machine Agent reconnects.
+
+    The stable run_id is also the machine command_id. The Machine Agent's
+    durable claim registry therefore returns the existing launch outcome
+    instead of spawning a second provider invocation.
+    """
+
+    from zerg import database as database_module
+    from zerg.services.catalogd_supervisor import get_catalogd_client
+    from zerg.services.machine_control_channel import get_machine_control_channel_registry
+
+    control = registry or get_machine_control_channel_registry()
+    if database_module.live_catalog_enabled():
+        catalog = get_catalogd_client()
+        if catalog is None:
+            raise ConsoleTurnUnavailable("catalog_unavailable", "Console turn catalog is unavailable")
+        result = await catalog.call(
+            "session.console.turn.starting_for_device.v2",
+            {"owner_id": owner_id, "device_id": device_id},
+        )
+        turns = result.get("turns") if isinstance(result.get("turns"), list) else []
+        reconciled: list[CatalogConsoleTurn | ConsoleTurnDispatch] = []
+        for turn in turns:
+            if not isinstance(turn, dict):
+                continue
+            capability = f"{turn.get('provider')}.turn_start"
+            if not control.supports(owner_id=owner_id, device_id=device_id, capability=capability):
+                error = f"Machine Agent reconnected without advertising {capability}; launch outcome remains unknown"
+                update_result = await _mark_catalog_start_outcome_unknown(
+                    catalog,
+                    turn_id=UUID(str(turn["turn_id"])),
+                    run_id=UUID(str(turn["run_id"])),
+                    error=error,
+                )
+                persisted_turn = dict(update_result.get("turn") or {})
+                applied = update_result.get("applied") is not False
+                reconciled.append(
+                    CatalogConsoleTurn(
+                        turn_id=UUID(str(turn["turn_id"])),
+                        run_id=UUID(str(turn["run_id"])),
+                        state=str(persisted_turn.get("state") or SESSION_TURN_STATE_STARTING),
+                        created=False,
+                        error_code="turn_start_outcome_unknown" if applied else None,
+                        error=error if applied else (str(persisted_turn.get("error") or "") or None),
+                    )
+                )
+                continue
+            reconciled.append(
+                await dispatch_catalog_claimed_turn(
+                    owner_id=owner_id,
+                    turn=turn,
+                    client=catalog,
+                    registry=control,
+                )
+            )
+        return reconciled
+
+    if db is None:
+        raise ConsoleTurnUnavailable("catalog_unavailable", "Console turn store is unavailable")
+    reconciled = []
+    for claimed in _starting_cold_console_turns_for_device(
+        db,
+        owner_id=owner_id,
+        device_id=device_id,
+    ):
+        capability = f"{claimed.provider}.turn_start"
+        if not control.supports(owner_id=owner_id, device_id=device_id, capability=capability):
+            error = f"Machine Agent reconnected without advertising {capability}; launch outcome remains unknown"
+            try:
+                _mark_starting_console_turn_unknown(db, turn_id=claimed.turn_id, error=error)
+            except ConsoleTurnConflict:
+                reconciled.append(_current_cold_dispatch(db, claimed))
+            else:
+                reconciled.append(
+                    ConsoleTurnDispatch(
+                        turn_id=claimed.turn_id,
+                        run_id=claimed.run_id,
+                        state=SESSION_TURN_STATE_STARTING,
+                        error_code="turn_start_outcome_unknown",
+                        error=error,
+                    )
+                )
+            continue
+        reconciled.append(
+            await _dispatch_claimed_console_turn(
+                db,
+                owner_id=owner_id,
+                claimed=claimed,
+                control=control,
+            )
+        )
+    return reconciled
+
+
+async def _mark_catalog_start_outcome_unknown(
+    catalog,
+    *,
+    turn_id: UUID,
+    run_id: UUID,
+    error: str,
+) -> dict[str, object]:
+    return await catalog.call(
+        "session.console.turn.update.v2",
+        {
+            "turn": {
+                "turn_id": str(turn_id),
+                "run_id": str(run_id),
+                "state": SESSION_TURN_STATE_STARTING,
+                "expected_state": SESSION_TURN_STATE_STARTING,
+                "error_code": "turn_start_outcome_unknown",
+                "error": error,
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        },
+    )
+
+
 def _fail_starting_console_turn(db: Session, *, turn_id: int, error_code: str, error: str) -> None:
     turn, input_row, run = _load_turn_lifecycle(db, turn_id)
     if turn.state != SESSION_TURN_STATE_STARTING:
@@ -750,6 +1022,15 @@ def _fail_starting_console_turn(db: Session, *, turn_id: int, error_code: str, e
     input_row.last_error = f"{error_code}: {error}"[:1000]
     run.ended_at = now
     run.exit_status = error_code[:64]
+    db.commit()
+
+
+def _mark_starting_console_turn_unknown(db: Session, *, turn_id: int, error: str) -> None:
+    turn, input_row, _run = _load_turn_lifecycle(db, turn_id)
+    if turn.state != SESSION_TURN_STATE_STARTING:
+        raise ConsoleTurnConflict(f"turn {turn_id} cannot become uncertain from {turn.state}")
+    turn.error_code = "turn_start_outcome_unknown"
+    input_row.last_error = f"turn_start_outcome_unknown: {error}"[:1000]
     db.commit()
 
 

--- a/server/zerg/services/console_turns.py
+++ b/server/zerg/services/console_turns.py
@@ -89,6 +89,7 @@ class ConsoleTurnDispatch:
     turn_id: int | None
     run_id: UUID | None
     state: str
+    error_code: str | None = None
     error: str | None = None
 
 
@@ -98,6 +99,7 @@ class CatalogConsoleTurn:
     run_id: UUID | None
     state: str
     created: bool
+    error_code: str | None = None
     error: str | None = None
 
 
@@ -422,12 +424,14 @@ async def dispatch_next_console_turn(
         _fail_starting_console_turn(
             db,
             turn_id=claimed.turn_id,
+            error_code="adapter_unavailable",
             error=f"Machine Agent does not advertise {capability}",
         )
         return ConsoleTurnDispatch(
             turn_id=claimed.turn_id,
             run_id=claimed.run_id,
             state=SESSION_TURN_STATE_FAILED,
+            error_code="adapter_unavailable",
             error=f"Machine Agent does not advertise {capability}",
         )
 
@@ -469,12 +473,14 @@ async def dispatch_next_console_turn(
         )
     if message.get("ok") is not True:
         detail = message.get("error") if isinstance(message.get("error"), dict) else {}
+        error_code = str(detail.get("code") or "provider_launch_failed")
         error = str(detail.get("message") or response.error or "Console turn dispatch failed")
-        _fail_starting_console_turn(db, turn_id=claimed.turn_id, error=error)
+        _fail_starting_console_turn(db, turn_id=claimed.turn_id, error_code=error_code, error=error)
         return ConsoleTurnDispatch(
             turn_id=claimed.turn_id,
             run_id=claimed.run_id,
             state=SESSION_TURN_STATE_FAILED,
+            error_code=error_code,
             error=error,
         )
 
@@ -533,8 +539,10 @@ async def enqueue_catalog_console_turn(
     provider = str(turn["provider"])
     device_id = str(turn["device_id"])
     capability = f"{provider}.turn_start"
+    error_code = None
     error = None
     if not control.supports(owner_id=owner_id, device_id=device_id, capability=capability):
+        error_code = "adapter_unavailable"
         error = f"Machine Agent does not advertise {capability}"
     else:
         dispatch_wall_ms = int(time.time() * 1000)
@@ -575,13 +583,17 @@ async def enqueue_catalog_console_turn(
             timeout_secs=15,
         )
         response_message = dict(response.message or {})
+        detail = response_message.get("error") if isinstance(response_message.get("error"), dict) else {}
+        response_error_code = str(detail.get("code") or "").strip() or None
         logger.info(
-            "console_latency stage=command_response session=%s turn=%s run=%s request=%s transport_ok=%s command_ms=%d total_ms=%d",
+            "console_latency stage=command_response session=%s turn=%s run=%s request=%s transport_ok=%s command_ok=%s error_code=%s command_ms=%d total_ms=%d",
             session_id,
             turn_id,
             run_id,
             payload["client_request_id"],
             response.transport_ok,
+            response_message.get("ok"),
+            response_error_code,
             int((time.monotonic() - command_started) * 1000),
             int((time.monotonic() - accepted_mono) * 1000),
         )
@@ -594,7 +606,7 @@ async def enqueue_catalog_console_turn(
                 error=str(response.error or "Console turn dispatch outcome is unknown"),
             )
         if response_message.get("ok") is not True:
-            detail = response_message.get("error") if isinstance(response_message.get("error"), dict) else {}
+            error_code = response_error_code or "provider_launch_failed"
             error = str(detail.get("message") or response.error or "Console turn dispatch failed")
 
     state = SESSION_TURN_STATE_FAILED if error else SESSION_TURN_STATE_ACTIVE
@@ -605,6 +617,7 @@ async def enqueue_catalog_console_turn(
                 "turn_id": str(turn_id),
                 "run_id": str(run_id),
                 "state": state,
+                "error_code": error_code,
                 "error": error,
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -623,6 +636,7 @@ async def enqueue_catalog_console_turn(
         run_id=run_id,
         state=state,
         created=bool(result.get("created")),
+        error_code=error_code,
         error=error,
     )
 
@@ -649,8 +663,10 @@ async def dispatch_catalog_claimed_turn(
     if catalog is None:
         raise ConsoleTurnUnavailable("catalog_unavailable", "Console turn catalog is unavailable")
     capability = f"{provider}.turn_start"
+    error_code = None
     error = None
     if not control.supports(owner_id=owner_id, device_id=device_id, capability=capability):
+        error_code = "adapter_unavailable"
         error = f"Machine Agent does not advertise {capability}"
     else:
         payload = {
@@ -687,6 +703,7 @@ async def dispatch_catalog_claimed_turn(
             )
         if message.get("ok") is not True:
             detail = message.get("error") if isinstance(message.get("error"), dict) else {}
+            error_code = str(detail.get("code") or "provider_launch_failed")
             error = str(detail.get("message") or response.error or "Console turn dispatch failed")
     state = SESSION_TURN_STATE_FAILED if error else SESSION_TURN_STATE_ACTIVE
     update_result = await catalog.call(
@@ -696,6 +713,7 @@ async def dispatch_catalog_claimed_turn(
                 "turn_id": str(turn_id),
                 "run_id": str(run_id),
                 "state": state,
+                "error_code": error_code,
                 "error": error,
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -709,21 +727,29 @@ async def dispatch_catalog_claimed_turn(
             client=catalog,
             registry=control,
         )
-    return CatalogConsoleTurn(turn_id=turn_id, run_id=run_id, state=state, created=True, error=error)
+    return CatalogConsoleTurn(
+        turn_id=turn_id,
+        run_id=run_id,
+        state=state,
+        created=True,
+        error_code=error_code,
+        error=error,
+    )
 
 
-def _fail_starting_console_turn(db: Session, *, turn_id: int, error: str) -> None:
+def _fail_starting_console_turn(db: Session, *, turn_id: int, error_code: str, error: str) -> None:
     turn, input_row, run = _load_turn_lifecycle(db, turn_id)
     if turn.state != SESSION_TURN_STATE_STARTING:
         raise ConsoleTurnConflict(f"turn {turn_id} cannot fail from {turn.state}")
     now = datetime.now(timezone.utc)
     turn.state = SESSION_TURN_STATE_FAILED
+    turn.error_code = error_code[:64]
     turn.terminal_at = now
     turn.durable_at = now
     input_row.status = INPUT_STATUS_FAILED
-    input_row.last_error = error[:1000]
+    input_row.last_error = f"{error_code}: {error}"[:1000]
     run.ended_at = now
-    run.exit_status = "dispatch_failed"
+    run.exit_status = error_code[:64]
     db.commit()
 
 

--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -912,7 +912,7 @@ export function SessionChat({
                 <span
                   className={`session-chat-queued__status session-chat-queued__status--${row.status}`}
                 >
-                  {row.status === "delivering" ? "Sending…" : "Queued"}
+                  {row.status === "delivering" ? row.last_error || "Sending…" : "Queued"}
                 </span>
                 {row.status === "queued" ? (
                   <button

--- a/web/src/components/__tests__/SessionChat.test.tsx
+++ b/web/src/components/__tests__/SessionChat.test.tsx
@@ -691,6 +691,34 @@ describe("SessionChat", () => {
     expect(screen.getByRole("button", { name: /cancel queued message/i })).toBeEnabled();
   });
 
+  it("shows an uncertain Console dispatch instead of leaving it silently sending", async () => {
+    requestMock.mockImplementation((path: string, init?: RequestInit) => {
+      if (String(path).endsWith("/lock")) {
+        return Promise.resolve({ locked: false, fork_available: false });
+      }
+      if (String(path).endsWith("/inputs") && !init) {
+        return Promise.resolve([
+          {
+            id: 43,
+            text: "survive the reconnect",
+            intent: "auto",
+            status: "delivering",
+            created_at: null,
+            last_error: "turn_start_outcome_unknown: Machine control channel disconnected",
+          },
+        ]);
+      }
+      return Promise.reject(new Error(`Unexpected request: ${path}`));
+    });
+
+    renderSessionChat({ chatMode: "managed_local", canQueueNextInput: true });
+
+    const chip = await screen.findByTestId("session-chat-queued");
+    expect(chip).toHaveTextContent("survive the reconnect");
+    expect(chip).toHaveTextContent("turn_start_outcome_unknown: Machine control channel disconnected");
+    expect(chip).not.toHaveTextContent("Sending…");
+  });
+
   it("shows Send update primary + Queue next secondary when steer capability is on", async () => {
     const user = userEvent.setup();
     const queryClient = new QueryClient({

--- a/web/src/hooks/__tests__/useSessionWorkspace.test.tsx
+++ b/web/src/hooks/__tests__/useSessionWorkspace.test.tsx
@@ -343,6 +343,29 @@ describe("useSessionWorkspace", () => {
     );
   });
 
+  it("keeps Console control state polling after the workspace stream connects", () => {
+    let handlers: { onConnected?: () => void } | undefined;
+    const consoleSession = {
+      ...baseSession,
+      session_state: makeSessionStateFacts({ mode: "console", startTurnAvailable: true }),
+    };
+    seedHookMocks(0, { session_state: consoleSession.session_state });
+    streamMocks.connectSessionWorkspaceStream.mockImplementation((_sessionId, nextHandlers) => {
+      handlers = nextHandlers;
+      return vi.fn();
+    });
+
+    renderHook(() => useSessionWorkspace(baseSession.id));
+    act(() => handlers?.onConnected?.());
+
+    const options = agentSessionMocks.useAgentSessionWorkspace.mock.calls.at(-1)?.[1];
+    expect(
+      options?.refetchInterval({
+        state: { data: { session: consoleSession }, error: null },
+      } as never),
+    ).toBe(5_000);
+  });
+
   it("invalidates the workspace query itself when the SSE stream reports a change", () => {
     let handlers:
       | {

--- a/web/src/hooks/useSessionWorkspace.ts
+++ b/web/src/hooks/useSessionWorkspace.ts
@@ -172,6 +172,14 @@ export function useSessionWorkspace(
       // Slow reconciliation: server flips unpaired tool calls to "dropped"
       // after 1h on demand, so we re-ask occasionally even when SSE is quiet.
       if (streamConnected) {
+        // Machine-control connect/disconnect is process-local state, not a
+        // durable workspace mutation, so it does not wake the session SSE
+        // stream. Keep a focused Console workspace polling until that state
+        // has its own fanout contract; otherwise "Control offline" can remain
+        // stale forever after the Machine Agent reconnects.
+        if (currentSession.session_state.mode === "console") {
+          return WORKSPACE_FALLBACK_REFRESH_MS;
+        }
         return workspaceHasRunningTool(query.state.data)
           ? WORKSPACE_RECONCILE_REFRESH_MS
           : false;


### PR DESCRIPTION
## Summary
- advertise Claude turn-start only when lifecycle hooks are actually configured
- preserve typed launch failures through the engine, catalog, API, logs, and turn-level UI
- refresh stale Console control state after Machine Agent reconnects
- replay ambiguous starting turns with the same durable run ID after Runtime Host replacement
- keep unresolved transport outcomes ownership-blocking and visibly marked as turn_start_outcome_unknown
- correct the hosted diagnostic SSH target

## Verification
- targeted Python Console/catalog/control suites
- Rust control-channel suite
- SessionChat and workspace hook tests
- TypeScript and lint checks
- branch CI, Web Quality, and installer validation