### PR TITLE
Finalize failed Resume evidence after teardown

### DIFF
--- a/server/tests_lite/test_provider_native_resume.py
+++ b/server/tests_lite/test_provider_native_resume.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import signal
 import subprocess
@@ -30,6 +31,7 @@ from zerg.qa.provider_native_resume import _cursor_bootstrap_prompt
 from zerg.qa.provider_native_resume import _cursor_idle_then_flush
 from zerg.qa.provider_native_resume import _cursor_interrupt_to_idle
 from zerg.qa.provider_native_resume import _cursor_tui_input_ready
+from zerg.qa.provider_native_resume import _finalize_result_payload
 from zerg.qa.provider_native_resume import _initialize_cursor_workspace
 from zerg.qa.provider_native_resume import _isolated_provider_home
 from zerg.qa.provider_native_resume import _launch_command
@@ -2291,6 +2293,203 @@ def test_failure_manifest_is_refreshed_after_final_cleanup(tmp_path: Path) -> No
     manifest = {entry["path"]: entry for entry in result["artifact_manifest"]}
     assert manifest["cleanup-receipt.json"]["size"] == (evidence / "cleanup-receipt.json").stat().st_size
     assert manifest["cleanup-receipt.json"]["sha256"].startswith("sha256:")
+
+
+def test_finalized_secret_scan_downgrades_pass_and_refreshes_manifest(tmp_path: Path) -> None:
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    receipt = evidence / "cleanup-receipt.json"
+    receipt.write_text('{"verified":true}\n')
+    result = {
+        "status": "pass",
+        "artifact_manifest": [],
+        "observation": {"artifact_secret_scan_passed": True},
+        "assertions": {"native_provider_resume_proven": True},
+    }
+    (evidence / "result.json").write_text(json.dumps(result))
+
+    finalized = _finalize_result_payload(
+        evidence,
+        result,
+        redacted_files=["cleanup-receipt.json"],
+        finalization_errors=[],
+    )
+
+    written = json.loads((evidence / "result.json").read_text())
+    manifest = {entry["path"]: entry for entry in written["artifact_manifest"]}
+    assert finalized == written
+    assert written["status"] == "fail"
+    assert written["failure_code"] == "finalized_artifact_secret_scan_failed"
+    assert written["observation"]["artifact_secret_scan_passed"] is False
+    assert written["assertions"]["native_provider_resume_proven"] is False
+    assert manifest["cleanup-receipt.json"]["sha256"] == (
+        "sha256:" + hashlib.sha256(receipt.read_bytes()).hexdigest()
+    )
+
+
+@pytest.mark.parametrize(
+    ("redacted_files", "failed_write_calls"),
+    (([], (2,)), (["cleanup-receipt.json"], (1, 3))),
+)
+def test_final_result_write_failure_removes_stale_green_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    redacted_files: list[str],
+    failed_write_calls: tuple[int, ...],
+) -> None:
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    (evidence / "cleanup-receipt.json").write_text('{"verified":true}\n')
+    (evidence / "result.json").write_text(
+        json.dumps(
+            {
+                "status": "pass",
+                "artifact_manifest": [],
+                "observation": {"artifact_secret_scan_passed": True},
+                "assertions": {"native_provider_resume_proven": True},
+            }
+        )
+    )
+    original_write_json = provider_native_resume._write_json
+    write_calls = 0
+
+    def fail_second_write(path: Path, payload: object) -> None:
+        nonlocal write_calls
+        write_calls += 1
+        if write_calls in failed_write_calls:
+            raise OSError("final result filesystem race")
+        original_write_json(path, payload)
+
+    monkeypatch.setattr(provider_native_resume, "_write_json", fail_second_write)
+
+    finalized = _finalize_result_payload(
+        evidence,
+        {
+            "status": "pass",
+            "artifact_manifest": [],
+            "observation": {"artifact_secret_scan_passed": True},
+            "assertions": {"native_provider_resume_proven": True},
+        },
+        redacted_files=redacted_files,
+        finalization_errors=[],
+    )
+
+    assert write_calls == max(failed_write_calls)
+    assert finalized is not None
+    assert finalized["status"] == "fail"
+    assert finalized["failure_code"] in {
+        "finalization_failed",
+        "finalized_artifact_secret_scan_failed",
+    }
+    assert not (evidence / "result.json").exists()
+
+
+@pytest.mark.parametrize("first_cleanup_raises", [False, True])
+def test_run_native_resume_refreshes_failure_manifest_after_finally_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    first_cleanup_raises: bool,
+) -> None:
+    """Exercise the real failure path, including the second finally cleanup."""
+
+    home = tmp_path / "provider-home"
+    home.mkdir()
+    provider_bin = tmp_path / "provider"
+    provider_bin.write_text("#!/bin/sh\nprintf 'test-provider\\n'\n", encoding="utf-8")
+    provider_bin.chmod(0o755)
+    args = _args(tmp_path)
+    args.evidence_root = tmp_path / "evidence"
+    args.provider_bin = provider_bin
+    args.variant = "clean_exit"
+    args.live_send_timeout_secs = 1
+
+    class FakeProcess:
+        process = SimpleNamespace(poll=lambda: None)
+
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def settle(self) -> None:
+            pass
+
+    class FakeShipper:
+        receipt = {"status": "pass", "events_shipped": 0}
+
+        def __init__(self) -> None:
+            self.stop_calls = 0
+
+        def flush(self, _label: str) -> dict[str, object]:
+            return self.receipt
+
+        def stop(self) -> dict[str, object]:
+            self.stop_calls += 1
+            return {"status": "pass", "process_dead": True, "stop_generation": self.stop_calls}
+
+    cleanup_calls = 0
+    shipper: FakeShipper | None = None
+
+    def fake_start_shipper(*_args: object, **_kwargs: object) -> FakeShipper:
+        nonlocal shipper
+        shipper = FakeShipper()
+        return shipper
+
+    def fake_cleanup(*_args: object, **_kwargs: object) -> dict[str, object]:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        if first_cleanup_raises and cleanup_calls == 1:
+            raise OSError("cleanup receipt raced with process exit")
+        return {"verified": cleanup_calls > 1, "cleanup_generation": cleanup_calls}
+
+    monkeypatch.setattr(provider_native_resume, "_isolated_provider_home", lambda: home)
+    monkeypatch.setattr(provider_native_resume, "_launch_command", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(provider_native_resume, "PtyProcess", FakeProcess)
+    monkeypatch.setattr(provider_native_resume, "_start_transcript_shipper", fake_start_shipper)
+    monkeypatch.setattr(provider_native_resume, "_wait_opencode_tui_ready", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        provider_native_resume,
+        "_wait_state",
+        lambda *_args, **_kwargs: {
+            "session_id": "session-1",
+            "run_id": "run-1",
+            "connection_id": "connection-1",
+            "provider_session_id": "provider-session-1",
+            "claude_pid": 101,
+        },
+    )
+    monkeypatch.setattr(provider_native_resume, "_provider_process_pid", lambda *_args: 101)
+    monkeypatch.setattr(provider_native_resume, "_wait_session_tail", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(provider_native_resume, "_assistant_event_digests", lambda *_args: set())
+    monkeypatch.setattr(provider_native_resume, "_control_send", lambda *_args, **_kwargs: {"returncode": 0})
+    monkeypatch.setattr(
+        provider_native_resume,
+        "_wait_assistant_response_after_marker",
+        lambda *_args, **_kwargs: ({}, {"marker_observed_in_transcript": False, "new_assistant_events": 0}),
+    )
+    monkeypatch.setattr(provider_native_resume, "_cleanup_processes", fake_cleanup)
+    monkeypatch.setattr(provider_native_resume, "_close_recordings", lambda *_args: None)
+    monkeypatch.setattr(provider_native_resume, "_secret_scan", lambda *_args: [])
+
+    result = provider_native_resume.run_native_resume("opencode", args)
+
+    assert result["status"] == "fail"
+    assert result["error"].startswith("RuntimeError: provider transcript did not correlate initial opencode marker")
+    assert cleanup_calls == 2
+    assert shipper is not None
+    assert shipper.stop_calls == 2
+    written = json.loads((args.evidence_root / "result.json").read_text())
+    manifest = {entry["path"]: entry for entry in written["artifact_manifest"]}
+    receipt = args.evidence_root / "cleanup-receipt.json"
+    assert json.loads(receipt.read_text())["cleanup_generation"] == 2
+    assert manifest["cleanup-receipt.json"]["size"] == receipt.stat().st_size
+    assert manifest["cleanup-receipt.json"]["sha256"] == (
+        "sha256:" + hashlib.sha256(receipt.read_bytes()).hexdigest()
+    )
+    ship_receipt = args.evidence_root / "transcript-shipper-receipt.json"
+    assert json.loads(ship_receipt.read_text())["stop_generation"] == 2
+    assert manifest["transcript-shipper-receipt.json"]["sha256"] == (
+        "sha256:" + hashlib.sha256(ship_receipt.read_bytes()).hexdigest()
+    )
+    assert result == written
 
 
 def test_antigravity_policy_proof_has_no_registration_or_spawn(tmp_path: Path) -> None:

--- a/server/zerg/qa/provider_native_resume.py
+++ b/server/zerg/qa/provider_native_resume.py
@@ -923,8 +923,8 @@ def _read_json(path: Path) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _refresh_failure_result_manifest(root: Path) -> None:
-    """Hash failure evidence after final cleanup has been written.
+def _refresh_result_manifest(root: Path) -> dict[str, Any] | None:
+    """Hash result evidence after final cleanup has been written.
 
     The failure path writes ``result.json`` before the ``finally`` block tears
     down provider processes and records ``cleanup-receipt.json``.  Refreshing
@@ -935,15 +935,100 @@ def _refresh_failure_result_manifest(root: Path) -> None:
 
     result_path = root / "result.json"
     if not result_path.is_file() or result_path.is_symlink():
-        return
+        return None
     try:
         result = _read_json(result_path)
     except (OSError, ValueError, TypeError):
-        return
-    if result.get("status") != "fail":
-        return
-    result["artifact_manifest"] = _artifact_manifest(root)
-    _write_json(result_path, result)
+        return None
+    if result.get("status") not in {"fail", "pass"}:
+        return None
+    try:
+        result["artifact_manifest"] = _artifact_manifest(root)
+        _write_json(result_path, result)
+    except (OSError, TypeError, ValueError):
+        return None
+    return result
+
+
+def _refresh_failure_result_manifest(root: Path) -> dict[str, Any] | None:
+    """Backward-compatible name for callers that refresh failure evidence."""
+
+    return _refresh_result_manifest(root)
+
+
+def _finalize_result_payload(
+    root: Path,
+    payload: dict[str, Any] | None,
+    *,
+    redacted_files: list[str],
+    finalization_errors: list[str],
+) -> dict[str, Any] | None:
+    """Persist a post-teardown result without certifying incomplete evidence."""
+
+    if payload is None:
+        return None
+
+    def mark_finalization_failure(reason: str) -> None:
+        if payload.get("status") != "pass":
+            return
+        payload["status"] = "fail"
+        payload["failure_code"] = "finalization_failed"
+        payload["error"] = reason
+        observation = payload.get("observation")
+        if isinstance(observation, dict):
+            observation["artifact_secret_scan_passed"] = False
+        assertions = payload.get("assertions")
+        if isinstance(assertions, dict):
+            assertions["native_provider_resume_proven"] = False
+
+    if finalization_errors:
+        mark_finalization_failure("; ".join(finalization_errors))
+    if redacted_files:
+        prior_redacted = payload.get("redacted_secret_files", [])
+        payload["redacted_secret_files"] = sorted(set(prior_redacted) | set(redacted_files))
+        if payload.get("status") == "pass":
+            payload["status"] = "fail"
+            payload["failure_code"] = "finalized_artifact_secret_scan_failed"
+            payload["error"] = "finalized evidence contained a qualification secret"
+            observation = payload.get("observation")
+            if isinstance(observation, dict):
+                observation["artifact_secret_scan_passed"] = False
+            assertions = payload.get("assertions")
+            if isinstance(assertions, dict):
+                assertions["native_provider_resume_proven"] = False
+
+    manifest_error: str | None = None
+    if redacted_files or finalization_errors:
+        try:
+            _write_json(root / "result.json", payload)
+        except Exception as exc:  # noqa: BLE001 - fail closed for a would-be pass
+            manifest_error = f"result write: {type(exc).__name__}: {exc}"
+    try:
+        refreshed_result = _refresh_result_manifest(root)
+        if refreshed_result is None:
+            manifest_error = manifest_error or "result manifest refresh returned no result"
+    except Exception as exc:  # noqa: BLE001 - never mask the causal result
+        refreshed_result = None
+        manifest_error = f"result manifest refresh: {type(exc).__name__}: {exc}"
+    if manifest_error:
+        mark_finalization_failure(manifest_error)
+    if refreshed_result is not None:
+        payload["artifact_manifest"] = refreshed_result["artifact_manifest"]
+    if redacted_files:
+        prior_redacted = payload.get("redacted_secret_files", [])
+        payload["redacted_secret_files"] = sorted(set(prior_redacted) | set(redacted_files))
+    try:
+        _write_json(root / "result.json", payload)
+    except OSError as exc:
+        # Never leave any previously written result behind when the final
+        # atomic write fails. Missing result evidence is rejected; stale
+        # green or stale failure evidence must not be accepted either.
+        try:
+            (root / "result.json").unlink()
+        except OSError:
+            pass
+        mark_finalization_failure(f"final result write: {type(exc).__name__}: {exc}")
+    return payload
 
 
 def _terminal_text(path: Path) -> str:
@@ -2812,6 +2897,7 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
     shipper: TranscriptShipper | None = None
     states: list[dict[str, Any]] = []
     final_cleanup: dict[str, Any] = {"verified": False}
+    result_payload: dict[str, Any] | None = None
     provider_cwd = args.repo_root
     try:
         home = _isolated_provider_home()
@@ -3233,7 +3319,6 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
         if shipper is not None:
             _write_json(root / "transcript-shipper-receipt.json", shipper.stop())
         _close_recordings((concurrent, resumed, initial))
-        _refresh_failure_result_manifest(root)
         redacted = _secret_scan(root, list(_qualification_secrets(environment, args.agents_token)))
         observation = {
             "variant": args.variant,
@@ -3288,6 +3373,7 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
             "post_resume_marker": post_marker,
             "artifact_manifest": _artifact_manifest(root),
         }
+        result_payload = result
         _write_json(root / "result.json", result)
         return result
     except Exception as exc:  # noqa: BLE001 - retain the exact causal failure
@@ -3304,12 +3390,30 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
                 _write_json(root / "state-candidates.json", _state_candidate_diagnostics(spec, home))
         except (OSError, TypeError):
             pass
-        final_cleanup = _cleanup_processes(spec, (initial, resumed, concurrent), states)
-        _write_json(root / "cleanup-receipt.json", final_cleanup)
+        try:
+            final_cleanup = _cleanup_processes(spec, (initial, resumed, concurrent), states)
+        except Exception as cleanup_exc:  # noqa: BLE001 - preserve the provider failure
+            final_cleanup = {
+                "verified": False,
+                "teardown_error": f"{type(cleanup_exc).__name__}: {cleanup_exc}",
+            }
+        try:
+            _write_json(root / "cleanup-receipt.json", final_cleanup)
+        except OSError:
+            pass
         if shipper is not None:
-            _write_json(root / "transcript-shipper-receipt.json", shipper.stop())
-        _close_recordings((concurrent, resumed, initial))
-        redacted = _secret_scan(root, list(_qualification_secrets(environment, args.agents_token)))
+            try:
+                _write_json(root / "transcript-shipper-receipt.json", shipper.stop())
+            except Exception:  # noqa: BLE001 - preserve the provider failure
+                pass
+        try:
+            _close_recordings((concurrent, resumed, initial))
+        except Exception:  # noqa: BLE001 - preserve the provider failure
+            pass
+        try:
+            redacted = _secret_scan(root, list(_qualification_secrets(environment, args.agents_token)))
+        except OSError:
+            redacted = []
         failure = {
             "schema_version": 1,
             "artifact_kind": "direct_native_resume_result",
@@ -3326,15 +3430,50 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
             "redacted_secret_files": redacted,
             "artifact_manifest": _artifact_manifest(root),
         }
+        result_payload = failure
         _write_json(root / "result.json", failure)
         return failure
     finally:
+        final_redacted: list[str] = []
+        finalization_errors: list[str] = []
         if shipper is not None:
-            _write_json(root / "transcript-shipper-receipt.json", shipper.stop())
+            try:
+                _write_json(root / "transcript-shipper-receipt.json", shipper.stop())
+            except Exception as exc:  # noqa: BLE001 - preserve the causal result
+                finalization_errors.append(f"transcript shipper stop: {type(exc).__name__}: {exc}")
         if not final_cleanup.get("verified"):
-            final_cleanup = _cleanup_processes(spec, (initial, resumed, concurrent), states)
-            _write_json(root / "cleanup-receipt.json", final_cleanup)
-        _close_recordings((concurrent, resumed, initial))
+            try:
+                final_cleanup = _cleanup_processes(spec, (initial, resumed, concurrent), states)
+            except Exception as cleanup_exc:  # noqa: BLE001 - preserve the causal result
+                final_cleanup = {
+                    "verified": False,
+                    "teardown_error": f"{type(cleanup_exc).__name__}: {cleanup_exc}",
+                }
+                finalization_errors.append(f"final cleanup: {type(cleanup_exc).__name__}: {cleanup_exc}")
+            try:
+                _write_json(root / "cleanup-receipt.json", final_cleanup)
+            except OSError as exc:
+                finalization_errors.append(f"cleanup receipt: {type(exc).__name__}: {exc}")
+        try:
+            _close_recordings((concurrent, resumed, initial))
+        except Exception as exc:  # noqa: BLE001 - preserve the causal result
+            finalization_errors.append(f"recording close: {type(exc).__name__}: {exc}")
+        try:
+            # Teardown can write receipts and flush terminal recordings. Scan
+            # those final bytes before pinning their manifest digests.
+            final_redacted = _secret_scan(root, list(_qualification_secrets(environment, args.agents_token)))
+        except OSError as exc:
+            finalization_errors.append(f"final secret scan: {type(exc).__name__}: {exc}")
+        finally:
+            # The result is written before this final cleanup guard runs.
+            # Refresh after the guard so teardown cannot invalidate its
+            # manifest, while keeping the in-memory return value identical.
+            _finalize_result_payload(
+                root,
+                result_payload,
+                redacted_files=final_redacted,
+                finalization_errors=finalization_errors,
+            )
 
 
 def parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary
- refresh the Resume result manifest after the final cleanup/shipper/recording writes
- keep returned and persisted failure payloads identical
- fail closed on teardown, secret-scan, or final result-write errors
- add integration and failure-injection coverage for stale manifests and stale green evidence

## Verification
- `make test-backend-single TEST=tests_lite/test_provider_native_resume.py` (99 passed)
- Hatch Sol final review: GO
- Hatch Opus independent review: GO with follow-ups incorporated

This fixes the retained Cursor assurance cases caused by cleanup-receipt TOCTOU.