### PR TITLE
QA: settle Cursor initial turn before transcript flush

### DIFF
--- a/server/tests_lite/test_provider_native_resume.py
+++ b/server/tests_lite/test_provider_native_resume.py
@@ -33,6 +33,7 @@ from zerg.qa.provider_native_resume import _cursor_bootstrap_prompt
 from zerg.qa.provider_native_resume import _cursor_hook_event_observation
 from zerg.qa.provider_native_resume import _cursor_idle_then_flush
 from zerg.qa.provider_native_resume import _cursor_idle_timeout_observation
+from zerg.qa.provider_native_resume import _cursor_initial_send_then_flush
 from zerg.qa.provider_native_resume import _cursor_interrupt_to_idle
 from zerg.qa.provider_native_resume import _cursor_projection_diagnostics
 from zerg.qa.provider_native_resume import _cursor_tui_input_ready
@@ -73,6 +74,25 @@ def _args(tmp_path: Path) -> argparse.Namespace:
     )
 
 
+def _write_cursor_binding(longhouse_home: Path, *, status: str = "observed") -> None:
+    binding = longhouse_home / "managed-local" / "cursor-helm" / "binding-probes" / "session-1.json"
+    binding.parent.mkdir(parents=True, exist_ok=True)
+    binding.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "provider": "cursor",
+                "status": status,
+                "session_id": "session-1",
+                "conversation_uuid": "cursor-thread-1",
+                "launch_id": "launch-1",
+                "run_id": "run-1",
+            }
+        )
+        + "\n"
+    )
+
+
 def test_each_native_provider_registers_both_exact_resume_variants() -> None:
     for provider in ("claude", "cursor", "opencode"):
         registration = registration_for(provider)
@@ -93,6 +113,7 @@ def test_each_native_provider_registers_both_exact_resume_variants() -> None:
             "post_stop_transcript_ship_receipt",
         } <= set(registration.required_artifacts)
         cursor_only = {
+            "initial_hook_correlation",
             "resume_bootstrap_response_correlation",
             "resume_bootstrap_transcript",
         }
@@ -1421,11 +1442,12 @@ def test_post_resume_correlation_requires_strict_assistant_proof(provider: str, 
 
 
 def test_cursor_bootstrap_hook_sequence_requires_a_foreground_turn(tmp_path: Path) -> None:
-    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1"}
+    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1", "run_id": "run-1"}
     marker = "LH_CURSOR_BOOTSTRAP_abc123"
     longhouse_home = tmp_path / "longhouse"
     events = longhouse_home / "managed-local" / "cursor-helm" / "hook-events" / "session-1.ndjson"
     events.parent.mkdir(parents=True)
+    _write_cursor_binding(longhouse_home)
     events.write_text(json.dumps({"event": "sessionStart", "session_id": "session-1", "conversation_id": "cursor-thread-1"}) + "\n")
     baseline = events.stat().st_size
     events.write_text(
@@ -1437,6 +1459,7 @@ def test_cursor_bootstrap_hook_sequence_requires_a_foreground_turn(tmp_path: Pat
                         "event": "beforeSubmitPrompt",
                         "session_id": "session-1",
                         "conversation_id": "cursor-thread-1",
+                        "launch_id": "launch-1",
                         "payload": {
                             "session_id": "cursor-thread-1",
                             "conversation_id": "cursor-thread-1",
@@ -1450,6 +1473,7 @@ def test_cursor_bootstrap_hook_sequence_requires_a_foreground_turn(tmp_path: Pat
                         "event": "afterAgentResponse",
                         "session_id": "session-1",
                         "conversation_id": "cursor-thread-1",
+                        "launch_id": "launch-1",
                         "payload": {
                             "session_id": "cursor-thread-1",
                             "conversation_id": "cursor-thread-1",
@@ -1477,15 +1501,70 @@ def test_cursor_bootstrap_hook_sequence_requires_a_foreground_turn(tmp_path: Pat
     assert sequence["timed_out"] is False
 
 
-def test_cursor_hook_timeout_diagnostics_do_not_repeat_polling_events(tmp_path: Path) -> None:
-    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1"}
+def test_cursor_hook_sequence_rejects_response_before_prompt(tmp_path: Path) -> None:
+    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1", "run_id": "run-1"}
+    marker = "LH_CURSOR_BOOTSTRAP_reversed"
     longhouse_home = tmp_path / "longhouse"
     events = longhouse_home / "managed-local" / "cursor-helm" / "hook-events" / "session-1.ndjson"
     events.parent.mkdir(parents=True)
+    _write_cursor_binding(longhouse_home)
+    events.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event": "afterAgentResponse",
+                        "session_id": "session-1",
+                        "conversation_id": "cursor-thread-1",
+                        "launch_id": "launch-1",
+                        "payload": {
+                            "session_id": "cursor-thread-1",
+                            "conversation_id": "cursor-thread-1",
+                            "generation_id": "generation-1",
+                            "text": marker,
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event": "beforeSubmitPrompt",
+                        "session_id": "session-1",
+                        "conversation_id": "cursor-thread-1",
+                        "launch_id": "launch-1",
+                        "payload": {
+                            "session_id": "cursor-thread-1",
+                            "conversation_id": "cursor-thread-1",
+                            "generation_id": "generation-1",
+                            "prompt": _cursor_bootstrap_prompt(marker),
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+
+    with pytest.raises(RuntimeError, match="beforeSubmitPrompt/afterAgentResponse"):
+        _wait_cursor_bootstrap_hook_sequence(
+            state,
+            {"LONGHOUSE_HOME": str(longhouse_home)},
+            marker=marker,
+            minimum_hook_event_bytes=0,
+            timeout=0.01,
+        )
+
+
+def test_cursor_hook_timeout_diagnostics_do_not_repeat_polling_events(tmp_path: Path) -> None:
+    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1", "run_id": "run-1"}
+    longhouse_home = tmp_path / "longhouse"
+    events = longhouse_home / "managed-local" / "cursor-helm" / "hook-events" / "session-1.ndjson"
+    events.parent.mkdir(parents=True)
+    _write_cursor_binding(longhouse_home)
     row = {
         "event": "beforeSubmitPrompt",
         "session_id": "session-1",
         "conversation_id": "cursor-thread-1",
+        "launch_id": "launch-1",
         "payload": {
             "session_id": "cursor-thread-1",
             "conversation_id": "cursor-thread-1",
@@ -1510,11 +1589,12 @@ def test_cursor_hook_timeout_diagnostics_do_not_repeat_polling_events(tmp_path: 
 
 
 def test_cursor_bootstrap_hook_sequence_does_not_accept_session_start(tmp_path: Path) -> None:
-    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1"}
+    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1", "run_id": "run-1"}
     marker = "LH_CURSOR_BOOTSTRAP_abc123"
     longhouse_home = tmp_path / "longhouse"
     events = longhouse_home / "managed-local" / "cursor-helm" / "hook-events" / "session-1.ndjson"
     events.parent.mkdir(parents=True)
+    _write_cursor_binding(longhouse_home)
     events.write_text(json.dumps({"event": "sessionStart", "session_id": "session-1", "conversation_id": "cursor-thread-1"}) + "\n")
 
     with pytest.raises(RuntimeError, match="beforeSubmitPrompt/afterAgentResponse"):
@@ -1537,11 +1617,12 @@ def test_cursor_bootstrap_hook_sequence_does_not_accept_session_start(tmp_path: 
     ],
 )
 def test_cursor_bootstrap_hook_sequence_rejects_unbound_response(tmp_path: Path, field: str, value: str) -> None:
-    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1"}
+    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1", "run_id": "run-1"}
     marker = "LH_CURSOR_BOOTSTRAP_abc123"
     longhouse_home = tmp_path / "longhouse"
     events = longhouse_home / "managed-local" / "cursor-helm" / "hook-events" / "session-1.ndjson"
     events.parent.mkdir(parents=True)
+    _write_cursor_binding(longhouse_home)
     before_payload = {
         "session_id": "cursor-thread-1",
         "conversation_id": "cursor-thread-1",
@@ -1567,6 +1648,7 @@ def test_cursor_bootstrap_hook_sequence_rejects_unbound_response(tmp_path: Path,
                         "event": "beforeSubmitPrompt",
                         "session_id": "session-1",
                         "conversation_id": "cursor-thread-1",
+                        "launch_id": "launch-1",
                         "payload": before_payload,
                     }
                 ),
@@ -1575,6 +1657,7 @@ def test_cursor_bootstrap_hook_sequence_rejects_unbound_response(tmp_path: Path,
                         "event": "afterAgentResponse",
                         "session_id": "session-1",
                         "conversation_id": "cursor-thread-1",
+                        "launch_id": "launch-1",
                         "payload": after_payload,
                     }
                 ),
@@ -1594,11 +1677,12 @@ def test_cursor_bootstrap_hook_sequence_rejects_unbound_response(tmp_path: Path,
 
 
 def test_cursor_bootstrap_hook_sequence_rejects_multiple_matching_generations(tmp_path: Path) -> None:
-    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1"}
+    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1", "run_id": "run-1"}
     marker = "LH_CURSOR_BOOTSTRAP_abc123"
     longhouse_home = tmp_path / "longhouse"
     events = longhouse_home / "managed-local" / "cursor-helm" / "hook-events" / "session-1.ndjson"
     events.parent.mkdir(parents=True)
+    _write_cursor_binding(longhouse_home)
     rows = []
     for generation in ("generation-1", "generation-2"):
         rows.append(
@@ -1606,6 +1690,7 @@ def test_cursor_bootstrap_hook_sequence_rejects_multiple_matching_generations(tm
                 "event": "beforeSubmitPrompt",
                 "session_id": "session-1",
                 "conversation_id": "cursor-thread-1",
+                "launch_id": "launch-1",
                 "payload": {
                     "session_id": "cursor-thread-1",
                     "conversation_id": "cursor-thread-1",
@@ -2165,6 +2250,134 @@ def test_cursor_initial_seed_bootstraps_through_the_provider_pty(tmp_path: Path)
     assert result["method"] == "provider_tty_bootstrap"
     assert result["returncode"] == 0
     assert process.sent == ["seed", "\x1b", "\r"]
+
+
+def test_cursor_initial_seed_flush_waits_for_ordered_hook_and_idle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[str, object]] = []
+
+    def fake_hook_sequence(*_args: object, **kwargs: object) -> dict[str, str]:
+        calls.append(("hook", kwargs))
+        return {"generation_id": "generation-1", "hook_response_correlated": True}
+
+    def fake_idle_then_flush(*_args: object, **kwargs: object) -> dict[str, str]:
+        calls.append(("flush", kwargs))
+        return {"status": "pass"}
+
+    monkeypatch.setattr(provider_native_resume, "_wait_cursor_hook_sequence", fake_hook_sequence)
+    monkeypatch.setattr(provider_native_resume, "_cursor_idle_then_flush", fake_idle_then_flush)
+
+    hook_sequence, ship_receipt = _cursor_initial_send_then_flush(
+        {"session_id": "session-1"},
+        {"LONGHOUSE_HOME": "/tmp/longhouse"},
+        object(),  # type: ignore[arg-type]
+        marker="LH_CURSOR_SEED_test",
+        expected_prompt="Reply with exactly LH_CURSOR_SEED_test and nothing else.",
+        minimum_hook_event_bytes=17,
+        timeout=12,
+        hook_correlation_path=tmp_path / "initial-hook-correlation.json",
+    )
+
+    assert hook_sequence["generation_id"] == "generation-1"
+    assert ship_receipt == {"status": "pass"}
+    assert [name for name, _ in calls] == ["hook", "flush"]
+    assert calls[1][1]["expected_generation_id"] == "generation-1"
+    assert calls[1][1]["minimum_hook_event_bytes"] == 17
+    assert json.loads((tmp_path / "initial-hook-correlation.json").read_text()) == hook_sequence
+
+
+def test_cursor_initial_seed_retains_hook_evidence_when_idle_settlement_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hook_sequence = {"generation_id": "generation-1", "hook_response_correlated": True}
+    monkeypatch.setattr(provider_native_resume, "_wait_cursor_hook_sequence", lambda *_args, **_kwargs: hook_sequence)
+
+    def fail_idle(*_args: object, **_kwargs: object) -> dict[str, str]:
+        raise RuntimeError("idle timeout")
+
+    monkeypatch.setattr(provider_native_resume, "_cursor_idle_then_flush", fail_idle)
+    path = tmp_path / "initial-hook-correlation.json"
+
+    with pytest.raises(RuntimeError, match="idle timeout"):
+        _cursor_initial_send_then_flush(
+            {"session_id": "session-1"},
+            {"LONGHOUSE_HOME": "/tmp/longhouse"},
+            object(),  # type: ignore[arg-type]
+            marker="LH_CURSOR_SEED_test",
+            expected_prompt="Reply with exactly LH_CURSOR_SEED_test",
+            minimum_hook_event_bytes=17,
+            timeout=12,
+            hook_correlation_path=path,
+        )
+
+    assert json.loads(path.read_text()) == hook_sequence
+
+
+def test_cursor_hook_sequence_waits_for_pending_claim_promotion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {"session_id": "session-1", "provider_session_id": "cursor-thread-1", "run_id": "run-1"}
+    marker = "LH_CURSOR_BOOTSTRAP_pending"
+    longhouse_home = tmp_path / "longhouse"
+    events = longhouse_home / "managed-local" / "cursor-helm" / "hook-events" / "session-1.ndjson"
+    events.parent.mkdir(parents=True)
+    _write_cursor_binding(longhouse_home, status="pending")
+    events.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "event": "beforeSubmitPrompt",
+                        "session_id": "session-1",
+                        "conversation_id": "cursor-thread-1",
+                        "launch_id": "launch-1",
+                        "payload": {
+                            "session_id": "cursor-thread-1",
+                            "conversation_id": "cursor-thread-1",
+                            "generation_id": "generation-1",
+                            "prompt": _cursor_bootstrap_prompt(marker),
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "event": "afterAgentResponse",
+                        "session_id": "session-1",
+                        "conversation_id": "cursor-thread-1",
+                        "launch_id": "launch-1",
+                        "payload": {
+                            "session_id": "cursor-thread-1",
+                            "conversation_id": "cursor-thread-1",
+                            "generation_id": "generation-1",
+                            "text": marker,
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    claim = longhouse_home / "managed-local" / "cursor-helm" / "binding-probes" / "session-1.json"
+    promoted = False
+
+    def promote(_seconds: float) -> None:
+        nonlocal promoted
+        if not promoted:
+            payload = json.loads(claim.read_text())
+            payload["status"] = "observed"
+            claim.write_text(json.dumps(payload) + "\n")
+            promoted = True
+
+    monkeypatch.setattr(provider_native_resume.time, "sleep", promote)
+    sequence = _wait_cursor_bootstrap_hook_sequence(
+        state,
+        {"LONGHOUSE_HOME": str(longhouse_home)},
+        marker=marker,
+        minimum_hook_event_bytes=0,
+        timeout=1,
+    )
+
+    assert promoted is True
+    assert sequence["launch_id"] == "launch-1"
 
 
 def test_cursor_control_send_retries_only_provider_idle_race(tmp_path: Path, monkeypatch) -> None:

--- a/server/zerg/qa/provider_native_resume.py
+++ b/server/zerg/qa/provider_native_resume.py
@@ -454,6 +454,7 @@ def registration_for(provider: str) -> ProducerRegistration:
             "native_resume_terminal_recording",
             *(
                 (
+                    "initial_hook_correlation",
                     "resume_bootstrap_response_correlation",
                     "resume_bootstrap_transcript",
                     "resume_bootstrap_transcript_ship_receipt",
@@ -1874,6 +1875,56 @@ def _cursor_idle_then_flush(
     return receipt
 
 
+def _cursor_initial_send_then_flush(
+    state: dict[str, Any],
+    environment: dict[str, str],
+    shipper: TranscriptShipper,
+    *,
+    marker: str,
+    expected_prompt: str,
+    minimum_hook_event_bytes: int,
+    timeout: float,
+    diagnostic_path: Path | None = None,
+    hook_correlation_path: Path | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Settle Cursor's first managed turn before asking the engine to ship it.
+
+    The initial Cursor seed is sent through the Helm socket after the native
+    argv bootstrap.  A successful socket write only means the request was
+    accepted; it does not mean Cursor completed the foreground turn.  Require
+    the identity-matched native hook sequence and the subsequent idle phase
+    before flushing the transcript.  This keeps the initial proof on the same
+    causal boundary as Resume and prevents a one-shot flush from racing the
+    provider's store projection.
+    """
+
+    hook_sequence = _wait_cursor_hook_sequence(
+        state,
+        environment,
+        marker=marker,
+        expected_prompt=expected_prompt,
+        minimum_hook_event_bytes=minimum_hook_event_bytes,
+        label="initial-seed",
+        timeout=timeout,
+    )
+    # Persist the provider-owned causal observation before waiting on the
+    # separate idle/projection boundary. If settlement fails, the valid hook
+    # sequence must remain available in the failure bundle.
+    if hook_correlation_path is not None:
+        _write_json(hook_correlation_path, hook_sequence)
+    ship_receipt = _cursor_idle_then_flush(
+        state,
+        environment,
+        shipper,
+        label="initial",
+        minimum_hook_event_bytes=minimum_hook_event_bytes,
+        expected_generation_id=hook_sequence.get("generation_id"),
+        marker=marker,
+        diagnostic_path=diagnostic_path,
+    )
+    return hook_sequence, ship_receipt
+
+
 def _cursor_bootstrap_correlation(
     transcript_correlation: dict[str, Any],
     hook_sequence: dict[str, Any],
@@ -2894,13 +2945,39 @@ def _wait_cursor_hook_sequence(
     longhouse_home = str(environment.get("LONGHOUSE_HOME") or "").strip()
     if not longhouse_home:
         raise RuntimeError("Cursor Helm qualification has no explicit Longhouse home")
-    path = Path(longhouse_home) / "managed-local" / "cursor-helm" / "hook-events" / f"{state['session_id']}.ndjson"
+    root = Path(longhouse_home) / "managed-local" / "cursor-helm"
+    path = root / "hook-events" / f"{state['session_id']}.ndjson"
+    claim_path = root / "binding-probes" / f"{state['session_id']}.json"
+    expected_launch_id: str | None = None
+    claim_status = ""
     deadline = time.monotonic() + timeout
     observed_events: list[str] = []
-    matching_befores: list[dict[str, Any]] = []
-    matching_afters: list[dict[str, Any]] = []
+    matching_befores: list[tuple[dict[str, Any], int]] = []
+    matching_afters: list[tuple[dict[str, Any], int]] = []
     seen_events: set[str] = set()
+    event_position = 0
     while time.monotonic() < deadline:
+        try:
+            claim = _read_json_bounded(claim_path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            claim = {}
+        current_launch_id = str(claim.get("launch_id") or "").strip()
+        claim_status = str(claim.get("status") or "").strip()
+        if (
+            claim.get("schema_version") != 2
+            or claim.get("provider") != "cursor"
+            or claim_status not in {"pending", "observed"}
+            or claim.get("session_id") != state.get("session_id")
+            or claim.get("conversation_uuid") != state.get("provider_session_id")
+            or claim.get("run_id") != state.get("run_id")
+            or not current_launch_id
+            or (expected_launch_id is not None and current_launch_id != expected_launch_id)
+        ):
+            raise RuntimeError(
+                "Cursor hook sequence lacks the enrolled launch binding "
+                f"(claim_path={claim_path}, binding={json.dumps(_diagnostic_mapping(claim, ('schema_version', 'provider', 'status', 'session_id', 'conversation_uuid', 'launch_id', 'run_id')), sort_keys=True)})"
+            )
+        expected_launch_id = current_launch_id
         try:
             with path.open("rb") as stream:
                 stream.seek(minimum_hook_event_bytes)
@@ -2918,6 +2995,8 @@ def _wait_cursor_hook_sequence(
                 continue
             if event.get("conversation_id") != state.get("provider_session_id"):
                 continue
+            if event.get("launch_id") != expected_launch_id:
+                continue
             event_key = json.dumps(event, sort_keys=True, separators=(",", ":"))
             if event_key in seen_events:
                 continue
@@ -2925,6 +3004,7 @@ def _wait_cursor_hook_sequence(
             name = str(event.get("event") or "")
             if name:
                 observed_events.append(name)
+                event_position += 1
             payload = event.get("payload")
             if not isinstance(payload, dict):
                 continue
@@ -2936,20 +3016,34 @@ def _wait_cursor_hook_sequence(
             if not generation_id:
                 continue
             if name == "beforeSubmitPrompt" and payload.get("prompt") == expected_prompt:
-                matching_befores.append(event)
+                matching_befores.append((event, event_position))
             elif name == "afterAgentResponse" and str(payload.get("text") or "").strip() == marker:
-                matching_afters.append(event)
-        before_generations = {str((event.get("payload") or {}).get("generation_id")) for event in matching_befores}
+                matching_afters.append((event, event_position))
+        before_generations = {str((event.get("payload") or {}).get("generation_id")) for event, _ in matching_befores}
         if len(before_generations) > 1:
             raise RuntimeError(
                 f"Cursor bootstrap hook observed matching prompts from multiple generations ({sorted(before_generations)!r})"
             )
         generation_id = next(iter(before_generations), "")
-        matching_response = next(
-            (event for event in matching_afters if str((event.get("payload") or {}).get("generation_id")) == generation_id),
+        matching_before = next(
+            (
+                (event, position)
+                for event, position in matching_befores
+                if str((event.get("payload") or {}).get("generation_id")) == generation_id
+            ),
             None,
         )
-        if generation_id and matching_response is not None:
+        matching_response = next(
+            (
+                (event, position)
+                for event, position in matching_afters
+                if str((event.get("payload") or {}).get("generation_id")) == generation_id
+                and matching_before is not None
+                and position > matching_before[1]
+            ),
+            None,
+        )
+        if matching_before is not None and matching_response is not None and claim_status == "observed":
             try:
                 end_bytes = path.stat().st_size
             except OSError:
@@ -2958,8 +3052,11 @@ def _wait_cursor_hook_sequence(
                 "start_bytes": minimum_hook_event_bytes,
                 "end_bytes": end_bytes,
                 "events": observed_events,
-                "before_submit_prompt": matching_befores[0],
-                "after_agent_response": matching_response,
+                "before_submit_prompt": matching_before[0],
+                "after_agent_response": matching_response[0],
+                "before_submit_prompt_position": matching_before[1],
+                "after_agent_response_position": matching_response[1],
+                "launch_id": expected_launch_id,
                 "generation_id": generation_id,
                 "hook_response_correlated": True,
                 "timed_out": False,
@@ -3505,6 +3602,7 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
                 marker=seed_marker,
                 label="initial-seed-before-send",
             )
+            initial_hook_event_bytes = _cursor_hook_event_bytes(initial_state, environment)
             initial_send = _control_send(
                 spec,
                 args,
@@ -3522,13 +3620,33 @@ def run_native_resume(provider: str, args: argparse.Namespace) -> dict[str, Any]
                 initial=True,
             )
         _write_json(root / "initial-seed-send.json", initial_send)
-        _write_json(root / "initial-transcript-ship-receipt.json", shipper.flush("initial"))
         if spec.provider == "cursor":
-            shipper.capture_cursor_projection_diagnostics(
-                initial_state,
-                marker=seed_marker,
-                label="initial-seed-after-flush",
-            )
+            try:
+                _, initial_ship_receipt = _cursor_initial_send_then_flush(
+                    initial_state,
+                    environment,
+                    shipper,
+                    marker=seed_marker,
+                    expected_prompt=_resume_marker_prompt(provider, seed_marker),
+                    minimum_hook_event_bytes=initial_hook_event_bytes,
+                    timeout=args.live_send_timeout_secs,
+                    diagnostic_path=root / "cursor-idle-timeout-initial-seed.json",
+                    hook_correlation_path=root / "initial-hook-correlation.json",
+                )
+            except RuntimeError as exc:
+                # Keep the lifecycle gate's failure evidence even when no
+                # transcript flush was safe to attempt. The artifact is
+                # mandatory on a pass and useful on a fail.
+                correlation_path = root / "initial-hook-correlation.json"
+                if not correlation_path.exists():
+                    _write_best_effort_json(
+                        correlation_path,
+                        {"available": False, "error": f"{type(exc).__name__}: {exc}"},
+                    )
+                raise
+        else:
+            initial_ship_receipt = shipper.flush("initial")
+        _write_json(root / "initial-transcript-ship-receipt.json", initial_ship_receipt)
         initial_tail, initial_response_correlation = _wait_assistant_response_after_marker(
             args.api_url,
             args.agents_token,


### PR DESCRIPTION
## What changed

Cursor's initial managed seed now waits for the enrolled launch identity, an ordered `beforeSubmitPrompt` → `afterAgentResponse` hook pair, and the matching idle phase before transcript shipping.

The qualification retains the hook correlation before idle settlement, registers it as required evidence, and adds regression coverage for reversed hooks and pending claim promotion.

## Validation

- `115 passed` in `tests_lite/test_provider_native_resume.py`
- Ruff and repository pre-commit checks pass
- Reviewed by Hatch Claude Opus and Codex Sol