### PR TITLE
Retain Cursor source-epoch lineage diagnostics

### DIFF
--- a/server/tests_lite/test_catalogd_storage_v2.py
+++ b/server/tests_lite/test_catalogd_storage_v2.py
@@ -1755,6 +1755,25 @@ async def test_source_epoch_raw_manifest_is_idempotent_ordered_and_overlap_safe(
         assert opened["created"] is True and opened["commit_seq"] == "1"
         assert replay_open["exact_replay"] is True and replay_open["commit_seq"] == "1"
 
+        missing_predecessor = uuid4()
+        missing_predecessor_raw = _raw_params(
+            epoch=uuid4(),
+            predecessor=missing_predecessor,
+            session_id=session_id,
+            start=0,
+            end=6,
+            records=(b"orphan\n",),
+            sealed_at=now,
+            opaque_source_id="missing-predecessor.jsonl",
+        )
+        with pytest.raises(CatalogRemoteError) as missing_predecessor_error:
+            await client.call("storage.raw_object.commit.v2", missing_predecessor_raw)
+        assert missing_predecessor_error.value.details == {
+            "reason": "predecessor_not_open_for_this_identity",
+            "predecessor_exists": False,
+            "expected_predecessor": str(missing_predecessor),
+        }
+
         raw = _raw_params(
             epoch=epoch,
             session_id=session_id,

--- a/server/tests_lite/test_provider_native_resume.py
+++ b/server/tests_lite/test_provider_native_resume.py
@@ -397,6 +397,61 @@ def test_transcript_shipper_retries_storage_lane_backpressure_once(
     assert receipt["events_shipped"] == 1
 
 
+def test_transcript_shipper_retries_mixed_backpressure_then_lineage_reconciliation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = iter(
+        [
+            SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="Error: storage-v2 repair lane busy; retry after 5000ms",
+            ),
+            SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="source_epoch_conflict_unresolved: predecessor_not_open_for_this_identity",
+            ),
+            SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"protocol": "storage-v2", "events_shipped": 1}),
+                stderr="",
+            ),
+        ]
+    )
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(
+        "zerg.qa.provider_native_resume.subprocess.run",
+        lambda *_args, **_kwargs: next(responses),
+    )
+    monkeypatch.setattr("zerg.qa.provider_native_resume.time.sleep", sleeps.append)
+    shipper = provider_native_resume.TranscriptShipper(
+        process=SimpleNamespace(poll=lambda: 0),
+        log_stream=None,
+        receipt={},
+        engine=tmp_path / "engine",
+        repo_root=tmp_path,
+        api_url="https://runtime.example",
+        machine_name="machine-1",
+        db_path=tmp_path / "shipper.db",
+        engine_environment={},
+        evidence_root=tmp_path,
+        redaction_secrets=(),
+        connect_command=[],
+    )
+
+    receipt = shipper.flush("resume-bootstrap")
+
+    assert receipt["status"] == "pass"
+    assert receipt["attempts"] == 3
+    assert receipt["retry_reasons"] == ["storage_lane_busy", "source_epoch_conflict_unresolved"]
+    assert receipt["retry_reason"] == "mixed"
+    assert receipt["events_shipped"] == 1
+    assert sleeps == [5.0]
+
+
 def test_transcript_shipper_caps_storage_lane_backpressure_delay(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -879,13 +934,81 @@ def test_cursor_projection_diagnostics_capture_marker_and_binding_state(tmp_path
         phase="post-resume-before-flush",
     )
 
-    assert payload["schema"] == "cursor_projection_diagnostics.v1"
+    assert payload["schema"] == "cursor_projection_diagnostics.v2"
     assert payload["managed_state"][0]["fields"]["conversation_uuid"] == "conversation-1"
     assert payload["engine_db"]["present"] is False
     assert len(payload["files"]) == 1
     assert payload["files"][0]["kind"] == "agent_transcript"
     assert payload["files"][0]["marker_observed"] is True
     assert payload["files"][0]["marker_count"] == 1
+
+
+def test_cursor_projection_diagnostics_capture_source_epoch_lineage(tmp_path: Path) -> None:
+    db_path = tmp_path / "shipper.db"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE source_epoch_registry (
+                source_epoch TEXT PRIMARY KEY,
+                provider TEXT NOT NULL,
+                opaque_source_id TEXT NOT NULL,
+                predecessor_epoch TEXT,
+                start_reason TEXT NOT NULL,
+                max_observed_len INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE source_epoch_lane_state (
+                source_epoch TEXT NOT NULL,
+                lane TEXT NOT NULL,
+                last_position INTEGER NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE pending_source_envelope (
+                source_epoch TEXT PRIMARY KEY,
+                source_path TEXT NOT NULL,
+                range_start INTEGER NOT NULL,
+                range_end INTEGER NOT NULL,
+                envelope_id TEXT NOT NULL,
+                raw_bytes INTEGER NOT NULL,
+                event_count INTEGER NOT NULL,
+                has_reply_evidence INTEGER NOT NULL,
+                has_more INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                attempt_count INTEGER NOT NULL,
+                last_attempt_at TEXT,
+                blocked_at TEXT,
+                block_kind TEXT,
+                block_detail TEXT
+            );
+            INSERT INTO source_epoch_registry VALUES
+                ('new', 'cursor', 'path-sha256:abc', 'old', 'revision_change', 42, 'now', 'now');
+            INSERT INTO source_epoch_lane_state VALUES ('old', 'durable', 42, 'now');
+            INSERT INTO pending_source_envelope VALUES
+                ('new', '/tmp/transcript.jsonl', 0, 42, 'env', 42, 1, 1, 0,
+                 'now', 2, 'now', 'now', 'source_epoch_conflict_unresolved',
+                 'predecessor_not_open_for_this_identity');
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    payload = provider_native_resume._cursor_projection_diagnostics(
+        environment={"HOME": str(tmp_path / "home")},
+        state={"session_id": "session-1", "provider_session_id": "conversation-1"},
+        marker="LH_CURSOR_POST_test",
+        engine_db_path=db_path,
+        phase="post-resume-after-flush",
+    )
+
+    engine_db = payload["engine_db"]
+    assert engine_db["table_rows"]["source_epoch_registry"][0]["predecessor_epoch"] == "old"
+    assert engine_db["table_rows"]["source_epoch_lane_state"][0]["last_position"] == 42
+    pending = engine_db["table_rows"]["pending_source_envelope"][0]
+    assert pending["block_kind"] == "source_epoch_conflict_unresolved"
+    assert pending["block_detail"] == "predecessor_not_open_for_this_identity"
 
 
 def test_cursor_projection_diagnostics_retains_active_wal_marker(tmp_path: Path) -> None:

--- a/server/tests_lite/test_provider_native_resume.py
+++ b/server/tests_lite/test_provider_native_resume.py
@@ -452,6 +452,98 @@ def test_transcript_shipper_retries_mixed_backpressure_then_lineage_reconciliati
     assert sleeps == [5.0]
 
 
+@pytest.mark.parametrize("failure", ["busy", "conflict"])
+def test_transcript_shipper_does_not_retry_the_same_typed_state_twice(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    stderr = (
+        "Error: storage-v2 repair lane busy; retry after 5000ms"
+        if failure == "busy"
+        else "source_epoch_conflict_unresolved: predecessor_not_open_for_this_identity"
+    )
+    calls = 0
+    sleeps: list[float] = []
+
+    def fake_run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(returncode=1, stdout="", stderr=stderr)
+
+    monkeypatch.setattr("zerg.qa.provider_native_resume.subprocess.run", fake_run)
+    monkeypatch.setattr("zerg.qa.provider_native_resume.time.sleep", sleeps.append)
+    shipper = TranscriptShipper(
+        process=SimpleNamespace(poll=lambda: 0),
+        log_stream=None,
+        receipt={},
+        engine=tmp_path / "engine",
+        repo_root=tmp_path,
+        api_url="https://runtime.example",
+        machine_name="machine-1",
+        db_path=tmp_path / "shipper.db",
+        engine_environment={},
+        evidence_root=tmp_path,
+        redaction_secrets=(),
+        connect_command=[],
+    )
+
+    receipt = shipper.flush("repeat-typed-failure")
+
+    assert calls == 2
+    assert receipt["status"] == "fail"
+    assert receipt["attempts"] == 2
+    expected_reason = "storage_lane_busy" if failure == "busy" else "source_epoch_conflict_unresolved"
+    assert receipt["retry_reasons"] == [expected_reason, expected_reason]
+    assert sleeps == ([5.0] if failure == "busy" else [])
+
+
+def test_transcript_shipper_prefers_backpressure_when_stderr_has_both_signals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = iter(
+        [
+            SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr=(
+                    "Error: storage-v2 repair lane busy; retry after 5000ms; "
+                    "source_epoch_conflict_unresolved"
+                ),
+            ),
+            SimpleNamespace(returncode=0, stdout=json.dumps({"events_shipped": 1}), stderr=""),
+        ]
+    )
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(
+        "zerg.qa.provider_native_resume.subprocess.run",
+        lambda *_args, **_kwargs: next(responses),
+    )
+    monkeypatch.setattr("zerg.qa.provider_native_resume.time.sleep", sleeps.append)
+    shipper = TranscriptShipper(
+        process=SimpleNamespace(poll=lambda: 0),
+        log_stream=None,
+        receipt={},
+        engine=tmp_path / "engine",
+        repo_root=tmp_path,
+        api_url="https://runtime.example",
+        machine_name="machine-1",
+        db_path=tmp_path / "shipper.db",
+        engine_environment={},
+        evidence_root=tmp_path,
+        redaction_secrets=(),
+        connect_command=[],
+    )
+
+    receipt = shipper.flush("both-transient-signals")
+
+    assert receipt["status"] == "pass"
+    assert receipt["retry_reason"] == "storage_lane_busy"
+    assert sleeps == [5.0]
+
+
 def test_transcript_shipper_caps_storage_lane_backpressure_delay(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1009,6 +1101,38 @@ def test_cursor_projection_diagnostics_capture_source_epoch_lineage(tmp_path: Pa
     pending = engine_db["table_rows"]["pending_source_envelope"][0]
     assert pending["block_kind"] == "source_epoch_conflict_unresolved"
     assert pending["block_detail"] == "predecessor_not_open_for_this_identity"
+
+
+def test_cursor_projection_diagnostics_hashes_untrusted_block_detail(tmp_path: Path) -> None:
+    db_path = tmp_path / "shipper.db"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            "CREATE TABLE pending_source_envelope "
+            "(source_epoch TEXT, block_kind TEXT, block_detail TEXT)"
+        )
+        block_detail = "Authorization: Bearer sk-live-XXX " + ("x" * 2048)
+        connection.execute(
+            "INSERT INTO pending_source_envelope VALUES (?, ?, ?)",
+            ("epoch", "source_epoch_conflict_unresolved", block_detail),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    payload = provider_native_resume._cursor_projection_diagnostics(
+        environment={"HOME": str(tmp_path / "home")},
+        state={"session_id": "session-1", "provider_session_id": "conversation-1"},
+        marker="LH_CURSOR_POST_test",
+        engine_db_path=db_path,
+        phase="post-resume-after-flush",
+    )
+
+    pending = payload["engine_db"]["table_rows"]["pending_source_envelope"][0]
+    assert pending["block_detail"] == "<omitted>"
+    assert pending["block_detail_length"] == len(block_detail)
+    assert pending["block_detail_sha256"] == hashlib.sha256(block_detail.encode()).hexdigest()
+    assert "Authorization" not in json.dumps(payload)
 
 
 def test_cursor_projection_diagnostics_retains_active_wal_marker(tmp_path: Path) -> None:

--- a/server/zerg/catalogd/store.py
+++ b/server/zerg/catalogd/store.py
@@ -5686,6 +5686,7 @@ class CatalogStore:
                         return _source_epoch_conflict(
                             connection,
                             reason="predecessor_not_open_for_this_identity",
+                            predecessor_exists=predecessor_row is not None,
                             expected_predecessor=expected_predecessor,
                             predecessor_state=(predecessor_row["state"] if predecessor_row is not None else None),
                         )

--- a/server/zerg/qa/provider_native_resume.py
+++ b/server/zerg/qa/provider_native_resume.py
@@ -53,6 +53,7 @@ _PROCESS_LOSS_RESUME_INTENT_TIMEOUT_SECS = 180.0
 _TRANSCRIPT_SHIP_MAX_ATTEMPTS = 3
 _STORAGE_LANE_BUSY_MAX_SLEEP_SECS = 10.0
 _STORAGE_LANE_BUSY_RE = re.compile(r"storage-v2 repair lane busy; retry after (?P<milliseconds>\d+)ms")
+_SAFE_DIAGNOSTIC_DETAIL_RE = re.compile(r"^[a-z0-9][a-z0-9_.:-]{0,127}$")
 
 
 def _qualification_secrets(environment: dict[str, str], agents_token: str) -> tuple[str, ...]:
@@ -153,6 +154,7 @@ class TranscriptShipper:
             self._terminate_daemon()
         attempts: list[dict[str, Any]] = []
         log_sections: list[str] = []
+        retry_reasons_seen: set[str] = set()
         # A failed admission quarantines the envelope and the next ship
         # invocation can reconcile a missing Cursor predecessor. A typed
         # storage-lane backpressure response is also safe to retry because the
@@ -212,26 +214,26 @@ class TranscriptShipper:
             attempt_retry_reason: str | None = None
             retry_delay_secs: float | None = None
             if completed.returncode != 0:
-                if "source_epoch_conflict_unresolved" in stderr:
+                busy_match = _STORAGE_LANE_BUSY_RE.search(stderr)
+                if busy_match is not None:
+                    advertised_delay_ms = int(busy_match.group("milliseconds"))
+                    attempt_retry_reason = "storage_lane_busy"
+                    retry_delay_secs = min(advertised_delay_ms / 1000, _STORAGE_LANE_BUSY_MAX_SLEEP_SECS)
+                    result["retry_after_ms"] = advertised_delay_ms
+                    result["retry_sleep_secs"] = retry_delay_secs
+                elif "source_epoch_conflict_unresolved" in stderr:
                     attempt_retry_reason = "source_epoch_conflict_unresolved"
-                else:
-                    busy_match = _STORAGE_LANE_BUSY_RE.search(stderr)
-                    if busy_match is not None:
-                        advertised_delay_ms = int(busy_match.group("milliseconds"))
-                        attempt_retry_reason = "storage_lane_busy"
-                        retry_delay_secs = min(advertised_delay_ms / 1000, _STORAGE_LANE_BUSY_MAX_SLEEP_SECS)
-                        result["retry_after_ms"] = advertised_delay_ms
-                        result["retry_sleep_secs"] = retry_delay_secs
             if attempt_retry_reason is not None:
                 result["retry_reason"] = attempt_retry_reason
             attempts.append(result)
             log_sections.append(f"attempt {attempt}\nstdout:\n{stdout}\nstderr:\n{stderr}\n")
             if completed.returncode == 0:
                 break
-            if attempt_retry_reason == "source_epoch_conflict_unresolved":
-                continue
-            if retry_delay_secs is None or attempt >= _TRANSCRIPT_SHIP_MAX_ATTEMPTS:
+            if attempt_retry_reason is None or attempt_retry_reason in retry_reasons_seen or attempt >= _TRANSCRIPT_SHIP_MAX_ATTEMPTS:
                 break
+            retry_reasons_seen.add(attempt_retry_reason)
+            if retry_delay_secs is None:
+                continue
             time.sleep(retry_delay_secs)
         result = dict(attempts[-1])
         result["attempts"] = len(attempts)
@@ -2227,9 +2229,12 @@ def _cursor_engine_db_observation(path: Path) -> dict[str, Any]:
     try:
         connection = sqlite3.connect(f"{path.as_uri()}?mode=ro", uri=True, timeout=1.0)
         try:
+            connection.execute("BEGIN DEFERRED")
             tables = {str(row[0]) for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
             table_counts: dict[str, int] = {}
+            table_counts_errors: dict[str, str] = {}
             table_rows: dict[str, list[dict[str, Any]]] = {}
+            table_rows_errors: dict[str, str] = {}
             for table in (
                 "source_epoch_registry",
                 "source_epoch_lane_state",
@@ -2238,7 +2243,10 @@ def _cursor_engine_db_observation(path: Path) -> dict[str, Any]:
                 "cursor_store_capture_cursor",
             ):
                 if table in tables:
-                    table_counts[table] = int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+                    try:
+                        table_counts[table] = int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+                    except sqlite3.Error as exc:
+                        table_counts_errors[table] = f"{type(exc).__name__}: {exc}"
             row_specs = {
                 "source_epoch_registry": (
                     "source_epoch",
@@ -2250,6 +2258,8 @@ def _cursor_engine_db_observation(path: Path) -> dict[str, Any]:
                     "source_revision",
                     "bound_session_id",
                     "provider_session_id",
+                    "file_incarnation",
+                    "wake_at",
                     "created_at",
                     "updated_at",
                     "ended_at",
@@ -2279,24 +2289,44 @@ def _cursor_engine_db_observation(path: Path) -> dict[str, Any]:
             for table, requested_columns in row_specs.items():
                 if table not in tables:
                     continue
-                available = {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})").fetchall()}
-                columns = [column for column in requested_columns if column in available]
-                if not columns:
-                    continue
-                select_columns = ", ".join(columns)
-                rows = connection.execute(f"SELECT {select_columns} FROM {table} ORDER BY rowid DESC LIMIT 128").fetchall()
-                table_rows[table] = [dict(zip(columns, row, strict=True)) for row in rows]
+                try:
+                    available = {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})").fetchall()}
+                    columns = [column for column in requested_columns if column in available]
+                    if not columns:
+                        continue
+                    select_columns = ", ".join(columns)
+                    try:
+                        rows = connection.execute(f"SELECT {select_columns} FROM {table} ORDER BY rowid DESC LIMIT 128").fetchall()
+                    except sqlite3.Error:
+                        rows = connection.execute(f"SELECT {select_columns} FROM {table} LIMIT 128").fetchall()
+                    serialized_rows: list[dict[str, Any]] = []
+                    for row in rows:
+                        serialized = dict(zip(columns, row, strict=True))
+                        raw_detail = serialized.get("block_detail")
+                        if isinstance(raw_detail, str) and not _SAFE_DIAGNOSTIC_DETAIL_RE.fullmatch(raw_detail):
+                            serialized["block_detail_sha256"] = hashlib.sha256(raw_detail.encode()).hexdigest()
+                            serialized["block_detail_length"] = len(raw_detail)
+                            serialized["block_detail"] = "<omitted>"
+                        serialized_rows.append(serialized)
+                    table_rows[table] = serialized_rows
+                except sqlite3.Error as exc:
+                    table_rows_errors[table] = f"{type(exc).__name__}: {exc}"
         finally:
             connection.close()
     except sqlite3.Error as exc:
         return {"path": str(path), "present": True, "sqlite_error": f"{type(exc).__name__}: {exc}"}
-    return {
+    observation = {
         "path": str(path),
         "present": True,
         "sqlite_tables": sorted(tables),
         "sqlite_counts": table_counts,
         "table_rows": table_rows,
     }
+    if table_rows_errors:
+        observation["table_rows_errors"] = table_rows_errors
+    if table_counts_errors:
+        observation["table_counts_errors"] = table_counts_errors
+    return observation
 
 
 def _cursor_managed_state_observation(root: Path, session_id: str) -> list[dict[str, Any]]:

--- a/server/zerg/qa/provider_native_resume.py
+++ b/server/zerg/qa/provider_native_resume.py
@@ -47,7 +47,10 @@ RUNTIME_AGENTS_TOKEN_ENV = "LONGHOUSE_RUNTIME_AGENTS_TOKEN"
 _EVIDENCE_SECRET_KEY_RE = re.compile(r"(?:^|_)(?:token|secret|password|api_key|access_key|authorization)$")
 _DEFAULT_RESUME_INTENT_TIMEOUT_SECS = 45.0
 _PROCESS_LOSS_RESUME_INTENT_TIMEOUT_SECS = 180.0
-_TRANSCRIPT_SHIP_MAX_ATTEMPTS = 2
+# A daemon shutdown can expose repair-lane backpressure immediately before a
+# quarantined Cursor epoch becomes eligible for lineage reconciliation. Keep
+# one bounded retry for each typed state, with no retry for arbitrary failures.
+_TRANSCRIPT_SHIP_MAX_ATTEMPTS = 3
 _STORAGE_LANE_BUSY_MAX_SLEEP_SECS = 10.0
 _STORAGE_LANE_BUSY_RE = re.compile(r"storage-v2 repair lane busy; retry after (?P<milliseconds>\d+)ms")
 
@@ -2211,7 +2214,13 @@ def _cursor_sqlite_observation(path: Path, *, marker: str) -> dict[str, Any]:
 
 
 def _cursor_engine_db_observation(path: Path) -> dict[str, Any]:
-    """Summarize engine state tables without copying transcript or credentials."""
+    """Summarize engine state tables without copying transcript or credentials.
+
+    Counts alone cannot distinguish a host-side source-epoch loss from a local
+    lineage decision. Keep bounded identity and position rows as diagnostic
+    evidence so a retained Cursor failure can be reconstructed without storing
+    the compressed request body or transcript payload.
+    """
 
     if not path.exists():
         return {"path": str(path), "present": False}
@@ -2220,6 +2229,7 @@ def _cursor_engine_db_observation(path: Path) -> dict[str, Any]:
         try:
             tables = {str(row[0]) for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
             table_counts: dict[str, int] = {}
+            table_rows: dict[str, list[dict[str, Any]]] = {}
             for table in (
                 "source_epoch_registry",
                 "source_epoch_lane_state",
@@ -2229,6 +2239,53 @@ def _cursor_engine_db_observation(path: Path) -> dict[str, Any]:
             ):
                 if table in tables:
                     table_counts[table] = int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+            row_specs = {
+                "source_epoch_registry": (
+                    "source_epoch",
+                    "provider",
+                    "opaque_source_id",
+                    "predecessor_epoch",
+                    "start_reason",
+                    "max_observed_len",
+                    "source_revision",
+                    "bound_session_id",
+                    "provider_session_id",
+                    "created_at",
+                    "updated_at",
+                    "ended_at",
+                    "end_reason",
+                ),
+                "source_epoch_lane_state": ("source_epoch", "lane", "last_position", "updated_at"),
+                "pending_source_envelope": (
+                    "source_epoch",
+                    "source_path",
+                    "range_start",
+                    "range_end",
+                    "envelope_id",
+                    "raw_bytes",
+                    "event_count",
+                    "has_reply_evidence",
+                    "has_more",
+                    "created_at",
+                    "attempt_count",
+                    "last_attempt_at",
+                    "blocked_at",
+                    "block_kind",
+                    "block_detail",
+                ),
+                "cursor_store_raw_record": ("source_epoch", "source_position", "record_hash"),
+                "cursor_store_capture_cursor": ("source_epoch", "last_blob_id", "updated_at"),
+            }
+            for table, requested_columns in row_specs.items():
+                if table not in tables:
+                    continue
+                available = {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})").fetchall()}
+                columns = [column for column in requested_columns if column in available]
+                if not columns:
+                    continue
+                select_columns = ", ".join(columns)
+                rows = connection.execute(f"SELECT {select_columns} FROM {table} ORDER BY rowid DESC LIMIT 128").fetchall()
+                table_rows[table] = [dict(zip(columns, row, strict=True)) for row in rows]
         finally:
             connection.close()
     except sqlite3.Error as exc:
@@ -2238,6 +2295,7 @@ def _cursor_engine_db_observation(path: Path) -> dict[str, Any]:
         "present": True,
         "sqlite_tables": sorted(tables),
         "sqlite_counts": table_counts,
+        "table_rows": table_rows,
     }
 
 
@@ -2332,7 +2390,7 @@ def _cursor_projection_diagnostics(
                 observation["kind"] = "agent_transcript"
                 files.append(observation)
     return {
-        "schema": "cursor_projection_diagnostics.v1",
+        "schema": "cursor_projection_diagnostics.v2",
         "phase": phase,
         "captured_at": _now(),
         "provider": "cursor",


### PR DESCRIPTION
## Summary
- retain bounded source-epoch, lane, and pending-envelope metadata in Cursor projection diagnostics
- distinguish repair-lane backpressure followed by lineage quarantine with a third typed attempt
- keep acceptance fail-closed and never copy request bodies or transcript payloads

## Evidence
The candidate Resume run reached a successful native Cursor hook response, then left one pending envelope after a `storage_lane_busy` followed by `source_epoch_conflict_unresolved` sequence. The extra attempt is bounded and covered by a mixed-state regression test.

## Validation
- `uv run --extra dev pytest tests_lite/test_provider_native_resume.py -q` (103 passed)
- Ruff and pre-commit clean