### PR TITLE
Finalize failed Resume evidence manifests

### DIFF
--- a/docs/generated/provider_census.json
+++ b/docs/generated/provider_census.json
@@ -8,7 +8,7 @@
     "opencode",
     "pi"
   ],
-  "file_count": 245,
+  "file_count": 247,
   "files": [
     {
       "path": "desktop/LonghouseMenuBarHarness/Sources/LonghouseMenuBarCore/ActionSink.swift",
@@ -106,7 +106,8 @@
         "claude",
         "codex",
         "cursor",
-        "opencode"
+        "opencode",
+        "pi"
       ]
     },
     {
@@ -125,7 +126,8 @@
         "claude",
         "codex",
         "cursor",
-        "opencode"
+        "opencode",
+        "pi"
       ]
     },
     {
@@ -144,7 +146,8 @@
         "claude",
         "codex",
         "cursor",
-        "opencode"
+        "opencode",
+        "pi"
       ]
     },
     {
@@ -295,7 +298,8 @@
         "antigravity",
         "claude",
         "codex",
-        "opencode"
+        "opencode",
+        "pi"
       ]
     },
     {
@@ -605,6 +609,13 @@
       ]
     },
     {
+      "path": "server/scripts/render_provider_factory_status.py",
+      "providers": [
+        "cursor",
+        "pi"
+      ]
+    },
+    {
       "path": "server/tests/integration/test_shipper_e2e.py",
       "providers": [
         "antigravity",
@@ -722,6 +733,13 @@
       "providers": [
         "codex",
         "cursor"
+      ]
+    },
+    {
+      "path": "server/tests_lite/test_catalogd_console_sessions.py",
+      "providers": [
+        "codex",
+        "pi"
       ]
     },
     {
@@ -968,7 +986,8 @@
         "claude",
         "codex",
         "cursor",
-        "opencode"
+        "opencode",
+        "pi"
       ]
     },
     {
@@ -1083,7 +1102,8 @@
         "claude",
         "codex",
         "cursor",
-        "opencode"
+        "opencode",
+        "pi"
       ]
     },
     {
@@ -1103,7 +1123,8 @@
         "claude",
         "codex",
         "cursor",
-        "opencode"
+        "opencode",
+        "pi"
       ]
     },
     {
@@ -1661,7 +1682,8 @@
         "claude",
         "codex",
         "cursor",
-        "opencode"
+        "opencode",
+        "pi"
       ]
     },
     {
@@ -1687,7 +1709,8 @@
         "claude",
         "codex",
         "cursor",
-        "opencode"
+        "opencode",
+        "pi"
       ]
     },
     {

--- a/server/tests_lite/test_provider_native_resume.py
+++ b/server/tests_lite/test_provider_native_resume.py
@@ -35,6 +35,7 @@ from zerg.qa.provider_native_resume import _opencode_tui_is_connected
 from zerg.qa.provider_native_resume import _post_resume_response_correlated
 from zerg.qa.provider_native_resume import _provider_process_pid
 from zerg.qa.provider_native_resume import _provision_transcript_roots
+from zerg.qa.provider_native_resume import _refresh_failure_result_manifest
 from zerg.qa.provider_native_resume import _resume_intent_timeout
 from zerg.qa.provider_native_resume import _resume_marker
 from zerg.qa.provider_native_resume import _resume_marker_prompt
@@ -1911,6 +1912,27 @@ def test_cleanup_retains_failed_pid_identity_as_unverified_receipt() -> None:
     assert receipt["verified"] is False
     assert receipt["orphan_count"] == 1
     assert receipt["provider_pid_errors"][0]["session_id"] == "session-without-provider-pid"
+
+
+def test_failure_manifest_is_refreshed_after_final_cleanup(tmp_path: Path) -> None:
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    (evidence / "cleanup-receipt.json").write_text('{"verified":true}\n')
+    (evidence / "result.json").write_text(
+        json.dumps(
+            {
+                "status": "fail",
+                "artifact_manifest": [],
+            }
+        )
+    )
+
+    _refresh_failure_result_manifest(evidence)
+
+    result = json.loads((evidence / "result.json").read_text())
+    manifest = {entry["path"]: entry for entry in result["artifact_manifest"]}
+    assert manifest["cleanup-receipt.json"]["size"] == (evidence / "cleanup-receipt.json").stat().st_size
+    assert manifest["cleanup-receipt.json"]["sha256"].startswith("sha256:")
 
 
 def test_antigravity_policy_proof_has_no_registration_or_spawn(tmp_path: Path) -> None:

--- a/server/zerg/qa/provider_native_resume.py
+++ b/server/zerg/qa/provider_native_resume.py
@@ -923,6 +923,29 @@ def _read_json(path: Path) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _refresh_failure_result_manifest(root: Path) -> None:
+    """Hash failure evidence after final cleanup has been written.
+
+    The failure path writes ``result.json`` before the ``finally`` block tears
+    down provider processes and records ``cleanup-receipt.json``.  Refreshing
+    the manifest after that finalization keeps failure evidence exhaustive and
+    prevents a legitimate cleanup receipt from looking like a TOCTOU mutation.
+    ``result.json`` is intentionally excluded by ``_artifact_manifest``.
+    """
+
+    result_path = root / "result.json"
+    if not result_path.is_file() or result_path.is_symlink():
+        return
+    try:
+        result = _read_json(result_path)
+    except (OSError, ValueError, TypeError):
+        return
+    if result.get("status") != "fail":
+        return
+    result["artifact_manifest"] = _artifact_manifest(root)
+    _write_json(result_path, result)
+
+
 def _terminal_text(path: Path) -> str:
     try:
         raw = path.read_bytes()
@@ -2922,6 +2945,7 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
         if shipper is not None:
             _write_json(root / "transcript-shipper-receipt.json", shipper.stop())
         _close_recordings((concurrent, resumed, initial))
+        _refresh_failure_result_manifest(root)
         redacted = _secret_scan(root, list(_qualification_secrets(environment, args.agents_token)))
         observation = {
             "variant": args.variant,


### PR DESCRIPTION
Failure-path Resume artifacts were finalized after result.json was hashed, so cleanup-receipt.json could not satisfy the immutable manifest validator. Refresh the failure manifest after process cleanup and add focused coverage.

Tests: make test-backend-single TEST=tests_lite/test_provider_native_resume.py (87 passed).