### PR TITLE
Show durable Console failures on their input

### DIFF
--- a/web/src/components/SessionChat.tsx
+++ b/web/src/components/SessionChat.tsx
@@ -478,13 +478,34 @@ export function SessionChat({
         }
         return true;
       } catch (e) {
+        // Console turn-start failures are durable input receipts. Refresh them
+        // immediately so the failed message stays attached to the turn instead
+        // of being represented only by a transient request error.
+        let persistedFailure = false;
+        try {
+          const refreshedInputs = await fetchSessionInputs(session.id);
+          queryClient.setQueryData<QueuedInputSummary[]>(
+            ["session-inputs", session.id],
+            refreshedInputs,
+          );
+          persistedFailure = refreshedInputs.some(
+            (row) => row.status === "failed" && row.text === message,
+          );
+        } catch {
+          // Preserve the request error when the receipt cannot be refreshed.
+        }
+
         // Parse structured backend errors so turn_ended on steer surfaces
         // as an actionable prompt, not a mystery failure.
-        const errorBody = (e as { body?: { detail?: { error_code?: string; message?: string } } })?.body;
-        const errorCode = errorBody?.detail?.error_code;
+        const errorBody = (e as {
+          body?: { detail?: { code?: string; error_code?: string; message?: string } };
+        })?.body;
+        const errorCode = errorBody?.detail?.error_code ?? errorBody?.detail?.code;
         if (intent === "steer" && errorCode === "turn_ended") {
           setTurnEndedDraft(message);
           setError(errorBody?.detail?.message ?? "Active turn ended before your update arrived.");
+        } else if (persistedFailure) {
+          setError(null);
         } else {
           setError(e instanceof Error ? e.message : "Unknown error");
         }

--- a/web/src/components/__tests__/SessionChat.test.tsx
+++ b/web/src/components/__tests__/SessionChat.test.tsx
@@ -719,6 +719,57 @@ describe("SessionChat", () => {
     expect(chip).not.toHaveTextContent("Sending…");
   });
 
+  it("shows a persisted Console launch failure on the input instead of a request banner", async () => {
+    const user = userEvent.setup();
+    let inputReads = 0;
+    requestMock.mockImplementation((path: string, init?: RequestInit) => {
+      if (String(path).endsWith("/lock")) {
+        return Promise.resolve({ locked: false, fork_available: false });
+      }
+      if (String(path).endsWith("/inputs") && !init) {
+        inputReads += 1;
+        return Promise.resolve(
+          inputReads === 1
+            ? []
+            : [
+                {
+                  id: null,
+                  live_input_id: "failed-console-input",
+                  text: "launch from missing cwd",
+                  intent: "auto",
+                  status: "failed",
+                  created_at: null,
+                  last_error: "cwd_not_found: cwd does not exist: /missing",
+                },
+              ],
+        );
+      }
+      if (String(path).endsWith("/input") && init?.method === "POST") {
+        return Promise.reject(
+          Object.assign(new Error("Request failed (502)"), {
+            body: {
+              detail: {
+                code: "cwd_not_found",
+                message: "cwd does not exist: /missing",
+              },
+            },
+          }),
+        );
+      }
+      return Promise.reject(new Error(`Unexpected request: ${path}`));
+    });
+
+    renderSessionChat({ chatMode: "managed_local", canQueueNextInput: true });
+
+    await user.type(screen.getByRole("textbox"), "launch from missing cwd");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    const failure = await screen.findByTestId("session-chat-queued-failed");
+    expect(failure).toHaveTextContent("launch from missing cwd");
+    expect(failure).toHaveTextContent("cwd_not_found: cwd does not exist: /missing");
+    expect(screen.queryByText("Request failed (502)")).not.toBeInTheDocument();
+  });
+
   it("shows Send update primary + Queue next secondary when steer capability is on", async () => {
     const user = userEvent.setup();
     const queryClient = new QueryClient({


### PR DESCRIPTION
## Summary
- refresh durable input receipts immediately after a failed Console dispatch
- suppress the generic request banner when the failure is represented by its per-turn receipt
- accept both `code` and `error_code` typed backend errors

## Production reproduction
An intentionally invalid cube cwd returned `cwd_not_found`; the API persisted the failed input correctly, but the UI remained at `0 entries` with only `Request failed (502)`.

## Verification
- SessionChat: 22 tests passed
- TypeScript validation passed
- pre-commit frontend lint/type checks passed