### PR TITLE
Retain Cursor initial seed projection diagnostics

### DIFF
--- a/server/tests_lite/test_provider_native_resume.py
+++ b/server/tests_lite/test_provider_native_resume.py
@@ -4,6 +4,7 @@ import argparse
 import hashlib
 import json
 import signal
+import sqlite3
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -19,6 +20,7 @@ from zerg.qa.codex_native_resume import _validate_resume_intent
 from zerg.qa.codex_native_resume import _write_json as write_codex_json
 from zerg.qa.codex_native_resume import _write_resume_contract_snapshot
 from zerg.qa.provider_native_resume import SPECS
+from zerg.qa.provider_native_resume import TranscriptShipper
 from zerg.qa.provider_native_resume import _accept_claude_development_channel_prompt
 from zerg.qa.provider_native_resume import _accept_claude_permission_prompt
 from zerg.qa.provider_native_resume import _accept_cursor_workspace_trust
@@ -30,6 +32,7 @@ from zerg.qa.provider_native_resume import _cursor_bootstrap_correlation
 from zerg.qa.provider_native_resume import _cursor_bootstrap_prompt
 from zerg.qa.provider_native_resume import _cursor_idle_then_flush
 from zerg.qa.provider_native_resume import _cursor_interrupt_to_idle
+from zerg.qa.provider_native_resume import _cursor_projection_diagnostics
 from zerg.qa.provider_native_resume import _cursor_tui_input_ready
 from zerg.qa.provider_native_resume import _finalize_result_payload
 from zerg.qa.provider_native_resume import _initialize_cursor_workspace
@@ -53,6 +56,7 @@ from zerg.qa.provider_native_resume import _wait_cursor_idle
 from zerg.qa.provider_native_resume import _wait_cursor_tui_ready
 from zerg.qa.provider_native_resume import _wait_session_tail
 from zerg.qa.provider_native_resume import _wait_state
+from zerg.qa.provider_native_resume import _write_best_effort_json
 from zerg.qa.provider_native_resume import registration_for
 
 
@@ -882,6 +886,77 @@ def test_cursor_projection_diagnostics_capture_marker_and_binding_state(tmp_path
     assert payload["files"][0]["kind"] == "agent_transcript"
     assert payload["files"][0]["marker_observed"] is True
     assert payload["files"][0]["marker_count"] == 1
+
+
+def test_cursor_projection_diagnostics_retains_active_wal_marker(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    store = home / ".cursor" / "projects" / "conversation-1" / "store.db"
+    store.parent.mkdir(parents=True)
+
+    connection = sqlite3.connect(store)
+    try:
+        connection.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+        connection.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, value BLOB)")
+        connection.execute("INSERT INTO meta(key, value) VALUES ('0', 'conversation-1')")
+        connection.commit()
+    finally:
+        connection.close()
+    wal = store.with_name("store.db-wal")
+    wal.write_bytes(b"uncheckpointed LH_CURSOR_SEED_wal-marker")
+
+    payload = _cursor_projection_diagnostics(
+        environment={
+            "HOME": str(home),
+            "CURSOR_HOME": str(home / ".cursor"),
+            "LONGHOUSE_HOME": str(home / ".longhouse"),
+        },
+        state={"session_id": "session-1", "provider_session_id": "conversation-1"},
+        marker="LH_CURSOR_SEED_wal-marker",
+        engine_db_path=tmp_path / "missing.db",
+        phase="initial-seed-after-flush",
+    )
+
+    wal_observation = next(item for item in payload["files"] if item["kind"] == "store_db_wal")
+    assert wal_observation["marker_observed"] is True
+
+
+def test_cursor_projection_diagnostics_are_non_authoritative_on_capture_or_write_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    shipper = object.__new__(TranscriptShipper)
+    shipper.evidence_root = evidence
+    shipper.engine_environment = {}
+    shipper.db_path = tmp_path / "engine.db"
+    monkeypatch.setattr(
+        provider_native_resume,
+        "_cursor_projection_diagnostics",
+        lambda **_kwargs: (_ for _ in ()).throw(OSError("read race")),
+    )
+
+    path = shipper.capture_cursor_projection_diagnostics(
+        {"session_id": "session-1", "provider_session_id": "conversation-1"},
+        marker="LH_CURSOR_SEED_test",
+        label="initial-seed-before-send",
+    )
+
+    payload = json.loads(Path(path).read_text())
+    assert payload["schema"] == "cursor_projection_diagnostics_unavailable.v1"
+    assert payload["status"] == "unavailable"
+
+    monkeypatch.setattr(
+        provider_native_resume,
+        "_write_json",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    assert shipper.capture_cursor_projection_diagnostics(
+        {"session_id": "session-1", "provider_session_id": "conversation-1"},
+        marker="LH_CURSOR_SEED_test",
+        label="initial-seed-after-flush",
+    ).endswith("initial-seed-after-flush.json")
+    assert _write_best_effort_json(evidence / "correlation.json", {"ok": True}) is False
 
 
 @pytest.mark.parametrize(
@@ -2473,6 +2548,11 @@ def test_run_native_resume_refreshes_failure_manifest_after_finally_cleanup(
 
     assert result["status"] == "fail"
     assert result["error"].startswith("RuntimeError: provider transcript did not correlate initial opencode marker")
+    initial_correlation = json.loads((args.evidence_root / "initial-response-correlation.json").read_text())
+    assert initial_correlation["marker_observed_in_transcript"] is False
+    assert initial_correlation["new_assistant_events"] == 0
+    assert not (args.evidence_root / "cursor-projection-diagnostics-initial-seed-before-send.json").exists()
+    assert not (args.evidence_root / "cursor-projection-diagnostics-initial-seed-after-flush.json").exists()
     assert cleanup_calls == 2
     assert shipper is not None
     assert shipper.stop_calls == 2

--- a/server/zerg/qa/provider_native_resume.py
+++ b/server/zerg/qa/provider_native_resume.py
@@ -276,15 +276,28 @@ class TranscriptShipper:
         transcript content into the proof bundle.
         """
 
-        payload = _cursor_projection_diagnostics(
-            environment=self.engine_environment,
-            state=state,
-            marker=marker,
-            engine_db_path=self.db_path,
-            phase=label,
-        )
         path = self.evidence_root / f"cursor-projection-diagnostics-{label}.json"
-        _write_json(path, payload)
+        try:
+            payload = _cursor_projection_diagnostics(
+                environment=self.engine_environment,
+                state=state,
+                marker=marker,
+                engine_db_path=self.db_path,
+                phase=label,
+            )
+        except Exception as exc:  # noqa: BLE001 - diagnostics never own the verdict
+            payload = {
+                "schema": "cursor_projection_diagnostics_unavailable.v1",
+                "phase": label,
+                "captured_at": _now(),
+                "provider": "cursor",
+                "session_id": state.get("session_id"),
+                "provider_session_id": state.get("provider_session_id"),
+                "marker": marker,
+                "status": "unavailable",
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        _write_best_effort_json(path, payload)
         return str(path)
 
     def _terminate_daemon(self) -> str | None:
@@ -580,6 +593,16 @@ def _write_json(path: Path, payload: object) -> None:
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     temporary.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
     temporary.replace(path)
+
+
+def _write_best_effort_json(path: Path, payload: object) -> bool:
+    """Write diagnostic evidence without taking ownership of the verdict."""
+
+    try:
+        _write_json(path, payload)
+    except Exception:  # noqa: BLE001 - diagnostic persistence is non-authoritative
+        return False
+    return True
 
 
 def _sha256(path: Path) -> str:
@@ -2295,6 +2318,15 @@ def _cursor_projection_diagnostics(
                     continue
             if path.name == "store.db":
                 files.append(_cursor_sqlite_observation(path, marker=marker))
+                # SQLite may leave the newest committed pages in an active
+                # WAL. Retain a metadata-only observation of that sidecar so
+                # a missing marker in the main file is not misread as proof
+                # that Cursor never persisted it.
+                wal_path = path.with_name(f"{path.name}-wal")
+                if wal_path.is_file():
+                    wal_observation = _cursor_file_observation(wal_path, marker=marker)
+                    wal_observation["kind"] = "store_db_wal"
+                    files.append(wal_observation)
             else:
                 observation = _cursor_file_observation(path, marker=marker)
                 observation["kind"] = "agent_transcript"
@@ -2998,6 +3030,15 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
             _write_json(root / "initial-bootstrap-transcript-ship-receipt.json", shipper.flush("initial-bootstrap"))
             bootstrap_tail = _wait_session_tail(args.api_url, args.agents_token, initial_state["session_id"])
             initial_prior_assistant_event_digests = _assistant_event_digests(bootstrap_tail)
+            # Keep the provider-owned store and engine projection boundary
+            # beside the strict seed correlation. This is diagnostic only; a
+            # missing snapshot must never turn a failed provider turn into a
+            # pass or mask its causal error.
+            shipper.capture_cursor_projection_diagnostics(
+                initial_state,
+                marker=seed_marker,
+                label="initial-seed-before-send",
+            )
             initial_send = _control_send(
                 spec,
                 args,
@@ -3016,6 +3057,12 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
             )
         _write_json(root / "initial-seed-send.json", initial_send)
         _write_json(root / "initial-transcript-ship-receipt.json", shipper.flush("initial"))
+        if spec.provider == "cursor":
+            shipper.capture_cursor_projection_diagnostics(
+                initial_state,
+                marker=seed_marker,
+                label="initial-seed-after-flush",
+            )
         initial_tail, initial_response_correlation = _wait_assistant_response_after_marker(
             args.api_url,
             args.agents_token,
@@ -3025,13 +3072,15 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
             require_assistant_marker=spec.provider != "claude",
             timeout=args.live_send_timeout_secs,
         )
+        # Write this before applying the strict predicate so failed cells
+        # retain the exact observation that explains the rejection.
+        _write_best_effort_json(root / "initial-response-correlation.json", initial_response_correlation)
         if not (
             initial_response_correlation["marker_observed_in_transcript"]
             and initial_response_correlation["new_assistant_events"] > 0
             and (spec.provider == "claude" or initial_response_correlation["marker_observed_in_assistant"])
         ):
             raise RuntimeError(f"provider transcript did not correlate initial {provider} marker {seed_marker}")
-        _write_json(root / "initial-response-correlation.json", initial_response_correlation)
         # The correlated assistant response is the completed-turn oracle for
         # the initial marker. Cursor's hook may publish its next idle phase
         # late (or omit that redundant transition while the TUI is redrawing),


### PR DESCRIPTION
## Summary

- retain Cursor initial seed correlation before applying the strict rejection predicate
- capture provider store, active WAL, managed binding, and engine projection diagnostics before and after the seed flush
- keep diagnostic capture and persistence non-authoritative so disk/read failures cannot replace the provider's causal result

## Validation

- `cd server && uv run --extra dev pytest -q tests_lite/test_provider_native_resume.py` (101 passed)
- Ruff and `git diff --check` clean
- Hatch Claude Opus re-review: APPROVE, run `hatch_20260811T131943.043953000Z_5d382801349f1b80`
- Hatch Codex Sol re-review: APPROVE, run `hatch_20260811T131943.320967000Z_9c966b4b84dafb52`

This is diagnostic hardening only. Cursor acceptance remains fail-closed until a fresh exact 41-cell proof-bearing tick passes.
