### PR TITLE
Give Cursor graceful exits a bounded 30-second window

### DIFF
--- a/server/tests_lite/test_provider_native_resume.py
+++ b/server/tests_lite/test_provider_native_resume.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import signal
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -1726,6 +1727,7 @@ def test_cursor_clean_stop_waits_for_provider_idle_before_exit(tmp_path: Path, m
     args = _args(tmp_path)
     args.live_send_timeout_secs = 17
     calls: list[tuple[str, object]] = []
+    wait_timeouts: list[float] = []
 
     class FakeProviderProcess:
         pid = 101
@@ -1739,6 +1741,7 @@ def test_cursor_clean_stop_waits_for_provider_idle_before_exit(tmp_path: Path, m
 
         @staticmethod
         def wait(_timeout: float) -> int:
+            wait_timeouts.append(_timeout)
             return 0
 
         @staticmethod
@@ -1771,6 +1774,7 @@ def test_cursor_clean_stop_waits_for_provider_idle_before_exit(tmp_path: Path, m
 
     assert receipt["clean"] is True
     assert calls == [("idle", {"timeout": 15.0}), ("send", "/exit")]
+    assert wait_timeouts == [30]
 
 
 def test_cursor_clean_stop_recovers_stranded_generation_before_exit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1828,6 +1832,47 @@ def test_cursor_clean_stop_recovers_stranded_generation_before_exit(tmp_path: Pa
     assert receipt["clean"] is True
     assert receipt["cursor_recovery"]["method"] == "cursor_ctrl_c_recovery"
     assert calls == [("idle", {"timeout": 15.0}), ("interrupt", {}), ("send", "/exit")]
+
+
+def test_cursor_forced_stop_keeps_short_shutdown_wait(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    args = _args(tmp_path)
+    wait_timeouts: list[float] = []
+    kill_signals: list[int] = []
+
+    class FakeProviderProcess:
+        pid = 101
+
+        class Process:
+            @staticmethod
+            def poll() -> int:
+                return 0
+
+        process = Process()
+
+        @staticmethod
+        def wait(timeout: float) -> int:
+            wait_timeouts.append(timeout)
+            return 0
+
+        @staticmethod
+        def kill_group(signal_number: int) -> None:
+            kill_signals.append(signal_number)
+
+    monkeypatch.setattr(provider_native_resume, "_wait_process_group_dead", lambda _pid: True)
+    monkeypatch.setattr(provider_native_resume, "_wait_pid_dead", lambda _pid: True)
+    monkeypatch.setattr(provider_native_resume, "_signal_pid_if_alive", lambda *_args: False)
+
+    receipt = provider_native_resume._stop(
+        SPECS["cursor"],
+        args,
+        {"session_id": "session-1", "cursor_pid": 202},
+        FakeProviderProcess(),  # type: ignore[arg-type]
+        force=True,
+    )
+
+    assert wait_timeouts == [10]
+    assert kill_signals == [signal.SIGKILL]
+    assert receipt["clean"] is False
 
 
 def test_cursor_interrupt_recovery_rejects_stale_conversation_before_signal(tmp_path: Path) -> None:

--- a/server/zerg/qa/provider_native_resume.py
+++ b/server/zerg/qa/provider_native_resume.py
@@ -2601,7 +2601,14 @@ def _stop(
             time.sleep(0.2)
             process.send("\x04")
         method = "claude_terminal_eof"
-    exit_code = process.wait(30 if spec.provider == "opencode" else 10)
+    # Cursor's native `/exit` is acknowledged before the outer Helm process
+    # has necessarily finished its shutdown.  Ten seconds is short enough to
+    # turn a slow but graceful exit into a SIGTERM fallback, which is
+    # deliberately unacceptable evidence for the clean-exit assurance cell.
+    # Keep the wait bounded, but give Cursor the same generous window used by
+    # the other interactive wrapper with a known asynchronous teardown.
+    exit_wait_timeout = 30 if spec.provider == "opencode" or (spec.provider == "cursor" and not force) else 10
+    exit_code = process.wait(exit_wait_timeout)
     fallback_signal: str | None = None
     if exit_code is None:
         fallback_signal = "SIGKILL" if force else "SIGTERM"

--- a/web/src/generated/openapi-types.ts
+++ b/web/src/generated/openapi-types.ts
@@ -6617,6 +6617,13 @@ export interface components {
              */
             permission_mode: string;
             /**
+             * Provider Config
+             * @description Provider-specific launch config stored on the thread and spread into Console turn dispatch
+             */
+            provider_config?: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Launch Actor
              * @description Positive launch actor provenance when known
              */
@@ -6681,7 +6688,7 @@ export interface components {
          *     Transport is auto-determined by launch context — not user-selectable.
          * @enum {string}
          */
-        ManagedSessionTransport: "claude_channel_bridge" | "codex_app_server" | "opencode_server_bridge" | "opencode_process" | "antigravity_hook_inbox" | "antigravity_process" | "cursor_exec" | "cursor_acp" | "cursor_helm";
+        ManagedSessionTransport: "claude_channel_bridge" | "codex_app_server" | "opencode_server_bridge" | "opencode_process" | "antigravity_hook_inbox" | "antigravity_process" | "cursor_exec" | "cursor_acp" | "cursor_helm" | "pi_print";
         /** ManagedTurnProviderSummaryResponse */
         ManagedTurnProviderSummaryResponse: {
             /** Completed Turns */


### PR DESCRIPTION
## Summary

- allow graceful Cursor `/exit` shutdown up to 30 seconds
- preserve the strict clean-exit rule: forced/fallback termination never qualifies
- add regression coverage for graceful and forced Cursor shutdown timing

## Validation

- `make test-backend-single TEST=tests_lite/test_provider_native_resume.py` (94 passed)
- Hatch Codex Sol review: GO

This is required by the provider-factory Resume assurance gate after a real Cursor clean-exit attempt exceeded the previous 10-second window.