### PR TITLE
Factory: finish provider startup handshakes

### DIFF
--- a/server/tests_lite/test_provider_native_resume.py
+++ b/server/tests_lite/test_provider_native_resume.py
@@ -381,6 +381,29 @@ def test_claude_tui_readiness_waits_for_the_provider_input_prompt(tmp_path: Path
     assert process.settled is True
 
 
+def test_claude_tui_readiness_accepts_the_bare_prompt_after_a_turn(tmp_path: Path) -> None:
+    recording = tmp_path / "claude.tty"
+    recording.write_text("\n❯\u00a0\n", encoding="utf-8")
+
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.recording = recording
+            self.process = SimpleNamespace(poll=lambda: None)
+            self.settled = False
+
+        def drain(self) -> bytes:
+            return b""
+
+        def settle(self) -> bytes:
+            self.settled = True
+            return b""
+
+    process = FakeProcess()
+    _wait_claude_tui_ready(process, recording, timeout=2)  # type: ignore[arg-type]
+
+    assert process.settled is True
+
+
 def test_opencode_readiness_does_not_treat_disconnected_logs_as_connected() -> None:
     assert _opencode_tui_is_connected("OpenCode event monitor disconnected; retrying") is False
     assert _opencode_tui_is_connected("OpenCode connection lost; retrying") is False
@@ -909,7 +932,7 @@ def test_cursor_initial_seed_bootstraps_through_the_provider_pty(tmp_path: Path)
 
     assert result["method"] == "provider_tty_bootstrap"
     assert result["returncode"] == 0
-    assert process.sent == ["seed\r"]
+    assert process.sent == ["seed", "\x1b", "\r"]
 
 
 def test_cursor_control_send_retries_only_provider_idle_race(tmp_path: Path, monkeypatch) -> None:

--- a/server/zerg/qa/provider_native_resume.py
+++ b/server/zerg/qa/provider_native_resume.py
@@ -929,8 +929,13 @@ def _wait_claude_tui_ready(process: PtyProcess, recording: Path, *, timeout: flo
         # channel server never initializes.
         _accept_claude_permission_prompt(process)
         _accept_claude_development_channel_prompt(process)
-        terminal = _terminal_text(process.recording)
-        if re.search(r"[❯>]\s*Try\b", terminal):
+        terminal = _terminal_text(process.recording).replace("\u00a0", " ")
+        # Claude 2.1.221 renders a bare `❯` after the first turn, while older
+        # builds include the `Try ...` placeholder. Both are the same
+        # provider-owned input boundary. Keep the historical placeholder
+        # match for redraws where the marker shares a line with screen text;
+        # the bare form is line-anchored so transcript text cannot satisfy it.
+        if re.search(r"[❯>]\s*Try\b", terminal) or re.search(r"(?m)^[ \t]*[❯>][ \t]*$", terminal):
             process.settle()
             return
         time.sleep(0.1)
@@ -965,7 +970,7 @@ def _state_candidate_diagnostics(spec: ProviderSpec, home: Path) -> list[dict[st
     return rows
 
 
-def _wait_opencode_tui_ready(process: PtyProcess, recording: Path, *, timeout: float = 60.0) -> None:
+def _wait_opencode_tui_ready(process: PtyProcess, recording: Path, *, timeout: float = 120.0) -> None:
     """Wait for the attached TUI, not merely the localhost bridge, to accept input."""
 
     deadline = time.monotonic() + timeout
@@ -1547,7 +1552,15 @@ def _control_send(
         # the authoritative Helm socket below.
         if process.process.poll() is not None:
             raise RuntimeError("cursor terminal control owner is no longer live")
-        process.send(text + "\r")
+        # Keep this byte sequence aligned with the native Cursor Helm socket:
+        # text, an escape to dismiss its completion overlay, then Enter. A
+        # single `text\\r` write can leave the text visible in the input box
+        # without submitting the foreground prompt.
+        process.send(text)
+        time.sleep(0.3)
+        process.send("\x1b")
+        time.sleep(0.1)
+        process.send("\r")
         return {"method": "provider_tty_bootstrap", "returncode": 0}
     elif spec.provider == "cursor":
         command = [str(args.engine), "cursor-helm", "send", "--session-id", state["session_id"], "--text", text]


### PR DESCRIPTION
Live factory evidence from the exact 2d01e912 + 27b23c436 pair exposed three provider-owned readiness races after Codex passed: Claude bare input prompt, Cursor PTY bootstrap submission, and OpenCode startup latency. This draft contains the bounded producer fixes.\n\nValidation: uv run pytest tests_lite/test_provider_native_resume.py -q (54 passed); uv run ruff check zerg/qa/provider_native_resume.py tests_lite/test_provider_native_resume.py. The prior candidate was rolled back by the factory; do not merge this draft until it receives the required independent Opus review and exact-pair qualification.